### PR TITLE
Added elkgs for ptolemy models

### DIFF
--- a/realworld/ptolemy/flattened/algebraic_heateropentank_HeaterOpenTank.elkg
+++ b/realworld/ptolemy/flattened/algebraic_heateropentank_HeaterOpenTank.elkg
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="QSSIntegrator"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="15.0" text="dp"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="106.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="106.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="0.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="185.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="185.0" y="8.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="146.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="149.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="149.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="3.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.5/@ports.3"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/algebraic_heateropentank_HeaterOpenTankRefactored.elkg
+++ b/realworld/ptolemy/flattened/algebraic_heateropentank_HeaterOpenTankRefactored.elkg
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.6 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="83.0" text="QSSIntegrator"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="124.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="124.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="106.0" text="MostRecent_mdot"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.2 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="95.0" text="MostRecent_TIn"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.3 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="85.0" text="MostRecent_T"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.5 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="156.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="124.0" text="heaterOutletPressure"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="156.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="120.0" text="pumpOutletPressure"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="15.0" text="dp"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="189.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="87.0" text="massFlowRate"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="189.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.3/@ports.3"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.8/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.14/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.14/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.14/@ports.0" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/algebraic_rlc_RLC.elkg
+++ b/realworld/ptolemy/flattened/algebraic_rlc_RLC.elkg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="CapacitorGain"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Capacitor"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="85.0" text="VoltageSource"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="92.0" text="VoltageSource2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="47.0" text="Inductor"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="InductorGain"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Resistance1"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="73.0" text="Resistance2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.10/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/aspect_cartrackingattackmodeling_CarTrackingAttackModeling.elkg
+++ b/realworld/ptolemy/flattened/aspect_cartrackingattackmodeling_CarTrackingAttackModeling.elkg
@@ -1,0 +1,799 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="48.0" text="Position"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.11 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="15.0" y="41.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="38.0" y="41.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="98.0" text="AttackStartEvent"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="93.0" text="AttackEndEvent"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="98.0" text="AttackStartEvent"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="93.0" text="AttackEndEvent"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="34.0" text="Inhibit"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.47 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="86.0" text="RecordingStart"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="93.0" text="AttackEndEvent"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="9.25" y="41.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="43.75" y="41.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="68.0" text="ReplayStart"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.16/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.17/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.19/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.1" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.21/@ports.1" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.22/@ports.0" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.0" targets="//@children.21/@ports.3"/>
+  <containedEdges identifier="E30" sources="//@children.24/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.25/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.27/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.28/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.29/@ports.1" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.30/@ports.1" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.30/@ports.1" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E38" sources="//@children.31/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.32/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.33/@ports.0" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.35/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.36/@ports.1" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.37/@ports.0" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.38/@ports.0" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.39/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.39/@ports.2" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.39/@ports.2" targets="//@children.41/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.40/@ports.1" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.40/@ports.1" targets="//@children.36/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.41/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.42/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.43/@ports.1" targets="//@children.40/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.44/@ports.0" targets="//@children.48/@ports.3"/>
+  <containedEdges identifier="E54" sources="//@children.46/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.47/@ports.0" targets="//@children.48/@ports.4"/>
+  <containedEdges identifier="E56" sources="//@children.48/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.49/@ports.0" targets="//@children.48/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/aspect_cartrackingattackmodeling_CarTrackingAttackModelingAllAttacksInOneModel.elkg
+++ b/realworld/ptolemy/flattened/aspect_cartrackingattackmodeling_CarTrackingAttackModelingAllAttacksInOneModel.elkg
@@ -1,0 +1,1210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="48.0" text="Position"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.54 //@containedEdges.62 //@containedEdges.70 //@containedEdges.78 //@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.57 //@containedEdges.65 //@containedEdges.73 //@containedEdges.81 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="103.0" text="PeriodicSampler1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="15.0" y="41.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="41.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="98.0" text="AttackStartEvent"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="93.0" text="AttackEndEvent"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="98.0" text="AttackStartEvent"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="93.0" text="AttackEndEvent"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.37 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="34.0" text="Inhibit"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="86.0" text="RecordingStart"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="93.0" text="AttackEndEvent"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="9.25" y="41.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="43.75" y="41.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="68.0" text="ReplayStart"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.55 //@containedEdges.56 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.63 //@containedEdges.64 //@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.71 //@containedEdges.72 //@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.79 //@containedEdges.80 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.87 //@containedEdges.88 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.0" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.21/@ports.1" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.1" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E30" sources="//@children.22/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.23/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.24/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.26/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.27/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.28/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.29/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.30/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.30/@ports.2" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.30/@ports.2" targets="//@children.32/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.31/@ports.1" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E41" sources="//@children.31/@ports.1" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E42" sources="//@children.32/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.33/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.34/@ports.1" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E45" sources="//@children.35/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.36/@ports.0" targets="//@children.40/@ports.3"/>
+  <containedEdges identifier="E47" sources="//@children.38/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.39/@ports.0" targets="//@children.40/@ports.4"/>
+  <containedEdges identifier="E49" sources="//@children.40/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.41/@ports.0" targets="//@children.40/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.42/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.43/@ports.2" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.44/@ports.2" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.45/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.46/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.47/@ports.2" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.47/@ports.2" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.47/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.48/@ports.1" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.49/@ports.2" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.50/@ports.2" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.51/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.52/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.53/@ports.2" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.53/@ports.2" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.53/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.54/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.55/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.56/@ports.2" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.57/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.58/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.59/@ports.2" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.59/@ports.2" targets="//@children.58/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.59/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.60/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.61/@ports.2" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.62/@ports.2" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E78" sources="//@children.63/@ports.0" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E79" sources="//@children.64/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.65/@ports.2" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.65/@ports.2" targets="//@children.64/@ports.1"/>
+  <containedEdges identifier="E82" sources="//@children.65/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.66/@ports.1" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.67/@ports.2" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.68/@ports.2" targets="//@children.71/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.69/@ports.0" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E87" sources="//@children.70/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.71/@ports.2" targets="//@children.67/@ports.1"/>
+  <containedEdges identifier="E89" sources="//@children.71/@ports.2" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.71/@ports.2" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/aspect_compositeqm_CheckExecutionTimeConstraints.elkg
+++ b/realworld/ptolemy/flattened/aspect_compositeqm_CheckExecutionTimeConstraints.elkg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="ThrowModelError"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="36.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="28.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.13/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.1" targets="//@children.15/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/aspect_compositeqm_CompositeQM.elkg
+++ b/realworld/ptolemy/flattened/aspect_compositeqm_CompositeQM.elkg
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="17.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="8.0" text="a"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="8.0" text="b"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="172.0" text="CommunicationResponsePort"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/aspect_de_DE2.elkg
+++ b/realworld/ptolemy/flattened/aspect_de_DE2.elkg
@@ -1,0 +1,622 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Ramp4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Ramp4"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="26.0" text="out2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.1" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.27/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.28/@ports.1" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.30/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.31/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.31/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.32/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.33/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.34/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.36/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.36/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.37/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.38/@ports.1" targets="//@children.37/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/backtrack_primetest_PrimeTest.elkg
+++ b/realworld/ptolemy/flattened/backtrack_primetest_PrimeTest.elkg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="130.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="130.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="162.0" text="Accumulator (Backtracking)"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="100.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="100.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="76.0" text="TimedDelay3"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.3" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.3" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.21/@ports.0" targets="//@children.19/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/backtrack_ramprollback_RampRollback.elkg
+++ b/realworld/ptolemy/flattened/backtrack_ramprollback_RampRollback.elkg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.12 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/backtrack_trialmodule_TrialModule.elkg
+++ b/realworld/ptolemy/flattened/backtrack_trialmodule_TrialModule.elkg
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="106.0" text="BooleanSelect (B)"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.5 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="97.0" text="StringSubstring1"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="97.0" text="StringSubstring2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="74.0" text="StringLength"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="62.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="56.0" text="Ramp (B)"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="EmptyString"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.2" targets="//@children.18/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/backtrack_trialmodule_TrialModuleNonBacktrack.elkg
+++ b/realworld/ptolemy/flattened/backtrack_trialmodule_TrialModuleNonBacktrack.elkg
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.8 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="97.0" text="StringSubstring1"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="97.0" text="StringSubstring2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="74.0" text="StringLength"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="62.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="38.0" text="Empty"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.1" targets="//@children.13/@ports.3"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.2" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.18/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ca_conway_Conway.elkg
+++ b/realworld/ptolemy/flattened/ca_conway_Conway.elkg
@@ -1,0 +1,482 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32 //@containedEdges.33 //@containedEdges.34 //@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="75.0" text="Comparator3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="75.0" text="Comparator4"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.3" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.3" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.2" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.3" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.2" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.16/@ports.3" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.17/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.19/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.19/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.3" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.21/@ports.2" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.23/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.24/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.25/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.26/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.27/@ports.2" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ca_conwayrandom_ConwayRandom.elkg
+++ b/realworld/ptolemy/flattened/ca_conwayrandom_ConwayRandom.elkg
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="141.0" width="153.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="101.0" text="CA2DConvolution"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.416666507720947" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.83333396911621" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="29.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="153.0" y="66.5" outgoingEdges="//@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="41.66666793823242" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="54.08333206176758" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="66.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="78.91666412353516" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="91.33333587646484" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="103.75" outgoingEdges="//@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="116.16666412353516" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="128.5833282470703" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.9" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.0/@ports.6"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.0/@ports.7"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.0/@ports.8"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.0/@ports.9"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.0/@ports.10"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.0/@ports.11"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ci_router_ComplexRouter.elkg
+++ b/realworld/ptolemy/flattened/ci_router_ComplexRouter.elkg
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="Counter - q1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="Counter - q2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="141.0" text="MonitorValue - q1 length"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="141.0" text="MonitorValue - q2 length"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="98.0" text="DatagramReader"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="79.0" text="QueueControl"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="-1.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="6.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="13.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="0.1666666716337204">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.6 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="32.83333206176758" outgoingEdges="//@containedEdges.7 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Sleep"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Sleep"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.7/@ports.6"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.7/@ports.8"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.7/@ports.7"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.9" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.10" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.4" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.9" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.10" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.2" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.15/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.12/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ci_router_Router.elkg
+++ b/realworld/ptolemy/flattened/ci_router_Router.elkg
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="DataReceived"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="141.0" text="MonitorValue - q1 length"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="141.0" text="MonitorValue - q2 length"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="47.0" text="dropped"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="60.0" text="Distributor"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="46.0" text="Queue1"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="26.5" y="-8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="46.0" text="Queue2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Sleep"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Sleep"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.4/@ports.4" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.1" targets="//@children.11/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ci_router_dropqueuetest1.elkg
+++ b/realworld/ptolemy/flattened/ci_router_dropqueuetest1.elkg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="49.0" text="Dropped"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="FrontDropQueue"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="VariableSleep"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="randomTime t2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="82.0" text="LongToDouble"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="80.0" text="VariableSleep"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="83.0" text="randonTime t1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="82.0" text="LongToDouble"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.15/@ports.0" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ci_router_queuetest1.elkg
+++ b/realworld/ptolemy/flattened/ci_router_queuetest1.elkg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="82.0" text="Queue Length"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="80.0" text="VariableSleep"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="87.0" text="randomTime t2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="82.0" text="LongToDouble"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="80.0" text="VariableSleep"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="83.0" text="randonTime t1"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="82.0" text="LongToDouble"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/colt_coltrandom_ColtRandom.elkg
+++ b/realworld/ptolemy/flattened/colt_coltrandom_ColtRandom.elkg
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="51.0" text="ColtBeta"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="ColtBinomial"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="32.0" text="Test2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="92.0" text="ColtBreitWigner"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="84.0" text="ColtChiSquare"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="91.0" text="ColtExponential"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="32.0" text="Test3"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="32.0" text="Test4"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="32.0" text="Test5"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="128.0" text="ColtExponentialPower"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="70.0" text="ColtGamma"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="117.0" text="ColtHyperGeometric"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="90.0" text="ColtLogarithmic"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="32.0" text="Test6"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="32.0" text="Test7"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="32.0" text="Test8"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="32.0" text="Test9"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="105.0" text="HistogramPlotter4"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18 //@containedEdges.22 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="122.0" text="ColtNegativeBinomial"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="64.0" text="ColtNormal"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="71.0" text="ColtPoisson"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="99.0" text="ColtPoissonSlow"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="76.0" text="ColtStudentT"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="80.0" text="ColtVonMises"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="49.0" text="ColtZeta"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="38.0" text="Test11"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="39.0" text="Test12"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="39.0" text="Test13"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="39.0" text="Test14"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="39.0" text="Test15"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="39.0" text="Test16"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="39.0" text="Test17"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="105.0" text="HistogramPlotter1"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.3 //@containedEdges.5 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="105.0" text="HistogramPlotter2"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.21 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="105.0" text="HistogramPlotter3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.9 //@containedEdges.13 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="105.0" text="HistogramPlotter5"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="24.0" text="Test"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.22/@ports.0" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.23/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.24/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.24/@ports.0" targets="//@children.35/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/comm_convolutionalcoder_ConvolutionalCoder.elkg
+++ b/realworld/ptolemy/flattened/comm_convolutionalcoder_ConvolutionalCoder.elkg
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="60.0" text="Scrambler"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="76.0" text="DeScrambler"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="58.0" text="Bernoulli2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="83.0" text="DeScrambler2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="86.0" text="ViterbiDecoder"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.5/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.23/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.24/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.25/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.26/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.27/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.28/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.29/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.30/@ports.2" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/comm_huffmandecoder_HuffmanDecoder.elkg
+++ b/realworld/ptolemy/flattened/comm_huffmandecoder_HuffmanDecoder.elkg
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="82.0" text="HuffmanCoder"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="HuffmanDecoder"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="107.0" text="HuffmanCodeBook"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="HuffmanCode"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="196.0" text="NumberOfBitsUsingHuffmanCoder"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="53.0" text="Counter2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="186.0" text="NumberOfBitsUsingBinaryCoder"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="143.0" text="FixedLengthBinaryCoder"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="182.0" text="CompareDecodedWithUncoded"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.9/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/comm_trellisdecoder_TrellisDecoder.elkg
+++ b/realworld/ptolemy/flattened/comm_trellisdecoder_TrellisDecoder.elkg
@@ -1,0 +1,493 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Slicer"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="59.0" text="LineCoder"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="LineCoder2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="83.0" text="TrellisDecoder"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.0" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.0" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.0" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/comm_viterbidecoder_ViterbiDecoder.elkg
+++ b/realworld/ptolemy/flattened/comm_viterbidecoder_ViterbiDecoder.elkg
@@ -1,0 +1,431 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="93.0" text="ViterbiDecoder2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.2" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_bouncingball_BouncingBall.elkg
+++ b/realworld/ptolemy/flattened/continuous_bouncingball_BouncingBall.elkg
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="61.0" text="Ball Model"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="75.0" text="Copy1:Const"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_cartpendulum_CartPendulum.elkg
+++ b/realworld/ptolemy/flattened/continuous_cartpendulum_CartPendulum.elkg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="0.1666666716337204">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="32.83333206176758">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="Positions"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="86.0" text="ViewScreen3D"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="33.0" text="stage"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="47.0" text="Cone3D"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7 //@containedEdges.9 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="43.0" text="cartbox"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="33.0" text="string"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="30.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.3" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_cartracking_CarTracking.elkg
+++ b/realworld/ptolemy/flattened/continuous_cartracking_CarTracking.elkg
@@ -1,0 +1,713 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="82.0" text="NetworkModel"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="20.0" text="Sin"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="31.0" text="Add2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="10.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="10.0" y="11.600000381469727">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="10.0" y="21.399999618530273" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="10.0" y="31.200000762939453" outgoingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="21.0" text="Pre"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="28.0" text="Pre2"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="55.0" width="194.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="150.0" text="Estimate Current Position"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="194.0" y="23.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="4.599999904632568" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="17.200000762939453" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="29.799999237060547" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="42.400001525878906" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="28.0" text="Pre3"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="49.0" text="Subtract"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.43 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="62.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.47 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.2" targets="//@children.4/@ports.4"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.2" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.17/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.18/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.19/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.3" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.28/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.28/@ports.1" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.28/@ports.4" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.28/@ports.4" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.29/@ports.1" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E38" sources="//@children.30/@ports.1" targets="//@children.31/@ports.3"/>
+  <containedEdges identifier="E39" sources="//@children.31/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.32/@ports.1" targets="//@children.31/@ports.4"/>
+  <containedEdges identifier="E41" sources="//@children.33/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.34/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.34/@ports.1" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E44" sources="//@children.35/@ports.2" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.36/@ports.2" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.37/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.38/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.39/@ports.2" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.39/@ports.2" targets="//@children.38/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_continuousinsidede_ContinuousInsideDE.elkg
+++ b/realworld/ptolemy/flattened/continuous_continuousinsidede_ContinuousInsideDE.elkg
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="91.0" text="ColtExponential"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8 //@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="91.0" text="ZeroOrderHold3"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_hierarchicalexecution_HierarchicalExecution.elkg
+++ b/realworld/ptolemy/flattened/continuous_hierarchicalexecution_HierarchicalExecution.elkg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="62.0" text="Integrator3"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="46.0" text="signal 1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="46.0" text="signal 2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="56.0" text="difference"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.2/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_levelcrossingdetector_LevelCrossingDetector.elkg
+++ b/realworld/ptolemy/flattened/continuous_levelcrossingdetector_LevelCrossingDetector.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Signals"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.7 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="39.0" text="Events"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="137.0" text="LevelCrossingDetector3"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="137.0" text="LevelCrossingDetector4"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="137.0" text="LevelCrossingDetector5"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.2" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_levelcrossingdetectordetectsglitches_LevelCrossingDetectorDetectsGlitches.elkg
+++ b/realworld/ptolemy/flattened/continuous_levelcrossingdetectordetectsglitches_LevelCrossingDetectorDetectsGlitches.elkg
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="111.0" text="SignalWithGlitches"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="118.0" text="Integral of the Signal"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="174.0" text="Detected Threshold Crossings"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="168.0" text="Piecewise Continuous Signal"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="143.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="143.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="95.0" text="Detected Events"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="137.0" text="LevelCrossingDetector1"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="137.0" text="LevelCrossingDetector3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_pendulum3d_Pendulum3D.elkg
+++ b/realworld/ptolemy/flattened/continuous_pendulum3d_Pendulum3D.elkg
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="22.625" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.6 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="34.875" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="79.0" text="Displacement"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="40.0" text="Angles"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="Angular Velocities"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="86.0" text="ViewScreen3D"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9 //@containedEdges.12 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="33.0" text="stage"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="47.0" text="Cone3D"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="33.0" text="string"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="30.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.3" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.5" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_sigmadelta_SigmaDelta.elkg
+++ b/realworld/ptolemy/flattened/continuous_sigmadelta_SigmaDelta.elkg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="31.0" text="delay"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="FIR Filter"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="Quantizer"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="DEPlot"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="90.0" text="Moving Average"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="117.0" text="Average 50 samples"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="75.0" text="Current Time"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="20.0" text="Sin"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="31.0" text="Add1"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="41.0" text="Scale1"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="88.0" text="ContinuousPlot"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.11 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_starmac_Starmac.elkg
+++ b/realworld/ptolemy/flattened/continuous_starmac_Starmac.elkg
@@ -1,0 +1,4099 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="Wind Velocity"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Angle"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.389">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.377">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="41.0" text="Control"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="48.0" text="Position"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="103.0" text="PeriodicSampler3"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.405">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="20.799999237060547" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="86.0" text="ViewScreen3D"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="64.0" text="Cylinder3D"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22 //@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.29 //@containedEdges.31 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="47.0" text="Box3D2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="47.0" text="Box3D3"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="71.0" text="Cylinder3D2"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="71.0" text="Cylinder3D3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="71.0" text="Cylinder3D4"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.49 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="102.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="102.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.38 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.39 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="25.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="49.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.50 //@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.61 //@containedEdges.62 //@containedEdges.63 //@containedEdges.64 //@containedEdges.65 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.82 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.61 //@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.83 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.64 //@containedEdges.65 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.67 //@containedEdges.68 //@containedEdges.69 //@containedEdges.70 //@containedEdges.71 //@containedEdges.72 //@containedEdges.73 //@containedEdges.74 //@containedEdges.75 //@containedEdges.76 //@containedEdges.77 //@containedEdges.78 //@containedEdges.79 //@containedEdges.80 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.67 //@containedEdges.68 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="107.0" text="VectorAssembler2"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.79 //@containedEdges.80 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.82 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="107.0" text="VectorAssembler3"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.76 //@containedEdges.77 //@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="107.0" text="VectorAssembler4"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.73 //@containedEdges.74 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.84 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="107.0" text="VectorAssembler5"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.70 //@containedEdges.71 //@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.90 //@containedEdges.91 //@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.87 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0 //@containedEdges.273">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.92 //@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="79.0" text="Viscous Drag"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="40.0" text="Gravity"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="40.0" text="Forces"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="47.0" text="Limiter2"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="47.0" text="Limiter3"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="47.0" text="Limiter4"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.93 //@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.94 //@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.95 //@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.96 //@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.101 //@containedEdges.102 //@containedEdges.103 //@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.97 //@containedEdges.98 //@containedEdges.99 //@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.101 //@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.108 //@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="63.0" text="Gaussian3"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="63.0" text="Gaussian4"/>
+    <ports identifier="P188" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.102 //@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.118 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.103 //@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.124 //@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.104 //@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.130 //@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.105 //@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.134 //@containedEdges.135 //@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.148 //@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.137 //@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.139 //@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.88 //@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.141 //@containedEdges.142 //@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="25.0" width="145.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="126.0" text="Pick First 2 Elements"/>
+    <ports identifier="P246" height="8.0" width="8.0" x="145.0" y="8.5" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.145 //@containedEdges.146 //@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.145 //@containedEdges.146 //@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="21.0" text="flap"/>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.168 //@containedEdges.219">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.169 //@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.170 //@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.171 //@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.173 //@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="87.0" text="MultiplyDivide6"/>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.174 //@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="87.0" text="MultiplyDivide7"/>
+    <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.175 //@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="87.0" text="MultiplyDivide8"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.176 //@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="41.0" text="Motor1"/>
+    <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P279" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="41.0" text="Motor4"/>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="41.0" text="Motor2"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="41.0" text="Motor3"/>
+    <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.157 //@containedEdges.158 //@containedEdges.159 //@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.161 //@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.177 //@containedEdges.184 //@containedEdges.191 //@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="74.0" text="Moment Arm"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="82.0" text="Moment Arm2"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="82.0" text="Moment Arm3"/>
+    <ports identifier="P299" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="82.0" text="Moment Arm4"/>
+    <ports identifier="P301" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.168 //@containedEdges.169 //@containedEdges.170 //@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.173 //@containedEdges.174 //@containedEdges.175 //@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="25.0" width="313.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P309" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.178 //@containedEdges.179 //@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P319" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.181 //@containedEdges.182 //@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="25.0" width="313.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P320" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.185 //@containedEdges.186 //@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.188 //@containedEdges.189 //@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="25.0" width="313.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P331" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.192 //@containedEdges.193 //@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P341" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.195 //@containedEdges.196 //@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="25.0" width="313.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P342" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P348" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P350" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.199 //@containedEdges.200 //@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P352" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.202 //@containedEdges.203 //@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="65.0" text="DotProduct"/>
+    <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P355" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P356" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P357" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.206 //@containedEdges.207 //@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="93.0" text="Flap Angle Gain"/>
+    <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P359" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.209 //@containedEdges.210 //@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P361" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P363" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.211 //@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P366" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="109.0" text="rotate 90 degrees2"/>
+    <ports identifier="P367" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P368" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="28.0" text="Gain"/>
+    <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P370" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.212 //@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P372" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P373" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P374" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.217 //@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.218 //@containedEdges.219 //@containedEdges.220 //@containedEdges.221 //@containedEdges.222 //@containedEdges.223 //@containedEdges.224 //@containedEdges.225 //@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P377" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.213 //@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P378" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="109.0" text="rotate 90 degrees3"/>
+    <ports identifier="P380" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P381" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.207 //@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P383" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P384" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="25.0" width="55.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P385" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P388" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P389" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="45.0" text="Select2"/>
+    <ports identifier="P390" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.231 //@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P391" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.232 //@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P392" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P393" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="42.0" text="Body Z"/>
+    <ports identifier="P395" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P396" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="25.0" width="137.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P397" height="8.0" width="8.0" x="137.0" y="8.5" outgoingEdges="//@containedEdges.236 //@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.233 //@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P401" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P402" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P404" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="28.0" text="Gain"/>
+    <ports identifier="P406" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P407" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.241 //@containedEdges.242 //@containedEdges.243 //@containedEdges.244 //@containedEdges.245 //@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P408" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P410" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P411" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P412" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P413" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="45.0" text="Product"/>
+    <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.248 //@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P415" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P416" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.257 //@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P418" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P419" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P420" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.259 //@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P422" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.251 //@containedEdges.252 //@containedEdges.253 //@containedEdges.254 //@containedEdges.255 //@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="25.0" width="17.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="7.0" text="J"/>
+    <ports identifier="P423" height="8.0" width="8.0" x="17.0" y="8.5" outgoingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P424" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="25.0" width="65.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="30.0" text="Inv(J)"/>
+    <ports identifier="P425" height="8.0" width="8.0" x="65.0" y="8.5" outgoingEdges="//@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P426" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="25.0" width="104.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="15.0" text="uT"/>
+    <ports identifier="P427" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="25.0" width="313.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P429" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P430" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P431" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.262">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P433" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P436" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P437" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.261 //@containedEdges.262 //@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N176" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L176" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P438" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P439" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.264 //@containedEdges.265 //@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N177" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P440" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.320">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P441" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.267 //@containedEdges.268 //@containedEdges.269 //@containedEdges.270 //@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P442" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.284 //@containedEdges.285 //@containedEdges.286 //@containedEdges.287 //@containedEdges.288 //@containedEdges.289 //@containedEdges.290 //@containedEdges.291 //@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P443" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P444" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.272 //@containedEdges.273 //@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="25.0" width="52.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P445" height="8.0" width="8.0" x="52.0" y="8.5" outgoingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P447" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P448" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.307">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P450" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N181" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L181" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P451" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N182" height="25.0" width="108.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L182" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P453" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P454" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N183" height="25.0" width="104.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L183" height="15.0" width="73.0" text="Expression5"/>
+    <ports identifier="P458" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P459" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P461" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P462" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P463" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N184" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L184" height="15.0" width="73.0" text="Expression6"/>
+    <ports identifier="P464" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P465" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N185" height="25.0" width="104.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L185" height="15.0" width="73.0" text="Expression7"/>
+    <ports identifier="P467" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@containedEdges.295">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P469" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P471" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P472" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N186" height="25.0" width="108.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L186" height="15.0" width="73.0" text="Expression8"/>
+    <ports identifier="P473" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@containedEdges.304">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P475" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.301">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P476" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P478" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N187" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L187" height="15.0" width="73.0" text="Expression9"/>
+    <ports identifier="P479" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N188" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L188" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P482" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P483" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N189" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L189" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P484" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P485" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N190" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L190" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P486" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P487" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N191" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L191" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P489" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.287">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N192" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L192" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P490" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P491" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N193" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L193" height="15.0" width="41.0" text="Scale6"/>
+    <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P493" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N194" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L194" height="15.0" width="41.0" text="Scale7"/>
+    <ports identifier="P494" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P495" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N195" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="41.0" text="Scale8"/>
+    <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P497" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N196" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L196" height="15.0" width="41.0" text="Scale9"/>
+    <ports identifier="P498" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P499" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N197" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L197" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P501" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.293 //@containedEdges.294 //@containedEdges.295 //@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N198" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L198" height="15.0" width="79.0" text="TrigFunction3"/>
+    <ports identifier="P502" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P503" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.297 //@containedEdges.298 //@containedEdges.299 //@containedEdges.300 //@containedEdges.301">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N199" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L199" height="15.0" width="79.0" text="TrigFunction4"/>
+    <ports identifier="P504" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P505" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.302 //@containedEdges.303 //@containedEdges.304 //@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N200" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L200" height="15.0" width="79.0" text="TrigFunction5"/>
+    <ports identifier="P506" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P507" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.306 //@containedEdges.307 //@containedEdges.308 //@containedEdges.309 //@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N201" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L201" height="15.0" width="79.0" text="TrigFunction6"/>
+    <ports identifier="P508" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P509" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.311 //@containedEdges.312 //@containedEdges.313 //@containedEdges.314 //@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N202" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L202" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P511" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.316 //@containedEdges.317 //@containedEdges.318 //@containedEdges.319 //@containedEdges.320 //@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N203" height="25.0" width="251.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L203" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P512" height="8.0" width="8.0" x="251.0" y="8.5" outgoingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P513" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P514" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P516" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P517" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N204" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L204" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P518" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P520" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N205" height="25.0" width="273.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L205" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P522" height="8.0" width="8.0" x="273.0" y="8.5" outgoingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P523" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P524" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.329">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P525" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P526" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N206" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L206" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P528" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P529" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.325 //@containedEdges.326 //@containedEdges.327 //@containedEdges.328 //@containedEdges.329 //@containedEdges.330 //@containedEdges.331 //@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N207" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L207" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.371">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P531" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.333 //@containedEdges.334 //@containedEdges.335 //@containedEdges.336 //@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N208" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L208" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P532" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.322 //@containedEdges.323 //@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P533" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N209" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L209" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P534" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P536" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P537" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N210" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L210" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P538" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P540" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P541" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N211" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L211" height="15.0" width="62.0" text="Integrator3"/>
+    <ports identifier="P542" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P544" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P545" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N212" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L212" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P547" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.342 //@containedEdges.343 //@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N213" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L213" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P548" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.339 //@containedEdges.340 //@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P549" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.345 //@containedEdges.346 //@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N214" height="25.0" width="313.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L214" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P550" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.350">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P553" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P554" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P555" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.353">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P556" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N215" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L215" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P558" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.349 //@containedEdges.350 //@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N216" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L216" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P559" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P560" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.352 //@containedEdges.353 //@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N217" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L217" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P561" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P562" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.358">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P563" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P564" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N218" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L218" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P565" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P567" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P568" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N219" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L219" height="15.0" width="62.0" text="Integrator3"/>
+    <ports identifier="P569" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P570" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P571" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P572" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N220" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L220" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P574" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.358 //@containedEdges.359 //@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N221" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L221" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.355 //@containedEdges.356 //@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P576" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.361 //@containedEdges.362 //@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N222" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L222" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P577" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P578" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P579" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P580" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N223" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L223" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P581" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P582" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P583" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P584" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N224" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L224" height="15.0" width="62.0" text="Integrator3"/>
+    <ports identifier="P585" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P587" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P588" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N225" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L225" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P589" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P590" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.367 //@containedEdges.368 //@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N226" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L226" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.364 //@containedEdges.365 //@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P592" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.370 //@containedEdges.371 //@containedEdges.372 //@containedEdges.373 //@containedEdges.374 //@containedEdges.375 //@containedEdges.376 //@containedEdges.377">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N227" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L227" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P593" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P594" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.381">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P595" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.378">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P596" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N228" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L228" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P597" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P598" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.382">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P599" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P600" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N229" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L229" height="15.0" width="62.0" text="Integrator3"/>
+    <ports identifier="P601" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P602" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.383">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P603" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.380">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P604" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N230" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L230" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P605" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P606" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.381 //@containedEdges.382 //@containedEdges.383">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N231" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L231" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P607" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.378 //@containedEdges.379 //@containedEdges.380">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P608" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.384 //@containedEdges.385 //@containedEdges.386 //@containedEdges.387 //@containedEdges.388 //@containedEdges.389">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N232" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L232" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P609" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.242 //@containedEdges.252 //@containedEdges.372 //@containedEdges.384">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P610" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.390 //@containedEdges.391 //@containedEdges.392">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N233" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L233" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.243 //@containedEdges.253 //@containedEdges.373 //@containedEdges.385">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P612" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.393 //@containedEdges.394 //@containedEdges.395">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N234" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L234" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P613" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.244 //@containedEdges.254 //@containedEdges.374 //@containedEdges.386">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P614" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.396 //@containedEdges.397 //@containedEdges.398">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N235" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L235" height="15.0" width="124.0" text="VectorDisassembler4"/>
+    <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.245 //@containedEdges.255 //@containedEdges.375 //@containedEdges.387">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P616" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.399 //@containedEdges.400 //@containedEdges.401">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N236" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L236" height="15.0" width="124.0" text="VectorDisassembler5"/>
+    <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.246 //@containedEdges.256 //@containedEdges.376 //@containedEdges.388">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P618" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.402 //@containedEdges.403 //@containedEdges.404">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N237" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L237" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.390 //@containedEdges.391 //@containedEdges.392 //@containedEdges.393 //@containedEdges.394 //@containedEdges.395 //@containedEdges.396 //@containedEdges.397 //@containedEdges.398 //@containedEdges.399 //@containedEdges.400 //@containedEdges.401 //@containedEdges.402 //@containedEdges.403 //@containedEdges.404">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P620" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.405">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.9/@ports.4"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.1" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E22" sources="//@children.17/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.18/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.19/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.24/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.25/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.26/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.28/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.29/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.30/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.31/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.33/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.34/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.35/@ports.2" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.36/@ports.2" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.37/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.38/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.39/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.41/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.42/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.43/@ports.2" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.44/@ports.2" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.45/@ports.0" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.46/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.47/@ports.1" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.47/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.47/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.47/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.47/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.47/@ports.1" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.47/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.47/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.48/@ports.2" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.49/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.50/@ports.1" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.51/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.51/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.51/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.52/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.52/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.52/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.53/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.53/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.53/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.53/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.53/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.53/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.53/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.53/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.53/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.53/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.53/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.53/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.53/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.53/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.53/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.55/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.55/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.57/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.57/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.59/@ports.2" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.60/@ports.2" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.60/@ports.2" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.61/@ports.2" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E91" sources="//@children.62/@ports.2" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.63/@ports.1" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.64/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.66/@ports.1" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.67/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.68/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.69/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.70/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.71/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.72/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.73/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.74/@ports.1" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.74/@ports.1" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.74/@ports.1" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.74/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.75/@ports.1" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.76/@ports.2" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E108" sources="//@children.77/@ports.2" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.78/@ports.2" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.78/@ports.2" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.79/@ports.1" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.80/@ports.1" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.81/@ports.0" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.82/@ports.0" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.83/@ports.0" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.84/@ports.0" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.85/@ports.2" targets="//@children.87/@ports.1"/>
+  <containedEdges identifier="E118" sources="//@children.86/@ports.2" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.87/@ports.2" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.87/@ports.2" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.88/@ports.1" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.89/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.90/@ports.2" targets="//@children.92/@ports.1"/>
+  <containedEdges identifier="E124" sources="//@children.91/@ports.2" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.92/@ports.2" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.92/@ports.2" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.93/@ports.1" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.94/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.95/@ports.2" targets="//@children.97/@ports.1"/>
+  <containedEdges identifier="E130" sources="//@children.96/@ports.2" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.97/@ports.2" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.97/@ports.2" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.98/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.99/@ports.1" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E135" sources="//@children.100/@ports.2" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.100/@ports.2" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E137" sources="//@children.100/@ports.2" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.101/@ports.2" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E139" sources="//@children.101/@ports.2" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.102/@ports.2" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.102/@ports.2" targets="//@children.166/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.103/@ports.2" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.103/@ports.2" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.103/@ports.2" targets="//@children.142/@ports.1"/>
+  <containedEdges identifier="E145" sources="//@children.104/@ports.0" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.105/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.105/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.105/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E149" sources="//@children.106/@ports.2" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.108/@ports.2" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.109/@ports.2" targets="//@children.135/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.110/@ports.2" targets="//@children.138/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.111/@ports.2" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.112/@ports.2" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E155" sources="//@children.113/@ports.2" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.114/@ports.2" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.115/@ports.2" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E158" sources="//@children.116/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.117/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E160" sources="//@children.118/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E161" sources="//@children.119/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.120/@ports.2" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.121/@ports.2" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E164" sources="//@children.122/@ports.2" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E165" sources="//@children.123/@ports.0" targets="//@children.131/@ports.0"/>
+  <containedEdges identifier="E166" sources="//@children.124/@ports.0" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E167" sources="//@children.125/@ports.0" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E168" sources="//@children.126/@ports.0" targets="//@children.140/@ports.0"/>
+  <containedEdges identifier="E169" sources="//@children.127/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E170" sources="//@children.127/@ports.1" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E171" sources="//@children.127/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E172" sources="//@children.127/@ports.1" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.128/@ports.1" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E174" sources="//@children.129/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E175" sources="//@children.129/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E176" sources="//@children.129/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E177" sources="//@children.129/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E178" sources="//@children.130/@ports.0" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E179" sources="//@children.131/@ports.1" targets="//@children.130/@ports.1"/>
+  <containedEdges identifier="E180" sources="//@children.131/@ports.1" targets="//@children.130/@ports.2"/>
+  <containedEdges identifier="E181" sources="//@children.131/@ports.1" targets="//@children.130/@ports.3"/>
+  <containedEdges identifier="E182" sources="//@children.132/@ports.1" targets="//@children.130/@ports.4"/>
+  <containedEdges identifier="E183" sources="//@children.132/@ports.1" targets="//@children.130/@ports.5"/>
+  <containedEdges identifier="E184" sources="//@children.132/@ports.1" targets="//@children.130/@ports.6"/>
+  <containedEdges identifier="E185" sources="//@children.133/@ports.0" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E186" sources="//@children.134/@ports.1" targets="//@children.133/@ports.1"/>
+  <containedEdges identifier="E187" sources="//@children.134/@ports.1" targets="//@children.133/@ports.2"/>
+  <containedEdges identifier="E188" sources="//@children.134/@ports.1" targets="//@children.133/@ports.3"/>
+  <containedEdges identifier="E189" sources="//@children.135/@ports.1" targets="//@children.133/@ports.4"/>
+  <containedEdges identifier="E190" sources="//@children.135/@ports.1" targets="//@children.133/@ports.5"/>
+  <containedEdges identifier="E191" sources="//@children.135/@ports.1" targets="//@children.133/@ports.6"/>
+  <containedEdges identifier="E192" sources="//@children.136/@ports.0" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E193" sources="//@children.137/@ports.1" targets="//@children.136/@ports.1"/>
+  <containedEdges identifier="E194" sources="//@children.137/@ports.1" targets="//@children.136/@ports.2"/>
+  <containedEdges identifier="E195" sources="//@children.137/@ports.1" targets="//@children.136/@ports.3"/>
+  <containedEdges identifier="E196" sources="//@children.138/@ports.1" targets="//@children.136/@ports.4"/>
+  <containedEdges identifier="E197" sources="//@children.138/@ports.1" targets="//@children.136/@ports.5"/>
+  <containedEdges identifier="E198" sources="//@children.138/@ports.1" targets="//@children.136/@ports.6"/>
+  <containedEdges identifier="E199" sources="//@children.139/@ports.0" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E200" sources="//@children.140/@ports.1" targets="//@children.139/@ports.1"/>
+  <containedEdges identifier="E201" sources="//@children.140/@ports.1" targets="//@children.139/@ports.2"/>
+  <containedEdges identifier="E202" sources="//@children.140/@ports.1" targets="//@children.139/@ports.3"/>
+  <containedEdges identifier="E203" sources="//@children.141/@ports.1" targets="//@children.139/@ports.4"/>
+  <containedEdges identifier="E204" sources="//@children.141/@ports.1" targets="//@children.139/@ports.5"/>
+  <containedEdges identifier="E205" sources="//@children.141/@ports.1" targets="//@children.139/@ports.6"/>
+  <containedEdges identifier="E206" sources="//@children.142/@ports.2" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E207" sources="//@children.143/@ports.1" targets="//@children.144/@ports.0"/>
+  <containedEdges identifier="E208" sources="//@children.143/@ports.1" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E209" sources="//@children.143/@ports.1" targets="//@children.160/@ports.1"/>
+  <containedEdges identifier="E210" sources="//@children.144/@ports.1" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E211" sources="//@children.144/@ports.1" targets="//@children.146/@ports.0"/>
+  <containedEdges identifier="E212" sources="//@children.144/@ports.1" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E213" sources="//@children.145/@ports.1" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E214" sources="//@children.146/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E215" sources="//@children.147/@ports.2" targets="//@children.148/@ports.0"/>
+  <containedEdges identifier="E216" sources="//@children.148/@ports.1" targets="//@children.149/@ports.0"/>
+  <containedEdges identifier="E217" sources="//@children.149/@ports.1" targets="//@children.102/@ports.1"/>
+  <containedEdges identifier="E218" sources="//@children.150/@ports.2" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E219" sources="//@children.151/@ports.2" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E220" sources="//@children.151/@ports.2" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E221" sources="//@children.151/@ports.2" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E222" sources="//@children.151/@ports.2" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E223" sources="//@children.151/@ports.2" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E224" sources="//@children.151/@ports.2" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E225" sources="//@children.151/@ports.2" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E226" sources="//@children.151/@ports.2" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E227" sources="//@children.151/@ports.2" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E228" sources="//@children.152/@ports.2" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E229" sources="//@children.153/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E230" sources="//@children.154/@ports.1" targets="//@children.156/@ports.1"/>
+  <containedEdges identifier="E231" sources="//@children.155/@ports.0" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E232" sources="//@children.156/@ports.2" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E233" sources="//@children.157/@ports.1" targets="//@children.153/@ports.0"/>
+  <containedEdges identifier="E234" sources="//@children.157/@ports.1" targets="//@children.161/@ports.0"/>
+  <containedEdges identifier="E235" sources="//@children.158/@ports.0" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E236" sources="//@children.159/@ports.0" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E237" sources="//@children.160/@ports.0" targets="//@children.154/@ports.2"/>
+  <containedEdges identifier="E238" sources="//@children.160/@ports.0" targets="//@children.157/@ports.2"/>
+  <containedEdges identifier="E239" sources="//@children.161/@ports.2" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E240" sources="//@children.162/@ports.0" targets="//@children.161/@ports.0"/>
+  <containedEdges identifier="E241" sources="//@children.163/@ports.0" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E242" sources="//@children.164/@ports.1" targets="//@children.165/@ports.0"/>
+  <containedEdges identifier="E243" sources="//@children.164/@ports.1" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E244" sources="//@children.164/@ports.1" targets="//@children.232/@ports.0"/>
+  <containedEdges identifier="E245" sources="//@children.164/@ports.1" targets="//@children.233/@ports.0"/>
+  <containedEdges identifier="E246" sources="//@children.164/@ports.1" targets="//@children.234/@ports.0"/>
+  <containedEdges identifier="E247" sources="//@children.164/@ports.1" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E248" sources="//@children.165/@ports.2" targets="//@children.211/@ports.0"/>
+  <containedEdges identifier="E249" sources="//@children.166/@ports.2" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E250" sources="//@children.167/@ports.2" targets="//@children.219/@ports.0"/>
+  <containedEdges identifier="E251" sources="//@children.168/@ports.2" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E252" sources="//@children.169/@ports.2" targets="//@children.229/@ports.0"/>
+  <containedEdges identifier="E253" sources="//@children.169/@ports.2" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E254" sources="//@children.169/@ports.2" targets="//@children.232/@ports.0"/>
+  <containedEdges identifier="E255" sources="//@children.169/@ports.2" targets="//@children.233/@ports.0"/>
+  <containedEdges identifier="E256" sources="//@children.169/@ports.2" targets="//@children.234/@ports.0"/>
+  <containedEdges identifier="E257" sources="//@children.169/@ports.2" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E258" sources="//@children.170/@ports.0" targets="//@children.168/@ports.0"/>
+  <containedEdges identifier="E259" sources="//@children.171/@ports.0" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E260" sources="//@children.172/@ports.0" targets="//@children.169/@ports.0"/>
+  <containedEdges identifier="E261" sources="//@children.173/@ports.0" targets="//@children.166/@ports.1"/>
+  <containedEdges identifier="E262" sources="//@children.174/@ports.1" targets="//@children.173/@ports.1"/>
+  <containedEdges identifier="E263" sources="//@children.174/@ports.1" targets="//@children.173/@ports.2"/>
+  <containedEdges identifier="E264" sources="//@children.174/@ports.1" targets="//@children.173/@ports.3"/>
+  <containedEdges identifier="E265" sources="//@children.175/@ports.1" targets="//@children.173/@ports.4"/>
+  <containedEdges identifier="E266" sources="//@children.175/@ports.1" targets="//@children.173/@ports.5"/>
+  <containedEdges identifier="E267" sources="//@children.175/@ports.1" targets="//@children.173/@ports.6"/>
+  <containedEdges identifier="E268" sources="//@children.176/@ports.1" targets="//@children.179/@ports.2"/>
+  <containedEdges identifier="E269" sources="//@children.176/@ports.1" targets="//@children.181/@ports.3"/>
+  <containedEdges identifier="E270" sources="//@children.176/@ports.1" targets="//@children.182/@ports.3"/>
+  <containedEdges identifier="E271" sources="//@children.176/@ports.1" targets="//@children.184/@ports.4"/>
+  <containedEdges identifier="E272" sources="//@children.176/@ports.1" targets="//@children.185/@ports.3"/>
+  <containedEdges identifier="E273" sources="//@children.177/@ports.2" targets="//@children.172/@ports.1"/>
+  <containedEdges identifier="E274" sources="//@children.177/@ports.2" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E275" sources="//@children.177/@ports.2" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E276" sources="//@children.178/@ports.0" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E277" sources="//@children.179/@ports.0" targets="//@children.188/@ports.0"/>
+  <containedEdges identifier="E278" sources="//@children.180/@ports.0" targets="//@children.189/@ports.0"/>
+  <containedEdges identifier="E279" sources="//@children.181/@ports.0" targets="//@children.190/@ports.0"/>
+  <containedEdges identifier="E280" sources="//@children.182/@ports.0" targets="//@children.191/@ports.0"/>
+  <containedEdges identifier="E281" sources="//@children.183/@ports.0" targets="//@children.192/@ports.0"/>
+  <containedEdges identifier="E282" sources="//@children.184/@ports.0" targets="//@children.193/@ports.0"/>
+  <containedEdges identifier="E283" sources="//@children.185/@ports.0" targets="//@children.194/@ports.0"/>
+  <containedEdges identifier="E284" sources="//@children.186/@ports.0" targets="//@children.195/@ports.0"/>
+  <containedEdges identifier="E285" sources="//@children.187/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E286" sources="//@children.188/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E287" sources="//@children.189/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E288" sources="//@children.190/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E289" sources="//@children.191/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E290" sources="//@children.192/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E291" sources="//@children.193/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E292" sources="//@children.194/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E293" sources="//@children.195/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E294" sources="//@children.196/@ports.1" targets="//@children.182/@ports.5"/>
+  <containedEdges identifier="E295" sources="//@children.196/@ports.1" targets="//@children.183/@ports.1"/>
+  <containedEdges identifier="E296" sources="//@children.196/@ports.1" targets="//@children.184/@ports.1"/>
+  <containedEdges identifier="E297" sources="//@children.196/@ports.1" targets="//@children.185/@ports.5"/>
+  <containedEdges identifier="E298" sources="//@children.197/@ports.1" targets="//@children.180/@ports.1"/>
+  <containedEdges identifier="E299" sources="//@children.197/@ports.1" targets="//@children.181/@ports.2"/>
+  <containedEdges identifier="E300" sources="//@children.197/@ports.1" targets="//@children.182/@ports.1"/>
+  <containedEdges identifier="E301" sources="//@children.197/@ports.1" targets="//@children.184/@ports.3"/>
+  <containedEdges identifier="E302" sources="//@children.197/@ports.1" targets="//@children.185/@ports.2"/>
+  <containedEdges identifier="E303" sources="//@children.198/@ports.1" targets="//@children.181/@ports.1"/>
+  <containedEdges identifier="E304" sources="//@children.198/@ports.1" targets="//@children.184/@ports.2"/>
+  <containedEdges identifier="E305" sources="//@children.198/@ports.1" targets="//@children.185/@ports.1"/>
+  <containedEdges identifier="E306" sources="//@children.198/@ports.1" targets="//@children.186/@ports.1"/>
+  <containedEdges identifier="E307" sources="//@children.199/@ports.1" targets="//@children.178/@ports.1"/>
+  <containedEdges identifier="E308" sources="//@children.199/@ports.1" targets="//@children.179/@ports.1"/>
+  <containedEdges identifier="E309" sources="//@children.199/@ports.1" targets="//@children.182/@ports.2"/>
+  <containedEdges identifier="E310" sources="//@children.199/@ports.1" targets="//@children.183/@ports.2"/>
+  <containedEdges identifier="E311" sources="//@children.199/@ports.1" targets="//@children.186/@ports.2"/>
+  <containedEdges identifier="E312" sources="//@children.200/@ports.1" targets="//@children.178/@ports.2"/>
+  <containedEdges identifier="E313" sources="//@children.200/@ports.1" targets="//@children.181/@ports.4"/>
+  <containedEdges identifier="E314" sources="//@children.200/@ports.1" targets="//@children.182/@ports.4"/>
+  <containedEdges identifier="E315" sources="//@children.200/@ports.1" targets="//@children.184/@ports.5"/>
+  <containedEdges identifier="E316" sources="//@children.200/@ports.1" targets="//@children.185/@ports.4"/>
+  <containedEdges identifier="E317" sources="//@children.201/@ports.1" targets="//@children.196/@ports.0"/>
+  <containedEdges identifier="E318" sources="//@children.201/@ports.1" targets="//@children.198/@ports.0"/>
+  <containedEdges identifier="E319" sources="//@children.201/@ports.1" targets="//@children.197/@ports.0"/>
+  <containedEdges identifier="E320" sources="//@children.201/@ports.1" targets="//@children.199/@ports.0"/>
+  <containedEdges identifier="E321" sources="//@children.201/@ports.1" targets="//@children.176/@ports.0"/>
+  <containedEdges identifier="E322" sources="//@children.201/@ports.1" targets="//@children.200/@ports.0"/>
+  <containedEdges identifier="E323" sources="//@children.202/@ports.0" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E324" sources="//@children.203/@ports.0" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E325" sources="//@children.204/@ports.0" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E326" sources="//@children.205/@ports.1" targets="//@children.202/@ports.1"/>
+  <containedEdges identifier="E327" sources="//@children.205/@ports.1" targets="//@children.204/@ports.1"/>
+  <containedEdges identifier="E328" sources="//@children.205/@ports.1" targets="//@children.202/@ports.2"/>
+  <containedEdges identifier="E329" sources="//@children.205/@ports.1" targets="//@children.203/@ports.1"/>
+  <containedEdges identifier="E330" sources="//@children.205/@ports.1" targets="//@children.204/@ports.2"/>
+  <containedEdges identifier="E331" sources="//@children.205/@ports.1" targets="//@children.202/@ports.3"/>
+  <containedEdges identifier="E332" sources="//@children.205/@ports.1" targets="//@children.203/@ports.2"/>
+  <containedEdges identifier="E333" sources="//@children.205/@ports.1" targets="//@children.204/@ports.3"/>
+  <containedEdges identifier="E334" sources="//@children.206/@ports.1" targets="//@children.202/@ports.4"/>
+  <containedEdges identifier="E335" sources="//@children.206/@ports.1" targets="//@children.203/@ports.3"/>
+  <containedEdges identifier="E336" sources="//@children.206/@ports.1" targets="//@children.204/@ports.4"/>
+  <containedEdges identifier="E337" sources="//@children.206/@ports.1" targets="//@children.202/@ports.5"/>
+  <containedEdges identifier="E338" sources="//@children.206/@ports.1" targets="//@children.204/@ports.5"/>
+  <containedEdges identifier="E339" sources="//@children.207/@ports.1" targets="//@children.224/@ports.0"/>
+  <containedEdges identifier="E340" sources="//@children.208/@ports.2" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E341" sources="//@children.209/@ports.2" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E342" sources="//@children.210/@ports.2" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E343" sources="//@children.211/@ports.1" targets="//@children.208/@ports.1"/>
+  <containedEdges identifier="E344" sources="//@children.211/@ports.1" targets="//@children.209/@ports.1"/>
+  <containedEdges identifier="E345" sources="//@children.211/@ports.1" targets="//@children.210/@ports.1"/>
+  <containedEdges identifier="E346" sources="//@children.212/@ports.1" targets="//@children.169/@ports.0"/>
+  <containedEdges identifier="E347" sources="//@children.212/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E348" sources="//@children.212/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E349" sources="//@children.213/@ports.0" targets="//@children.165/@ports.1"/>
+  <containedEdges identifier="E350" sources="//@children.214/@ports.1" targets="//@children.213/@ports.1"/>
+  <containedEdges identifier="E351" sources="//@children.214/@ports.1" targets="//@children.213/@ports.2"/>
+  <containedEdges identifier="E352" sources="//@children.214/@ports.1" targets="//@children.213/@ports.3"/>
+  <containedEdges identifier="E353" sources="//@children.215/@ports.1" targets="//@children.213/@ports.4"/>
+  <containedEdges identifier="E354" sources="//@children.215/@ports.1" targets="//@children.213/@ports.5"/>
+  <containedEdges identifier="E355" sources="//@children.215/@ports.1" targets="//@children.213/@ports.6"/>
+  <containedEdges identifier="E356" sources="//@children.216/@ports.2" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E357" sources="//@children.217/@ports.2" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E358" sources="//@children.218/@ports.2" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E359" sources="//@children.219/@ports.1" targets="//@children.216/@ports.1"/>
+  <containedEdges identifier="E360" sources="//@children.219/@ports.1" targets="//@children.217/@ports.1"/>
+  <containedEdges identifier="E361" sources="//@children.219/@ports.1" targets="//@children.218/@ports.1"/>
+  <containedEdges identifier="E362" sources="//@children.220/@ports.1" targets="//@children.168/@ports.0"/>
+  <containedEdges identifier="E363" sources="//@children.220/@ports.1" targets="//@children.174/@ports.0"/>
+  <containedEdges identifier="E364" sources="//@children.220/@ports.1" targets="//@children.205/@ports.0"/>
+  <containedEdges identifier="E365" sources="//@children.221/@ports.2" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E366" sources="//@children.222/@ports.2" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E367" sources="//@children.223/@ports.2" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E368" sources="//@children.224/@ports.1" targets="//@children.221/@ports.1"/>
+  <containedEdges identifier="E369" sources="//@children.224/@ports.1" targets="//@children.222/@ports.1"/>
+  <containedEdges identifier="E370" sources="//@children.224/@ports.1" targets="//@children.223/@ports.1"/>
+  <containedEdges identifier="E371" sources="//@children.225/@ports.1" targets="//@children.201/@ports.0"/>
+  <containedEdges identifier="E372" sources="//@children.225/@ports.1" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E373" sources="//@children.225/@ports.1" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E374" sources="//@children.225/@ports.1" targets="//@children.232/@ports.0"/>
+  <containedEdges identifier="E375" sources="//@children.225/@ports.1" targets="//@children.233/@ports.0"/>
+  <containedEdges identifier="E376" sources="//@children.225/@ports.1" targets="//@children.234/@ports.0"/>
+  <containedEdges identifier="E377" sources="//@children.225/@ports.1" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E378" sources="//@children.225/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E379" sources="//@children.226/@ports.2" targets="//@children.230/@ports.0"/>
+  <containedEdges identifier="E380" sources="//@children.227/@ports.2" targets="//@children.230/@ports.0"/>
+  <containedEdges identifier="E381" sources="//@children.228/@ports.2" targets="//@children.230/@ports.0"/>
+  <containedEdges identifier="E382" sources="//@children.229/@ports.1" targets="//@children.226/@ports.1"/>
+  <containedEdges identifier="E383" sources="//@children.229/@ports.1" targets="//@children.227/@ports.1"/>
+  <containedEdges identifier="E384" sources="//@children.229/@ports.1" targets="//@children.228/@ports.1"/>
+  <containedEdges identifier="E385" sources="//@children.230/@ports.1" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E386" sources="//@children.230/@ports.1" targets="//@children.232/@ports.0"/>
+  <containedEdges identifier="E387" sources="//@children.230/@ports.1" targets="//@children.233/@ports.0"/>
+  <containedEdges identifier="E388" sources="//@children.230/@ports.1" targets="//@children.234/@ports.0"/>
+  <containedEdges identifier="E389" sources="//@children.230/@ports.1" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E390" sources="//@children.230/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E391" sources="//@children.231/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E392" sources="//@children.231/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E393" sources="//@children.231/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E394" sources="//@children.232/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E395" sources="//@children.232/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E396" sources="//@children.232/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E397" sources="//@children.233/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E398" sources="//@children.233/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E399" sources="//@children.233/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E400" sources="//@children.234/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E401" sources="//@children.234/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E402" sources="//@children.234/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E403" sources="//@children.235/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E404" sources="//@children.235/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E405" sources="//@children.235/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E406" sources="//@children.236/@ports.1" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_staticunits_StaticUnits.elkg
+++ b/realworld/ptolemy/flattened/continuous_staticunits_StaticUnits.elkg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="23.0" text="flow"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="110.0" text="growthAddSubtract"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="238.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="28.0" text="Limit"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="328.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="39.0" text="growth"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="243.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="181.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_staticunits_StaticUnits2.elkg
+++ b/realworld/ptolemy/flattened/continuous_staticunits_StaticUnits2.elkg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="49.0" text="flow rate"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="158.0" text="Convert Population to Joule"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="14.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="110.0" text="growthAddSubtract"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="238.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="28.0" text="Limit"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="328.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="39.0" text="growth"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="243.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="181.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_stickymasses_StickyMasses.elkg
+++ b/realworld/ptolemy/flattened/continuous_stickymasses_StickyMasses.elkg
@@ -1,0 +1,1209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="46.0" text="Masses"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="-2.555555582046509" outgoingEdges="//@containedEdges.0 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="2.8888888359069824" outgoingEdges="//@containedEdges.1 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="13.777777671813965" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="19.22222137451172" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="30.11111068725586" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="35.55555725097656" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Force"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="79.0" text="Accelerations"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="56.0" text="Velocities"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="54.0" text="Positions"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="57.0" text="Scale3D3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="43.0" text="left wall"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="84.0" text="Translate3D26"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18 //@containedEdges.20 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="62.0" text="Rotate3D1"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="25.0" text="floor"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="51.0" text="right wall"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15 //@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="55.0" text="Torus3D1"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="55.0" text="Torus3D2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.31 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="69.0" text="Rotate3D10"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="69.0" text="Rotate3D13"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="69.0" text="Rotate3D14"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="55.0" text="Torus3D3"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="62.0" text="Rotate3D4"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.34 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="62.0" text="Torus3D16"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="69.0" text="Rotate3D17"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="69.0" text="Rotate3D20"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="84.0" text="Translate3D24"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.38 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="62.0" text="Torus3D27"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="69.0" text="Rotate3D28"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="84.0" text="Translate3D33"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.41 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="62.0" text="Torus3D38"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="62.0" text="Torus3D39"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="69.0" text="Rotate3D40"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="69.0" text="Rotate3D41"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="84.0" text="Translate3D42"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.46 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="69.0" text="Rotate3D43"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="84.0" text="Translate3D52"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.48 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.50 //@containedEdges.51 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="65.0" text="Sphere3D1"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="85.0" text="Compute Twist"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.61 //@containedEdges.62 //@containedEdges.63 //@containedEdges.64 //@containedEdges.65 //@containedEdges.66 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="55.0" text="Torus3D1"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="55.0" text="Torus3D2"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.72 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="69.0" text="Rotate3D10"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="69.0" text="Rotate3D13"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="69.0" text="Rotate3D14"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="55.0" text="Torus3D3"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="62.0" text="Rotate3D4"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.75 //@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="62.0" text="Torus3D16"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="69.0" text="Rotate3D17"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="69.0" text="Rotate3D20"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="84.0" text="Translate3D24"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.79 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="62.0" text="Torus3D27"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="69.0" text="Rotate3D28"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="84.0" text="Translate3D33"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.82 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="62.0" text="Torus3D38"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="62.0" text="Torus3D39"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="69.0" text="Rotate3D40"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="69.0" text="Rotate3D41"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="84.0" text="Translate3D42"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.87 //@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="69.0" text="Rotate3D43"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="84.0" text="Translate3D52"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.89 //@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.91 //@containedEdges.92 //@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="65.0" text="Sphere3D1"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.70 //@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="85.0" text="Compute Twist"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.97 //@containedEdges.98 //@containedEdges.99 //@containedEdges.100 //@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.102 //@containedEdges.103 //@containedEdges.104 //@containedEdges.105 //@containedEdges.106 //@containedEdges.107 //@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.4" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.0/@ports.7" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.1" targets="//@children.79/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.10/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.19/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.20/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.21/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.22/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.24/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.25/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.26/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.27/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.28/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.29/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.30/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.31/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.32/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.33/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.34/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.35/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.36/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.37/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.38/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.39/@ports.0" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.40/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.41/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.42/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.43/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.44/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.45/@ports.1" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.45/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.45/@ports.1" targets="//@children.41/@ports.2"/>
+  <containedEdges identifier="E54" sources="//@children.46/@ports.0" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.47/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.48/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.49/@ports.0" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E58" sources="//@children.49/@ports.0" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E59" sources="//@children.49/@ports.0" targets="//@children.36/@ports.2"/>
+  <containedEdges identifier="E60" sources="//@children.49/@ports.0" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E61" sources="//@children.49/@ports.0" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.50/@ports.0" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E63" sources="//@children.50/@ports.0" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E64" sources="//@children.50/@ports.0" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E65" sources="//@children.50/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E66" sources="//@children.50/@ports.0" targets="//@children.42/@ports.2"/>
+  <containedEdges identifier="E67" sources="//@children.50/@ports.0" targets="//@children.44/@ports.2"/>
+  <containedEdges identifier="E68" sources="//@children.50/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.51/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.52/@ports.0" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.53/@ports.1" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.54/@ports.1" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.55/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.56/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.57/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.58/@ports.1" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.59/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.60/@ports.0" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.61/@ports.1" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.62/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.63/@ports.1" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.64/@ports.0" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.65/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.66/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.67/@ports.0" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.68/@ports.0" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.69/@ports.1" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.70/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.71/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.72/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.73/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.74/@ports.1" targets="//@children.55/@ports.2"/>
+  <containedEdges identifier="E93" sources="//@children.74/@ports.1" targets="//@children.62/@ports.2"/>
+  <containedEdges identifier="E94" sources="//@children.74/@ports.1" targets="//@children.70/@ports.2"/>
+  <containedEdges identifier="E95" sources="//@children.75/@ports.0" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.76/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.77/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.78/@ports.0" targets="//@children.54/@ports.2"/>
+  <containedEdges identifier="E99" sources="//@children.78/@ports.0" targets="//@children.58/@ports.2"/>
+  <containedEdges identifier="E100" sources="//@children.78/@ports.0" targets="//@children.65/@ports.2"/>
+  <containedEdges identifier="E101" sources="//@children.78/@ports.0" targets="//@children.72/@ports.2"/>
+  <containedEdges identifier="E102" sources="//@children.78/@ports.0" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.79/@ports.0" targets="//@children.53/@ports.2"/>
+  <containedEdges identifier="E104" sources="//@children.79/@ports.0" targets="//@children.59/@ports.2"/>
+  <containedEdges identifier="E105" sources="//@children.79/@ports.0" targets="//@children.63/@ports.2"/>
+  <containedEdges identifier="E106" sources="//@children.79/@ports.0" targets="//@children.66/@ports.2"/>
+  <containedEdges identifier="E107" sources="//@children.79/@ports.0" targets="//@children.71/@ports.2"/>
+  <containedEdges identifier="E108" sources="//@children.79/@ports.0" targets="//@children.73/@ports.2"/>
+  <containedEdges identifier="E109" sources="//@children.79/@ports.0" targets="//@children.78/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_units_Units.elkg
+++ b/realworld/ptolemy/flattened/continuous_units_Units.elkg
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="DisplayVoltage"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="54.0" text="InUnitsOf"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="85.0" text="DisplayCurrent"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="41.0" text="Scale1"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="129.0" text="DisplayCurrentInAmps"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/continuous_v2v_V2V.elkg
+++ b/realworld/ptolemy/flattened/continuous_v2v_V2V.elkg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Velocities"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="52.0" text="Distance"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="51.0" text="1:Limiter"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="120.0" text="ContinuousSinewave"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.3" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/curriculum_curriculum_Curriculum.elkg
+++ b/realworld/ptolemy/flattened/curriculum_curriculum_Curriculum.elkg
@@ -1,0 +1,809 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="20"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="40"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="23.0" text="61A"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="23.0" text="61B"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="24.0" text="61C"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24 //@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="70"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28 //@containedEdges.29 //@containedEdges.30 //@containedEdges.31 //@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="22.0" text="150"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="22.0" text="152"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="22.0" text="160"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="48.0" text="Math 53"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Math 54"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="22.0" text="162"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.20 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="22.0" text="164"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="22.0" text="169"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.22 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="22.0" text="170"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.42 //@containedEdges.43 //@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.23 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="22.0" text="172"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="22.0" text="184"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="22.0" text="186"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="22.0" text="188"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="67.0" text="Physics 7A"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="67.0" text="Physics 7B"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.47 //@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="21.0" text="113"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="22.0" text="105"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.50 //@containedEdges.51 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="21.0" text="117"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6 //@containedEdges.36 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="68.0" text="Physics 7C"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="21.0" text="119"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="22.0" text="120"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="22.0" text="121"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.54 //@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="22.0" text="122"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="22.0" text="123"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="22.0" text="125"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="22.0" text="128"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="22.0" text="Or2"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.37 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="22.0" text="130"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="22.0" text="140"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="22.0" text="141"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="22.0" text="142"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.58 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="22.0" text="143"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="32.0" text="145M"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="29.0" text="145L"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="22.0" text="192"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.35 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="22.0" text="126"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="22.0" text="129"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="30.0" text="145B"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="22.0" text="149"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2 //@containedEdges.25 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="22.0" text="161"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.26 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="30.0" text="127A"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="22.0" text="134"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="22.0" text="147"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="22.0" text="174"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="22.0" text="176"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="22.0" text="191"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="30.0" text="137A"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="30.0" text="137B"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="22.0" text="144"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.3/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.4/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.4/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.4/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.4/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.4/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.4/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.4/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.5/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.5/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.5/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.5/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.5/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.5/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.5/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.6/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.9/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.9/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.10/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.10/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.10/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.10/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.14/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.14/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.14/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.19/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.20/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.20/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.20/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.22/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.22/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.22/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.24/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.26/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.26/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.26/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.26/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.26/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.26/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.26/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.26/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.32/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.34/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.41/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.52/@ports.0" targets="//@children.53/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/curriculum_curriculum_Curriculum149.elkg
+++ b/realworld/ptolemy/flattened/curriculum_curriculum_Curriculum149.elkg
@@ -1,0 +1,857 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="20"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="40"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.43 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="23.0" text="61A"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="23.0" text="61B"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="24.0" text="61C"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24 //@containedEdges.25 //@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="70"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="22.0" text="150"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="22.0" text="152"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="22.0" text="160"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="48.0" text="Math 53"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Math 54"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.33 //@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="48.0" text="Math 55"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="22.0" text="162"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.22 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="22.0" text="164"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="22.0" text="169"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="22.0" text="170"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.25 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="22.0" text="172"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="22.0" text="182"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="22.0" text="184"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="22.0" text="186"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="22.0" text="188"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="12.0" text="or"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.28 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="67.0" text="Physics 7A"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="67.0" text="Physics 7B"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.43 //@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="22.0" text="100"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.44 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="21.0" text="113"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="22.0" text="105"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.47 //@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="49.0" text="Math 1A"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="49.0" text="Math 1B"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="21.0" text="117"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6 //@containedEdges.31 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="21.0" text="118"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="68.0" text="Physics 7C"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="21.0" text="119"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="22.0" text="120"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.60 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63 //@containedEdges.64 //@containedEdges.65 //@containedEdges.66 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="22.0" text="121"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.60 //@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="22.0" text="122"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="22.0" text="123"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="22.0" text="125"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="22.0" text="128"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="22.0" text="Or2"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.32 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="22.0" text="130"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8 //@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="22.0" text="131"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="22.0" text="133"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="22.0" text="140"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="22.0" text="141"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="22.0" text="142"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.64 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="22.0" text="143"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="32.0" text="145M"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="29.0" text="145L"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="22.0" text="192"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.30 //@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="30.0" text="CS 3"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="15.0" text="Or"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.13 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="15.0" text="42"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="15.0" text="43"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="22.0" text="126"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="22.0" text="129"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="30.0" text="145B"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="22.0" text="149"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3 //@containedEdges.27 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.1/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.4/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.4/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.4/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.4/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.4/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.4/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.5/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.6/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.9/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.9/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.10/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.10/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.10/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.11/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.15/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.21/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.21/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.21/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.21/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.22/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.23/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.23/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.23/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.24/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.26/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.26/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.26/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.27/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.28/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.28/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.28/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.28/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.28/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.28/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.28/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.28/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.31/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.33/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.33/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.33/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.33/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.33/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.33/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.33/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.33/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.39/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.40/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.43/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E72" sources="//@children.50/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.51/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.52/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.54/@ports.0" targets="//@children.34/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/curriculum_curriculum_curriculumAbstracted.elkg
+++ b/realworld/ptolemy/flattened/curriculum_curriculum_curriculumAbstracted.elkg
@@ -1,0 +1,827 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="20"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="40"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.40 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="23.0" text="61A"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="23.0" text="61B"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="24.0" text="61C"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="70"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="22.0" text="150"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="22.0" text="152"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="22.0" text="160"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="48.0" text="Math 53"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Math 54"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="22.0" text="162"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="22.0" text="164"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="22.0" text="169"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.18 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="22.0" text="170"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="22.0" text="172"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="22.0" text="182"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="22.0" text="184"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="22.0" text="186"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="22.0" text="188"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="67.0" text="Physics 7A"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="67.0" text="Physics 7B"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.40 //@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="22.0" text="100"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.41 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="21.0" text="113"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="22.0" text="105"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="49.0" text="Math 1A"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="49.0" text="Math 1B"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.48 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="21.0" text="117"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6 //@containedEdges.33 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="21.0" text="118"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="68.0" text="Physics 7C"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="21.0" text="119"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="22.0" text="120"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="22.0" text="121"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.56 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="22.0" text="122"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="22.0" text="123"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="22.0" text="125"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="22.0" text="128"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="22.0" text="Or2"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.34 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="22.0" text="130"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="22.0" text="131"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="22.0" text="133"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="22.0" text="140"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="22.0" text="141"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="22.0" text="142"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.60 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="22.0" text="143"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="32.0" text="145M"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="29.0" text="145L"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="22.0" text="192"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.32 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="30.0" text="CS 3"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="15.0" text="Or"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.13 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="15.0" text="42"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="15.0" text="43"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="22.0" text="126"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="22.0" text="129"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="30.0" text="145B"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="22.0" text="124"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.1/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.3/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.3/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.3/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.3/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.3/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.4/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.5/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.5/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.5/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.6/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.9/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.9/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.10/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.10/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.10/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.20/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.21/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.21/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.21/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.22/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.24/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.24/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.24/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.25/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.26/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.26/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.26/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.26/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.26/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.26/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.26/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.29/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.31/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.31/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.31/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.31/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.31/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.31/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.31/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.31/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.37/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.38/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.41/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.48/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.49/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.50/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.52/@ports.0" targets="//@children.32/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/curriculum_curriculum_curriculumLS1.elkg
+++ b/realworld/ptolemy/flattened/curriculum_curriculum_curriculumLS1.elkg
@@ -1,0 +1,827 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="20"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="40"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.40 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="23.0" text="61A"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="23.0" text="61B"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="24.0" text="61C"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="70"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="22.0" text="150"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="22.0" text="152"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="22.0" text="160"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="48.0" text="Math 53"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Math 54"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="22.0" text="162"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="22.0" text="164"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="22.0" text="169"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.18 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="22.0" text="170"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="22.0" text="172"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="22.0" text="182"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="22.0" text="184"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="22.0" text="186"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="22.0" text="188"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="67.0" text="Physics 7A"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="67.0" text="Physics 7B"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.40 //@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="22.0" text="100"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.41 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="21.0" text="113"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="22.0" text="105"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="49.0" text="Math 1A"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="49.0" text="Math 1B"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.48 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="21.0" text="117"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6 //@containedEdges.33 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="21.0" text="118"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="68.0" text="Physics 7C"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="21.0" text="119"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="22.0" text="120"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="22.0" text="121"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.56 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="22.0" text="122"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="22.0" text="123"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="22.0" text="125"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="22.0" text="128"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="22.0" text="Or2"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.34 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="22.0" text="130"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="22.0" text="131"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="22.0" text="133"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="22.0" text="140"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="22.0" text="141"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="22.0" text="142"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.60 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="22.0" text="143"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="32.0" text="145M"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="29.0" text="145L"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="22.0" text="192"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.32 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="30.0" text="CS 3"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="15.0" text="Or"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.13 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="15.0" text="42"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="15.0" text="43"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="22.0" text="126"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="22.0" text="129"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="30.0" text="145B"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="22.0" text="124"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.1/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.3/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.3/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.3/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.3/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.3/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.4/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.5/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.5/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.5/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.6/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.9/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.9/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.10/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.10/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.10/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.20/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.21/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.21/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.21/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.22/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.24/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.24/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.24/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.25/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.26/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.26/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.26/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.26/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.26/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.26/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.26/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.29/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.31/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.31/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.31/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.31/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.31/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.31/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.31/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.31/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.37/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.38/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.41/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.48/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.49/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.50/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.52/@ports.0" targets="//@children.32/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/curriculum_curriculum_curriculumOption1.elkg
+++ b/realworld/ptolemy/flattened/curriculum_curriculum_curriculumOption1.elkg
@@ -1,0 +1,800 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="20"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="40"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.39 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="23.0" text="61A"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="23.0" text="61B"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="24.0" text="61C"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="70"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="22.0" text="150"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="22.0" text="152"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="22.0" text="160"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="48.0" text="Math 53"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Math 54"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.30 //@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="48.0" text="Math 55"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="22.0" text="162"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="22.0" text="164"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="22.0" text="169"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.22 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="22.0" text="170"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.23 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="22.0" text="172"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="22.0" text="182"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="22.0" text="184"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="22.0" text="186"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="22.0" text="188"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="12.0" text="or"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.25 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="67.0" text="Physics 7A"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="67.0" text="Physics 7B"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="22.0" text="100"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.40 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="21.0" text="113"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="22.0" text="105"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.43 //@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="49.0" text="Math 1A"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="49.0" text="Math 1B"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.47 //@containedEdges.48 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="21.0" text="117"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4 //@containedEdges.28 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="21.0" text="118"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="68.0" text="Physics 7C"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="21.0" text="119"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="22.0" text="120"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1 //@containedEdges.31 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="22.0" text="121"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="22.0" text="122"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.64 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="22.0" text="123"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="22.0" text="125"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="22.0" text="128"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="22.0" text="Or2"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.29 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="22.0" text="130"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="22.0" text="131"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="22.0" text="133"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="22.0" text="140"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="22.0" text="141"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="22.0" text="142"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.60 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="22.0" text="143"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="32.0" text="145M"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="29.0" text="145L"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="22.0" text="192"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.27 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="15.0" text="Or"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.11 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="22.0" text="129"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="30.0" text="145B"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="15.0" text="26"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.68 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.3/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.4/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.4/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.4/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.4/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.5/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.6/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.9/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.9/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.10/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.10/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.10/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.11/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.15/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.21/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.21/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.21/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.22/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.23/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.23/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.23/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.24/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.26/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.26/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.26/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.27/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.28/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.28/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.28/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.28/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.28/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.28/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.28/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.28/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.31/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.33/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.33/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.33/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.33/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.33/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.33/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.33/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.33/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.39/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.40/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.43/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.50/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.53/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.53/@ports.0" targets="//@children.35/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/curriculum_curriculum_curriculumProbStat.elkg
+++ b/realworld/ptolemy/flattened/curriculum_curriculum_curriculumProbStat.elkg
@@ -1,0 +1,827 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="20"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="40"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.40 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="23.0" text="61A"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="23.0" text="61B"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="24.0" text="61C"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="70"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="22.0" text="150"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="22.0" text="152"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="22.0" text="160"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="48.0" text="Math 53"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Math 54"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="22.0" text="162"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="22.0" text="164"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="22.0" text="169"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.18 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="22.0" text="170"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="22.0" text="172"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="22.0" text="182"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="22.0" text="184"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="22.0" text="186"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="22.0" text="188"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="67.0" text="Physics 7A"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="67.0" text="Physics 7B"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.40 //@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="22.0" text="100"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.41 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="21.0" text="113"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="22.0" text="105"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="49.0" text="Math 1A"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="49.0" text="Math 1B"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.48 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="21.0" text="117"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6 //@containedEdges.33 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="21.0" text="118"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="68.0" text="Physics 7C"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="21.0" text="119"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="22.0" text="120"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="22.0" text="121"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.56 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="22.0" text="122"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="22.0" text="123"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="22.0" text="125"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="22.0" text="128"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="22.0" text="Or2"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.34 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="22.0" text="130"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="22.0" text="131"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="22.0" text="133"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="22.0" text="140"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="22.0" text="141"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="22.0" text="142"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.60 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="22.0" text="143"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="32.0" text="145M"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="29.0" text="145L"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="22.0" text="192"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.32 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="30.0" text="CS 3"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="20.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="15.0" text="Or"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="20.0" y="6.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.13 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="15.0" text="42"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="15.0" text="43"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="22.0" text="126"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="38.0" y="8.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="22.0" text="129"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="30.0" text="145B"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="24.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="22.0" text="124"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="38.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.1/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.3/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.3/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.3/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.3/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.3/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.4/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.5/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.5/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.5/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.6/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.9/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.9/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.10/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.10/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.10/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.20/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.21/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.21/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.21/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.22/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.24/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.24/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.24/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.25/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.26/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.26/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.26/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.26/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.26/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.26/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.26/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.29/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.31/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.31/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.31/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.31/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.31/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.31/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.31/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.31/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.37/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.38/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.41/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.48/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.49/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.50/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.52/@ports.0" targets="//@children.32/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/dde_localzeno_LocalZeno.elkg
+++ b/realworld/ptolemy/flattened/dde_localzeno_LocalZeno.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="58.0" text="UpperJoin"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="60.0" text="UpperFork"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="93.0" text="UpperFeedBack"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="58.0" text="LowerJoin"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="60.0" text="LowerFork"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="93.0" text="LowerFeedBack"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="60.0" text="UpperRcvr"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="60.0" text="LowerRcvr"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="71.0" text="upperPlotter"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="69.0" text="lowerPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="63.0" text="UpperTime"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="63.0" text="LowerTime"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/dde_localzeno_LocalZenoTest.elkg
+++ b/realworld/ptolemy/flattened/dde_localzeno_LocalZenoTest.elkg
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="58.0" text="UpperJoin"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="60.0" text="UpperFork"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="93.0" text="UpperFeedBack"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="58.0" text="LowerJoin"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="60.0" text="LowerFork"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="93.0" text="LowerFeedBack"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="60.0" text="UpperRcvr"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="60.0" text="LowerRcvr"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="82.0" text="1:CurrentTime"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="57.0" text="FileWriter"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="4:FileWriter"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="63.0" text="UpperTime"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="63.0" text="LowerTime"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.10/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ddf_LoopSyntactic2.elkg
+++ b/realworld/ptolemy/flattened/ddf_LoopSyntactic2.elkg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="138.0" text="Outside-the-loop Plotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="127.0" text="Inside-the-loop Plotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.3" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ddf_LoopSyntacticC.elkg
+++ b/realworld/ptolemy/flattened/ddf_LoopSyntacticC.elkg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="138.0" text="Outside-the-loop Plotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="127.0" text="Inside-the-loop Plotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.0" targets="//@children.13/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ddf_eratosthenes_Eratosthenes.elkg
+++ b/realworld/ptolemy/flattened/ddf_eratosthenes_Eratosthenes.elkg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="90.0" text="ActorRecursion"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="140.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="140.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.3" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.3" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.0" targets="//@children.8/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ddf_huffmandecoder_HuffmanDecoder.elkg
+++ b/realworld/ptolemy/flattened/ddf_huffmandecoder_HuffmanDecoder.elkg
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="82.0" text="HuffmanCoder"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="HuffmanDecoder"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="107.0" text="HuffmanCodeBook"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="HuffmanCode"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="196.0" text="NumberOfBitsUsingHuffmanCoder"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="53.0" text="Counter2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="186.0" text="NumberOfBitsUsingBinaryCoder"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="143.0" text="FixedLengthBinaryCoder"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="182.0" text="CompareDecodedWithUncoded"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.9/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ddf_randomwalk_RandomWalk.elkg
+++ b/realworld/ptolemy/flattened/ddf_randomwalk_RandomWalk.elkg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="52.0" text="Uniform2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="99.0" text="CartesianToPolar"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="22.0" text="Ceil"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="34.0" y="13.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="49.0" text="Repeat2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="Accumulator2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ddf_rijndaelencryption_RijndaelEncryption.elkg
+++ b/realworld/ptolemy/flattened/ddf_rijndaelencryption_RijndaelEncryption.elkg
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="96.0" text="RoundSequence"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="508.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="508.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="203.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="203.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="modal model"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="61.0" text="UpSample"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="227.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="92.0" text="PadToTwoChars"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="61.0" text="UpSample"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="227.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="92.0" text="PadToTwoChars"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.4" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.4" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.15/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.16/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.1" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.24/@ports.0" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_CommunicationAnomalyDetectionAOM.elkg
+++ b/realworld/ptolemy/flattened/de_CommunicationAnomalyDetectionAOM.elkg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="93.0" text="OutgoingPacket"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="99.0" text="LatencyEstimate"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="TrainOrTest?"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="81.0" text="TrainOrTest?2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="110.0" text="SequenceToArray2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="79.0" text="UpdateLabels"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="56.0" text="GetToken"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="90.0" text="CompareLabels"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="66.0" text="CountTrues"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="54.0" text="Average2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="54.0" text="Average3"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="104.0" text="SequencePlotter2"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="172.0" text="ParameterEstimatorGaussian"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="1.600000023841858" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="140.0" text="HMMGaussianClassifier"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="79.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="79.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="123.0" text="CommunicationDelay"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.42 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="79.0" text="UpdateLabels"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="106.0" text="UpdateCQMToken"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="112.0" text="LatencyDistribution"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.50 //@containedEdges.51 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.50 //@containedEdges.51 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.3" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.3" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.15/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.17/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.18/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.3" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.19/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.21/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.22/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.23/@ports.1" targets="//@children.28/@ports.4"/>
+  <containedEdges identifier="E33" sources="//@children.24/@ports.1" targets="//@children.28/@ports.5"/>
+  <containedEdges identifier="E34" sources="//@children.25/@ports.1" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.27/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.27/@ports.3" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.27/@ports.4" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.28/@ports.3" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.30/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.31/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.31/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.31/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.33/@ports.1" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E44" sources="//@children.33/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.33/@ports.2" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E46" sources="//@children.33/@ports.2" targets="//@children.39/@ports.2"/>
+  <containedEdges identifier="E47" sources="//@children.34/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.35/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.36/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.37/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.39/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.39/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.39/@ports.1" targets="//@children.38/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_CommunicationAnomalyDetectionCQM.elkg
+++ b/realworld/ptolemy/flattened/de_CommunicationAnomalyDetectionCQM.elkg
@@ -1,0 +1,652 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="93.0" text="OutgoingPacket"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="LatencyEstimate"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="TrainOrTest?2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TrainOrTest?"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="110.0" text="SequenceToArray2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="93.0" text="IncomingPacket"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="10.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="90.0" text="CompareLabels"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="66.0" text="CountTrues"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="40.0" text="priors2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="54.0" text="Average2"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="54.0" text="Average3"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="104.0" text="SequencePlotter2"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="172.0" text="ParameterEstimatorGaussian"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="1.600000023841858" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="11.199999809265137" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="140.0" text="HMMGaussianClassifier"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38 //@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="123.0" text="CommunicationDelay"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.43 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="79.0" text="UpdateLabels"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="106.0" text="UpdateCQMToken"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="112.0" text="LatencyDistribution"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.49 //@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.49 //@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.3" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.3" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.14/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.17/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.18/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.19/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.1" targets="//@children.26/@ports.4"/>
+  <containedEdges identifier="E32" sources="//@children.22/@ports.1" targets="//@children.26/@ports.5"/>
+  <containedEdges identifier="E33" sources="//@children.23/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.25/@ports.2" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.25/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.25/@ports.3" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.25/@ports.4" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.26/@ports.3" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.27/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.27/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.27/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.29/@ports.1" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E43" sources="//@children.29/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.29/@ports.2" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E45" sources="//@children.29/@ports.2" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E46" sources="//@children.30/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.31/@ports.0" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.32/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.33/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.35/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.35/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.35/@ports.1" targets="//@children.34/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_afdx_AFDX.elkg
+++ b/realworld/ptolemy/flattened/de_afdx_AFDX.elkg
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.7 //@containedEdges.9 //@containedEdges.12 //@containedEdges.14 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="17.0" text="D2"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="24.0" text="D41"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="24.0" text="D42"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="17.0" text="D3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="78.0" text="CurrentTime4"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.4/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.5/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.9/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.1" targets="//@children.6/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_clock_Clock.elkg
+++ b/realworld/ptolemy/flattened/de_clock_Clock.elkg
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="60.0" text="ClipPlayer"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="Copy2:Box3D"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="111.0" text="Copy3:Translate3D"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="64.0" text="Cylinder3D"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="77.0" text="ViewScreen2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9 //@containedEdges.12 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.8/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.4" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.4" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.7/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_clock_ClockTest.elkg
+++ b/realworld/ptolemy/flattened/de_clock_ClockTest.elkg
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="59.0" text="LineCoder"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="102.0" text="Copy1:UpSample"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="Copy2:Box3D"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="111.0" text="Copy3:Translate3D"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="64.0" text="Cylinder3D"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="77.0" text="ViewScreen2"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11 //@containedEdges.14 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="126.0" text="Copy1:Lowpass Filter"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="118.0" text="Copy1:Allpass Filter"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="206.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="74.0" text="Copy1:Delay"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="206.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="75.0" text="Copy1:Scale"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="112.0" text="Copy1:AudioPlayer"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="61.0" text="UpSample"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.4" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.4" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.22/@ports.1" targets="//@children.21/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_clockdrift_ClockDrifts.elkg
+++ b/realworld/ptolemy/flattened/de_clockdrift_ClockDrifts.elkg
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="120.0" text="ContinuousSinewave"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_compositeqm_CheckExecutionTimeConstraints.elkg
+++ b/realworld/ptolemy/flattened/de_compositeqm_CheckExecutionTimeConstraints.elkg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="ThrowModelError"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="36.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="28.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.13/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.1" targets="//@children.15/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_compositeqm_CompositeQM.elkg
+++ b/realworld/ptolemy/flattened/de_compositeqm_CompositeQM.elkg
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="17.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="8.0" text="a"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="8.0" text="b"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="93.0" text="CQMOutputPort"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_datagram_Datagram.elkg
+++ b/realworld/ptolemy/flattened/de_datagram_Datagram.elkg
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="358.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="358.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="78.0" text="EventButton2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="78.0" text="ArrayLength4"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="DatagramReader"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="92.0" text="DatagramWriter"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="191.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression1"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="191.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="78.0" text="ArrayLength2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="239.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="239.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="36.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="28.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.7 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="78.0" text="EventButton3"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="116.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="116.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="64.0" text="Datagram2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="64.0" text="Datagram1"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="159.0" text="StringToUnsignedByteArray"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="93.0" text="IntArrayToString"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_datedemo_DateDemo.elkg
+++ b/realworld/ptolemy/flattened/de_datedemo_DateDemo.elkg
@@ -1,0 +1,846 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="CurrentDate"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="24.0" text="now"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="82.0" text="DateElements"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="-3.6363637447357178" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="0.7272727489471436" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="5.090909004211426" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="9.454545021057129" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="13.818181991577148" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="18.18181800842285" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="22.545454025268555" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="26.909090042114258" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="31.272727966308594" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="35.6363639831543" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="31.0" text="now2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="31.0" text="now3"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="31.0" text="now4"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="31.0" text="now5"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="31.0" text="now6"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="31.0" text="now7"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="31.0" text="now8"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="31.0" text="now9"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="38.0" text="now10"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="now11"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="66.0" text="ModifyDate"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="66.0" text="1 hour later"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="73.0" text="ModifyDate2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="116.0" text="1 millisecond earlier"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="38.0" text="now12"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="38.0" text="now13"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="69.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="69.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="38.0" text="now14"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="95.0" text="DateConstructor"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="-4.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="4.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="12.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="20.0">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.0">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="36.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="104.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@containedEdges.37 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="98.0" text="constructed date"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="102.0" text="DateConstructor2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="-4.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="12.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.0">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="109.0" text="reconstructed date"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="48.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="48.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.41 //@containedEdges.42 //@containedEdges.43 //@containedEdges.44 //@containedEdges.45 //@containedEdges.46 //@containedEdges.47 //@containedEdges.48 //@containedEdges.49 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="73.0" text="ModifyDate3"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.51 //@containedEdges.52 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="90.0" text="2 seconds later"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="72.0" text="DateToEvent"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="130.0" text="output 2 seconds later"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="102.0" text="DateConstructor3"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="-4.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="4.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="12.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="20.0">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.0">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="36.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="75.0" text="StringToDate"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="272.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="272.0" y="8.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="105.0" text="constructed date3"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="105.0" text="constructed date2"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="82.0" text="StringToDate2"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="230.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="230.0" y="8.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="105.0" text="constructed date4"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="73.0" text="EventToDate"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="105.0" text="constructed date5"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="80.0" text="EventToDate2"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="105.0" text="constructed date6"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="104.0" text="DateToModelTime"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="38.0" text="now15"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.0" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.0" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.0" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.2" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.3" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.4" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.4" targets="//@children.27/@ports.3"/>
+  <containedEdges identifier="E17" sources="//@children.2/@ports.5" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.2/@ports.5" targets="//@children.27/@ports.4"/>
+  <containedEdges identifier="E19" sources="//@children.2/@ports.6" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.2/@ports.6" targets="//@children.27/@ports.5"/>
+  <containedEdges identifier="E21" sources="//@children.2/@ports.7" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.2/@ports.7" targets="//@children.27/@ports.6"/>
+  <containedEdges identifier="E23" sources="//@children.2/@ports.10" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.2/@ports.10" targets="//@children.27/@ports.9"/>
+  <containedEdges identifier="E25" sources="//@children.2/@ports.8" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.2/@ports.9" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.13/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.13/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.13/@ports.2" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.13/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.14/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.14/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.16/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.20/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.22/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.24/@ports.11" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.25/@ports.0" targets="//@children.24/@ports.10"/>
+  <containedEdges identifier="E39" sources="//@children.25/@ports.0" targets="//@children.36/@ports.10"/>
+  <containedEdges identifier="E40" sources="//@children.27/@ports.11" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.29/@ports.0" targets="//@children.24/@ports.9"/>
+  <containedEdges identifier="E42" sources="//@children.30/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.30/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.30/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.30/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.30/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.30/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.30/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.30/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.30/@ports.0" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.30/@ports.0" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.31/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.31/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.31/@ports.2" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.32/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.34/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.36/@ports.11" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.37/@ports.0" targets="//@children.36/@ports.9"/>
+  <containedEdges identifier="E59" sources="//@children.38/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.39/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.42/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.43/@ports.0" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.45/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.47/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.48/@ports.1" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.50/@ports.1" targets="//@children.51/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_de_DE2.elkg
+++ b/realworld/ptolemy/flattened/de_de_DE2.elkg
@@ -1,0 +1,622 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Ramp4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="167.0" text="ResourceMappingOutputPort"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="167.0" text="ResourceMappingOutputPort"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="175.0" text="ResourceMappingOutputPort2"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Ramp4"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="26.0" text="out2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.1" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.27/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.28/@ports.1" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.30/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.31/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.31/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.32/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.33/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.34/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.36/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.36/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.37/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.38/@ports.1" targets="//@children.37/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_decg_DECGPi.elkg
+++ b/realworld/ptolemy/flattened/de_decg_DECGPi.elkg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.2" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.2" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.11/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.14/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.15/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.16/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_generatorcontactorload_GeneratorContactorLoad.elkg
+++ b/realworld/ptolemy/flattened/de_generatorcontactorload_GeneratorContactorLoad.elkg
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="174.0" text="GeneratorContractorLoadFMU"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_inspection_Inspection.elkg
+++ b/realworld/ptolemy/flattened/de_inspection_Inspection.elkg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="119.0" text="Poisson Bus Arrivals"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="107.0" text="Passenger Arrivals"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="128.0" text="Poisson Waiting Time"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="Timed Plotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="59.0" text="Histogram"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="116.0" text="Regular Bus Arrivals"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="Regular Waiting Time"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="179.0" text="Display Average Waiting Times"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.18 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="76.0" text="SingleEvent0"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.0" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_linefault_LineFault.elkg
+++ b/realworld/ptolemy/flattened/de_linefault_LineFault.elkg
@@ -1,0 +1,1362 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="77.0" text="FullClockPlot"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="79.0" text="FaultLocation"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="121.0" text="Discrete TimeDelay2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="63.0" text="IsPresent2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.26 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="77.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.28 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="73.0" text="LookupTable"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="38.0" text="Round"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="219.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="223.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="223.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.47 //@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.52 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="63.0" text="IsPresent2"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.55 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.56 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.63 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="77.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.65 //@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.66 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.68 //@containedEdges.69 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.72 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.76 //@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="73.0" text="LookupTable"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="38.0" text="Round"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="219.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="25.0" width="223.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="223.0" y="8.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.84 //@containedEdges.85 //@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.88 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.92 //@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.92 //@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="25.0" width="57.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="57.0" y="8.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="78.0" text="MostRecent4"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.53 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.100 //@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.67/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.2" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.2" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.22/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.22/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.23/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.23/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.23/@ports.0" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.24/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.25/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.26/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.27/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.29/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.30/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.30/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.31/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.33/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.34/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.35/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.36/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.37/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.37/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.37/@ports.1" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.38/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.39/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.40/@ports.0" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.40/@ports.0" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.41/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.42/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.43/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.44/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.45/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.46/@ports.1" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E61" sources="//@children.46/@ports.1" targets="//@children.44/@ports.2"/>
+  <containedEdges identifier="E62" sources="//@children.47/@ports.2" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.47/@ports.2" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.48/@ports.0" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.49/@ports.2" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.50/@ports.0" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.51/@ports.2" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.51/@ports.2" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.52/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.52/@ports.0" targets="//@children.63/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.52/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.53/@ports.2" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.54/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.55/@ports.0" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.56/@ports.2" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.58/@ports.1" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.59/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.59/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.60/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.61/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.62/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.63/@ports.0" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.64/@ports.1" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E84" sources="//@children.65/@ports.0" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.66/@ports.1" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.66/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.66/@ports.1" targets="//@children.54/@ports.2"/>
+  <containedEdges identifier="E88" sources="//@children.67/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E89" sources="//@children.69/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.69/@ports.0" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.70/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.71/@ports.2" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.72/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.72/@ports.1" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E95" sources="//@children.73/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.74/@ports.0" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.75/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.76/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.77/@ports.1" targets="//@children.71/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.78/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.79/@ports.1" targets="//@children.76/@ports.2"/>
+  <containedEdges identifier="E102" sources="//@children.79/@ports.1" targets="//@children.77/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_primetest_PrimeTest.elkg
+++ b/realworld/ptolemy/flattened/de_primetest_PrimeTest.elkg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="130.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="130.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="162.0" text="Accumulator (Backtracking)"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="100.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="100.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="76.0" text="TimedDelay3"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.3" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.3" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.21/@ports.0" targets="//@children.19/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_printingpress_PrintingPress-Validation.elkg
+++ b/realworld/ptolemy/flattened/de_printingpress_PrintingPress-Validation.elkg
@@ -1,0 +1,4911 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="152.0" text="reserveFeedPaperRadius2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.78 //@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="104.0" text="feedPaperVelocity"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="106.0" text="feedPaperRadius3"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.320">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="40.0" text="omega"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="407.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="119.0" text="initialRadiusSquared"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="65.0" text="coreRadius"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.30 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.43 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="91.0" text="coreMassScale"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.60 //@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.63 //@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.70 //@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.68 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.64 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.72 //@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.73 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.61 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.78 //@containedEdges.79 //@containedEdges.80 //@containedEdges.81 //@containedEdges.82 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="25.0" width="219.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@containedEdges.85 //@containedEdges.86 //@containedEdges.87 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.90" incomingEdges="//@containedEdges.219">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.89" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.92" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.79 //@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.89 //@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.96 //@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.100" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P204" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.105 //@containedEdges.106 //@containedEdges.107 //@containedEdges.108 //@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.110 //@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.116 //@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.111 //@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.118 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.119 //@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.106 //@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.124 //@containedEdges.125 //@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.128 //@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="25.0" width="407.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="119.0" text="initialRadiusSquared"/>
+    <ports identifier="P248" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.132 //@containedEdges.133 //@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="58.0" text="constzero"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="40.0" text="omega"/>
+    <ports identifier="P256" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="65.0" text="constzero2"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="65.0" text="coreRadius"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.138 //@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.108 //@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="45.0" text="Select2"/>
+    <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.134 //@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P275" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.144 //@containedEdges.145 //@containedEdges.146 //@containedEdges.147 //@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.151 //@containedEdges.152 //@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P292" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.150 //@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.162 //@containedEdges.163 //@containedEdges.164 //@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="91.0" text="coreMassScale"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.167" incomingEdges="//@containedEdges.301">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P310" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.169" incomingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P312" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P314" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P320" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P325" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P329" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.172 //@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P331" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P335" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P338" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.173 //@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P341" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.178" incomingEdges="//@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P343" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P345" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.180 //@containedEdges.181" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P346" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P348" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P349" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P350" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P351" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.183 //@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P354" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.185 //@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P356" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P357" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P361" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P363" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P365" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.191 //@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P367" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P368" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.193 //@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P372" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P374" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P377" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P378" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P380" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P382" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P384" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P385" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P386" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P388" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.190 //@containedEdges.196 //@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P390" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P393" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P395" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P396" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P397" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.197 //@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P399" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P400" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P401" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P403" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P404" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P406" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P407" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P408" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P410" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P411" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P412" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P413" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P414" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P415" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P416" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.214 //@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P418" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P420" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.218 //@containedEdges.219 //@containedEdges.220" incomingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P421" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P424" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P425" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P426" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.222 //@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P427" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P429" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.224 //@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P430" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P431" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P432" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P433" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P436" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P437" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P438" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P439" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P440" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.230 //@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P442" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P443" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P444" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N176" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L176" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P445" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.232 //@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P447" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N177" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P448" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P449" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P450" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P451" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P453" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P454" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P455" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P457" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N181" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L181" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P459" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P460" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P461" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N182" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L182" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P462" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P463" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N183" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L183" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.229 //@containedEdges.235 //@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P465" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N184" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L184" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P467" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P468" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N185" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L185" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P469" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P470" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P471" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P472" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N186" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L186" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P473" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.236 //@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P474" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N187" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L187" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P475" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P476" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N188" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L188" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P478" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N189" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L189" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P479" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N190" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L190" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P482" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P483" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N191" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L191" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P484" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P485" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P486" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N192" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L192" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P487" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P488" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P489" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N193" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L193" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P490" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P491" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.253 //@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N194" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L194" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P493" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N195" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P494" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.256" incomingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P495" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N196" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L196" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P497" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.258" incomingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N197" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L197" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P498" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P501" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P502" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N198" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L198" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P503" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.260 //@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P504" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N199" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L199" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P505" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P506" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.262 //@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N200" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L200" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P507" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.262">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P508" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N201" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L201" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P509" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N202" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L202" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P511" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P512" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P513" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N203" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L203" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P514" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P515" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N204" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L204" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P516" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P517" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.268 //@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N205" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L205" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P518" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P519" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N206" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L206" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P520" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N207" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L207" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.270 //@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P523" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P524" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N208" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L208" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P525" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P526" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.273">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N209" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L209" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P528" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N210" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L210" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P529" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P530" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P531" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P532" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N211" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L211" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P533" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P534" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N212" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L212" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P536" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P537" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P538" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N213" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L213" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P540" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N214" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L214" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P541" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.267 //@containedEdges.273 //@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P542" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N215" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L215" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P544" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P545" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N216" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L216" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P547" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.287">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P548" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P549" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N217" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L217" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.274 //@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P551" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.284 //@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N218" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L218" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P552" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P553" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N219" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L219" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P554" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P555" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.287">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N220" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L220" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P556" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N221" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L221" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P558" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P559" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P560" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N222" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L222" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P562" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P563" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N223" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L223" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P564" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P565" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P566" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N224" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L224" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P567" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P568" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.292 //@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N225" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L225" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P570" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N226" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L226" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P571" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.295">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N227" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L227" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P573" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P574" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N228" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L228" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.285 //@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P576" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P577" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.295">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N229" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L229" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P578" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P579" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.299" incomingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N230" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L230" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P581" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.301 //@containedEdges.302" incomingEdges="//@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N231" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L231" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P582" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P583" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P584" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N232" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L232" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P585" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P587" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P588" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P589" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N233" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L233" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P592" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.304 //@containedEdges.305 //@containedEdges.306 //@containedEdges.307">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N234" height="25.0" width="111.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L234" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P593" height="8.0" width="8.0" x="111.0" y="8.5" outgoingEdges="//@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P594" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.304">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N235" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L235" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P595" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N236" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L236" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P597" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P598" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N237" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L237" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P600" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P601" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N238" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L238" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P602" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N239" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L239" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P604" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P605" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N240" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L240" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P606" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P607" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P608" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N241" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L241" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P609" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.307">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P610" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N242" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L242" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P612" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N243" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L243" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P613" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P614" height="8.0" width="8.0" x="66.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N244" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L244" height="15.0" width="61.0" text="TrueGate2"/>
+    <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P616" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N245" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L245" height="15.0" width="66.0" text="Sequence2"/>
+    <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P618" height="8.0" width="8.0" x="66.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N246" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L246" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.318" incomingEdges="//@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P620" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N247" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L247" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P622" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.320 //@containedEdges.321 //@containedEdges.322 //@containedEdges.323" incomingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N248" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L248" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P623" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P624" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N249" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L249" height="15.0" width="101.0" text="CompositeActor7"/>
+    <ports identifier="P625" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P626" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.326" incomingEdges="//@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N250" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L250" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P628" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P629" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N251" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L251" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P630" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P631" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P633" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P634" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N252" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L252" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P636" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P637" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N253" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L253" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P638" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P639" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P641" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P642" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N254" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L254" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P643" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.329 //@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P645" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P646" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P647" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N255" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L255" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P648" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.329">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P649" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.331 //@containedEdges.332 //@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P650" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N256" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L256" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P651" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P652" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P653" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N257" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L257" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P654" height="8.0" width="8.0" x="36.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P655" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N258" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L258" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P656" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P657" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N259" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L259" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P658" height="8.0" width="8.0" x="29.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P659" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N260" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L260" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P660" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P661" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P662" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N261" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L261" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P663" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.336" incomingEdges="//@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P664" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N262" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L262" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P665" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.337" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P666" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N263" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L263" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P667" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P668" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.339" incomingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N264" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L264" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.340" incomingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P670" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N265" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L265" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P671" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P672" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P673" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N266" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L266" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P674" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P676" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P677" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P678" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N267" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L267" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P679" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P680" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.342 //@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P681" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N268" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L268" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P682" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.350">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P683" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N269" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L269" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P684" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P685" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.344 //@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P686" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N270" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L270" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P687" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P688" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P689" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N271" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L271" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P690" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P691" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P692" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N272" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L272" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P693" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N273" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L273" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P695" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P696" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N274" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L274" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P698" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P699" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N275" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L275" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.343 //@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P701" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.350">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P702" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N276" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L276" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P703" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.351" incomingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P704" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N277" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L277" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P705" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.352" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P706" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N278" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L278" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P707" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.353" incomingEdges="//@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P708" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.353">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N279" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L279" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P709" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P710" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.355" incomingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N280" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L280" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P711" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P712" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P713" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N281" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L281" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P714" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P715" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P717" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P718" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N282" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L282" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P719" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P720" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.357 //@containedEdges.358">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P721" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N283" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L283" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P722" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P723" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.359 //@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P724" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N284" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L284" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P725" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P726" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P727" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N285" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L285" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P728" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P729" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P730" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N286" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L286" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P731" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P732" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N287" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L287" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P733" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P734" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N288" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L288" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P735" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P736" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P737" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N289" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L289" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P738" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P739" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P740" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N290" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L290" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P741" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.358 //@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P742" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P743" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N291" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L291" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P744" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.366" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P745" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N292" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L292" height="15.0" width="150.0" text="reserveFeedPaperVelocity"/>
+    <ports identifier="P746" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N293" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L293" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P747" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P748" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P749" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N294" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L294" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P750" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P751" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P752" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P753" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P754" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N295" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L295" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+    <ports identifier="P755" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P756" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N296" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L296" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+    <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P758" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.291/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.7/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.7/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.12/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.21/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.2" targets="//@children.264/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.2" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.23/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.23/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.24/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.25/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.1" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.26/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.27/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.28/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.29/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.30/@ports.1" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.31/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.31/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.31/@ports.1" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.31/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.31/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.31/@ports.1" targets="//@children.230/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.32/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.33/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.34/@ports.1" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.34/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.34/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.35/@ports.2" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.36/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.37/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.38/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.39/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.40/@ports.1" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.41/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.42/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.43/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.43/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.43/@ports.2" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.43/@ports.2" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.44/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.45/@ports.2" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.45/@ports.2" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.45/@ports.2" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.46/@ports.2" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.46/@ports.2" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.47/@ports.2" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.48/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.49/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.50/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.50/@ports.1" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.51/@ports.2" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E72" sources="//@children.52/@ports.2" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.53/@ports.2" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.53/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.54/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.55/@ports.0" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.56/@ports.2" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.57/@ports.2" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.58/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.58/@ports.2" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.58/@ports.2" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.58/@ports.2" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.58/@ports.2" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.58/@ports.2" targets="//@children.249/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.59/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.60/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E87" sources="//@children.60/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.60/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E89" sources="//@children.60/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.61/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.61/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E92" sources="//@children.62/@ports.0" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E93" sources="//@children.62/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.65/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.66/@ports.0" targets="//@children.65/@ports.2"/>
+  <containedEdges identifier="E96" sources="//@children.67/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.68/@ports.2" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.68/@ports.2" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.69/@ports.1" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.72/@ports.0" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E101" sources="//@children.72/@ports.1" targets="//@children.261/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.74/@ports.0" targets="//@children.73/@ports.2"/>
+  <containedEdges identifier="E103" sources="//@children.76/@ports.0" targets="//@children.75/@ports.2"/>
+  <containedEdges identifier="E104" sources="//@children.77/@ports.2" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.79/@ports.1" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.80/@ports.2" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.80/@ports.2" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.80/@ports.2" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E109" sources="//@children.80/@ports.2" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.80/@ports.2" targets="//@children.251/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.81/@ports.2" targets="//@children.80/@ports.1"/>
+  <containedEdges identifier="E112" sources="//@children.81/@ports.2" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.82/@ports.2" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E114" sources="//@children.83/@ports.1" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.84/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.85/@ports.1" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.86/@ports.2" targets="//@children.82/@ports.1"/>
+  <containedEdges identifier="E118" sources="//@children.87/@ports.2" targets="//@children.82/@ports.1"/>
+  <containedEdges identifier="E119" sources="//@children.88/@ports.2" targets="//@children.90/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.88/@ports.2" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.89/@ports.0" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.90/@ports.0" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.91/@ports.2" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.92/@ports.2" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.93/@ports.2" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.93/@ports.2" targets="//@children.279/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.93/@ports.2" targets="//@children.292/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.94/@ports.2" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.95/@ports.1" targets="//@children.94/@ports.1"/>
+  <containedEdges identifier="E130" sources="//@children.95/@ports.1" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E131" sources="//@children.96/@ports.0" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.97/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.98/@ports.1" targets="//@children.102/@ports.1"/>
+  <containedEdges identifier="E134" sources="//@children.98/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E135" sources="//@children.98/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.99/@ports.0" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E137" sources="//@children.100/@ports.2" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.101/@ports.0" targets="//@children.106/@ports.2"/>
+  <containedEdges identifier="E139" sources="//@children.102/@ports.0" targets="//@children.103/@ports.1"/>
+  <containedEdges identifier="E140" sources="//@children.102/@ports.0" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.103/@ports.2" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.104/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.105/@ports.1" targets="//@children.107/@ports.2"/>
+  <containedEdges identifier="E144" sources="//@children.106/@ports.1" targets="//@children.100/@ports.1"/>
+  <containedEdges identifier="E145" sources="//@children.107/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.107/@ports.1" targets="//@children.112/@ports.1"/>
+  <containedEdges identifier="E147" sources="//@children.107/@ports.1" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E148" sources="//@children.107/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E149" sources="//@children.107/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.108/@ports.1" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.109/@ports.2" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.110/@ports.1" targets="//@children.111/@ports.1"/>
+  <containedEdges identifier="E153" sources="//@children.110/@ports.1" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.110/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E155" sources="//@children.111/@ports.2" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E156" sources="//@children.112/@ports.0" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.113/@ports.0" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E158" sources="//@children.114/@ports.1" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.115/@ports.1" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E160" sources="//@children.116/@ports.1" targets="//@children.118/@ports.1"/>
+  <containedEdges identifier="E161" sources="//@children.117/@ports.1" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.118/@ports.2" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.119/@ports.2" targets="//@children.86/@ports.1"/>
+  <containedEdges identifier="E164" sources="//@children.119/@ports.2" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E165" sources="//@children.119/@ports.2" targets="//@children.89/@ports.1"/>
+  <containedEdges identifier="E166" sources="//@children.119/@ports.2" targets="//@children.92/@ports.1"/>
+  <containedEdges identifier="E167" sources="//@children.120/@ports.1" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E168" sources="//@children.121/@ports.0" targets="//@children.121/@ports.1"/>
+  <containedEdges identifier="E169" sources="//@children.122/@ports.0" targets="//@children.122/@ports.1"/>
+  <containedEdges identifier="E170" sources="//@children.122/@ports.1" targets="//@children.276/@ports.0"/>
+  <containedEdges identifier="E171" sources="//@children.124/@ports.0" targets="//@children.123/@ports.2"/>
+  <containedEdges identifier="E172" sources="//@children.126/@ports.0" targets="//@children.125/@ports.2"/>
+  <containedEdges identifier="E173" sources="//@children.127/@ports.2" targets="//@children.130/@ports.1"/>
+  <containedEdges identifier="E174" sources="//@children.127/@ports.2" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E175" sources="//@children.129/@ports.1" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E176" sources="//@children.130/@ports.0" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E177" sources="//@children.131/@ports.1" targets="//@children.132/@ports.2"/>
+  <containedEdges identifier="E178" sources="//@children.132/@ports.1" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E179" sources="//@children.133/@ports.0" targets="//@children.133/@ports.1"/>
+  <containedEdges identifier="E180" sources="//@children.134/@ports.0" targets="//@children.134/@ports.1"/>
+  <containedEdges identifier="E181" sources="//@children.134/@ports.1" targets="//@children.275/@ports.0"/>
+  <containedEdges identifier="E182" sources="//@children.134/@ports.1" targets="//@children.290/@ports.0"/>
+  <containedEdges identifier="E183" sources="//@children.135/@ports.0" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E184" sources="//@children.136/@ports.0" targets="//@children.153/@ports.0"/>
+  <containedEdges identifier="E185" sources="//@children.136/@ports.0" targets="//@children.159/@ports.2"/>
+  <containedEdges identifier="E186" sources="//@children.137/@ports.1" targets="//@children.138/@ports.0"/>
+  <containedEdges identifier="E187" sources="//@children.137/@ports.1" targets="//@children.139/@ports.1"/>
+  <containedEdges identifier="E188" sources="//@children.138/@ports.1" targets="//@children.140/@ports.1"/>
+  <containedEdges identifier="E189" sources="//@children.139/@ports.0" targets="//@children.140/@ports.0"/>
+  <containedEdges identifier="E190" sources="//@children.140/@ports.2" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E191" sources="//@children.141/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.142/@ports.1" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E193" sources="//@children.142/@ports.1" targets="//@children.144/@ports.1"/>
+  <containedEdges identifier="E194" sources="//@children.143/@ports.1" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E195" sources="//@children.144/@ports.0" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E196" sources="//@children.145/@ports.2" targets="//@children.146/@ports.0"/>
+  <containedEdges identifier="E197" sources="//@children.146/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E198" sources="//@children.147/@ports.1" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E199" sources="//@children.148/@ports.2" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E200" sources="//@children.148/@ports.3" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E201" sources="//@children.149/@ports.1" targets="//@children.148/@ports.1"/>
+  <containedEdges identifier="E202" sources="//@children.150/@ports.2" targets="//@children.136/@ports.1"/>
+  <containedEdges identifier="E203" sources="//@children.150/@ports.3" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E204" sources="//@children.151/@ports.1" targets="//@children.150/@ports.1"/>
+  <containedEdges identifier="E205" sources="//@children.153/@ports.2" targets="//@children.148/@ports.0"/>
+  <containedEdges identifier="E206" sources="//@children.154/@ports.2" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E207" sources="//@children.154/@ports.3" targets="//@children.156/@ports.1"/>
+  <containedEdges identifier="E208" sources="//@children.155/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E209" sources="//@children.156/@ports.0" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E210" sources="//@children.157/@ports.1" targets="//@children.154/@ports.1"/>
+  <containedEdges identifier="E211" sources="//@children.158/@ports.0" targets="//@children.159/@ports.0"/>
+  <containedEdges identifier="E212" sources="//@children.159/@ports.1" targets="//@children.153/@ports.1"/>
+  <containedEdges identifier="E213" sources="//@children.160/@ports.1" targets="//@children.162/@ports.0"/>
+  <containedEdges identifier="E214" sources="//@children.161/@ports.1" targets="//@children.163/@ports.0"/>
+  <containedEdges identifier="E215" sources="//@children.162/@ports.1" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E216" sources="//@children.162/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E217" sources="//@children.163/@ports.1" targets="//@children.149/@ports.0"/>
+  <containedEdges identifier="E218" sources="//@children.164/@ports.0" targets="//@children.164/@ports.1"/>
+  <containedEdges identifier="E219" sources="//@children.164/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E220" sources="//@children.164/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E221" sources="//@children.164/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E222" sources="//@children.165/@ports.0" targets="//@children.180/@ports.0"/>
+  <containedEdges identifier="E223" sources="//@children.166/@ports.0" targets="//@children.183/@ports.0"/>
+  <containedEdges identifier="E224" sources="//@children.166/@ports.0" targets="//@children.189/@ports.2"/>
+  <containedEdges identifier="E225" sources="//@children.167/@ports.1" targets="//@children.168/@ports.0"/>
+  <containedEdges identifier="E226" sources="//@children.167/@ports.1" targets="//@children.169/@ports.1"/>
+  <containedEdges identifier="E227" sources="//@children.168/@ports.1" targets="//@children.170/@ports.1"/>
+  <containedEdges identifier="E228" sources="//@children.169/@ports.0" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E229" sources="//@children.170/@ports.2" targets="//@children.171/@ports.0"/>
+  <containedEdges identifier="E230" sources="//@children.171/@ports.1" targets="//@children.182/@ports.0"/>
+  <containedEdges identifier="E231" sources="//@children.172/@ports.1" targets="//@children.173/@ports.0"/>
+  <containedEdges identifier="E232" sources="//@children.172/@ports.1" targets="//@children.174/@ports.1"/>
+  <containedEdges identifier="E233" sources="//@children.173/@ports.1" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E234" sources="//@children.174/@ports.0" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E235" sources="//@children.175/@ports.2" targets="//@children.176/@ports.0"/>
+  <containedEdges identifier="E236" sources="//@children.176/@ports.1" targets="//@children.182/@ports.0"/>
+  <containedEdges identifier="E237" sources="//@children.177/@ports.1" targets="//@children.185/@ports.0"/>
+  <containedEdges identifier="E238" sources="//@children.178/@ports.2" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E239" sources="//@children.178/@ports.3" targets="//@children.172/@ports.0"/>
+  <containedEdges identifier="E240" sources="//@children.179/@ports.1" targets="//@children.178/@ports.1"/>
+  <containedEdges identifier="E241" sources="//@children.180/@ports.2" targets="//@children.166/@ports.1"/>
+  <containedEdges identifier="E242" sources="//@children.180/@ports.3" targets="//@children.184/@ports.0"/>
+  <containedEdges identifier="E243" sources="//@children.181/@ports.1" targets="//@children.180/@ports.1"/>
+  <containedEdges identifier="E244" sources="//@children.183/@ports.2" targets="//@children.178/@ports.0"/>
+  <containedEdges identifier="E245" sources="//@children.184/@ports.2" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E246" sources="//@children.184/@ports.3" targets="//@children.186/@ports.1"/>
+  <containedEdges identifier="E247" sources="//@children.185/@ports.1" targets="//@children.182/@ports.0"/>
+  <containedEdges identifier="E248" sources="//@children.186/@ports.0" targets="//@children.185/@ports.0"/>
+  <containedEdges identifier="E249" sources="//@children.187/@ports.1" targets="//@children.184/@ports.1"/>
+  <containedEdges identifier="E250" sources="//@children.188/@ports.0" targets="//@children.189/@ports.0"/>
+  <containedEdges identifier="E251" sources="//@children.189/@ports.1" targets="//@children.183/@ports.1"/>
+  <containedEdges identifier="E252" sources="//@children.190/@ports.1" targets="//@children.192/@ports.0"/>
+  <containedEdges identifier="E253" sources="//@children.191/@ports.1" targets="//@children.193/@ports.0"/>
+  <containedEdges identifier="E254" sources="//@children.192/@ports.1" targets="//@children.181/@ports.0"/>
+  <containedEdges identifier="E255" sources="//@children.192/@ports.1" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E256" sources="//@children.193/@ports.1" targets="//@children.179/@ports.0"/>
+  <containedEdges identifier="E257" sources="//@children.194/@ports.0" targets="//@children.194/@ports.1"/>
+  <containedEdges identifier="E258" sources="//@children.195/@ports.0" targets="//@children.195/@ports.1"/>
+  <containedEdges identifier="E259" sources="//@children.195/@ports.1" targets="//@children.260/@ports.0"/>
+  <containedEdges identifier="E260" sources="//@children.196/@ports.0" targets="//@children.211/@ports.0"/>
+  <containedEdges identifier="E261" sources="//@children.197/@ports.0" targets="//@children.214/@ports.0"/>
+  <containedEdges identifier="E262" sources="//@children.197/@ports.0" targets="//@children.220/@ports.2"/>
+  <containedEdges identifier="E263" sources="//@children.198/@ports.1" targets="//@children.199/@ports.0"/>
+  <containedEdges identifier="E264" sources="//@children.198/@ports.1" targets="//@children.200/@ports.1"/>
+  <containedEdges identifier="E265" sources="//@children.199/@ports.1" targets="//@children.201/@ports.1"/>
+  <containedEdges identifier="E266" sources="//@children.200/@ports.0" targets="//@children.201/@ports.0"/>
+  <containedEdges identifier="E267" sources="//@children.201/@ports.2" targets="//@children.202/@ports.0"/>
+  <containedEdges identifier="E268" sources="//@children.202/@ports.1" targets="//@children.213/@ports.0"/>
+  <containedEdges identifier="E269" sources="//@children.203/@ports.1" targets="//@children.204/@ports.0"/>
+  <containedEdges identifier="E270" sources="//@children.203/@ports.1" targets="//@children.205/@ports.1"/>
+  <containedEdges identifier="E271" sources="//@children.204/@ports.1" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E272" sources="//@children.205/@ports.0" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E273" sources="//@children.206/@ports.2" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E274" sources="//@children.207/@ports.1" targets="//@children.213/@ports.0"/>
+  <containedEdges identifier="E275" sources="//@children.208/@ports.1" targets="//@children.216/@ports.0"/>
+  <containedEdges identifier="E276" sources="//@children.209/@ports.2" targets="//@children.198/@ports.0"/>
+  <containedEdges identifier="E277" sources="//@children.209/@ports.3" targets="//@children.203/@ports.0"/>
+  <containedEdges identifier="E278" sources="//@children.210/@ports.1" targets="//@children.209/@ports.1"/>
+  <containedEdges identifier="E279" sources="//@children.211/@ports.2" targets="//@children.197/@ports.1"/>
+  <containedEdges identifier="E280" sources="//@children.211/@ports.3" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E281" sources="//@children.212/@ports.1" targets="//@children.211/@ports.1"/>
+  <containedEdges identifier="E282" sources="//@children.214/@ports.2" targets="//@children.209/@ports.0"/>
+  <containedEdges identifier="E283" sources="//@children.215/@ports.2" targets="//@children.208/@ports.0"/>
+  <containedEdges identifier="E284" sources="//@children.215/@ports.3" targets="//@children.217/@ports.1"/>
+  <containedEdges identifier="E285" sources="//@children.216/@ports.1" targets="//@children.226/@ports.1"/>
+  <containedEdges identifier="E286" sources="//@children.216/@ports.1" targets="//@children.227/@ports.0"/>
+  <containedEdges identifier="E287" sources="//@children.217/@ports.0" targets="//@children.216/@ports.0"/>
+  <containedEdges identifier="E288" sources="//@children.218/@ports.1" targets="//@children.215/@ports.1"/>
+  <containedEdges identifier="E289" sources="//@children.219/@ports.0" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E290" sources="//@children.220/@ports.1" targets="//@children.214/@ports.1"/>
+  <containedEdges identifier="E291" sources="//@children.221/@ports.1" targets="//@children.223/@ports.0"/>
+  <containedEdges identifier="E292" sources="//@children.222/@ports.1" targets="//@children.224/@ports.0"/>
+  <containedEdges identifier="E293" sources="//@children.223/@ports.1" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E294" sources="//@children.223/@ports.1" targets="//@children.218/@ports.0"/>
+  <containedEdges identifier="E295" sources="//@children.224/@ports.1" targets="//@children.210/@ports.0"/>
+  <containedEdges identifier="E296" sources="//@children.225/@ports.0" targets="//@children.227/@ports.2"/>
+  <containedEdges identifier="E297" sources="//@children.226/@ports.0" targets="//@children.227/@ports.0"/>
+  <containedEdges identifier="E298" sources="//@children.227/@ports.1" targets="//@children.213/@ports.0"/>
+  <containedEdges identifier="E299" sources="//@children.228/@ports.0" targets="//@children.228/@ports.1"/>
+  <containedEdges identifier="E300" sources="//@children.228/@ports.1" targets="//@children.245/@ports.0"/>
+  <containedEdges identifier="E301" sources="//@children.229/@ports.0" targets="//@children.229/@ports.1"/>
+  <containedEdges identifier="E302" sources="//@children.229/@ports.1" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E303" sources="//@children.229/@ports.1" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E304" sources="//@children.231/@ports.0" targets="//@children.230/@ports.2"/>
+  <containedEdges identifier="E305" sources="//@children.232/@ports.2" targets="//@children.233/@ports.1"/>
+  <containedEdges identifier="E306" sources="//@children.232/@ports.2" targets="//@children.237/@ports.1"/>
+  <containedEdges identifier="E307" sources="//@children.232/@ports.2" targets="//@children.238/@ports.0"/>
+  <containedEdges identifier="E308" sources="//@children.232/@ports.2" targets="//@children.240/@ports.0"/>
+  <containedEdges identifier="E309" sources="//@children.233/@ports.0" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E310" sources="//@children.234/@ports.0" targets="//@children.232/@ports.1"/>
+  <containedEdges identifier="E311" sources="//@children.235/@ports.1" targets="//@children.236/@ports.1"/>
+  <containedEdges identifier="E312" sources="//@children.236/@ports.2" targets="//@children.241/@ports.0"/>
+  <containedEdges identifier="E313" sources="//@children.237/@ports.0" targets="//@children.239/@ports.0"/>
+  <containedEdges identifier="E314" sources="//@children.238/@ports.1" targets="//@children.239/@ports.1"/>
+  <containedEdges identifier="E315" sources="//@children.239/@ports.2" targets="//@children.243/@ports.0"/>
+  <containedEdges identifier="E316" sources="//@children.240/@ports.1" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E317" sources="//@children.241/@ports.1" targets="//@children.242/@ports.0"/>
+  <containedEdges identifier="E318" sources="//@children.243/@ports.1" targets="//@children.244/@ports.0"/>
+  <containedEdges identifier="E319" sources="//@children.245/@ports.0" targets="//@children.245/@ports.1"/>
+  <containedEdges identifier="E320" sources="//@children.246/@ports.0" targets="//@children.246/@ports.1"/>
+  <containedEdges identifier="E321" sources="//@children.246/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E322" sources="//@children.246/@ports.1" targets="//@children.194/@ports.0"/>
+  <containedEdges identifier="E323" sources="//@children.246/@ports.1" targets="//@children.263/@ports.0"/>
+  <containedEdges identifier="E324" sources="//@children.246/@ports.1" targets="//@children.277/@ports.0"/>
+  <containedEdges identifier="E325" sources="//@children.247/@ports.0" targets="//@children.247/@ports.1"/>
+  <containedEdges identifier="E326" sources="//@children.248/@ports.0" targets="//@children.248/@ports.1"/>
+  <containedEdges identifier="E327" sources="//@children.248/@ports.1" targets="//@children.101/@ports.1"/>
+  <containedEdges identifier="E328" sources="//@children.250/@ports.0" targets="//@children.249/@ports.2"/>
+  <containedEdges identifier="E329" sources="//@children.252/@ports.0" targets="//@children.251/@ports.2"/>
+  <containedEdges identifier="E330" sources="//@children.253/@ports.0" targets="//@children.254/@ports.0"/>
+  <containedEdges identifier="E331" sources="//@children.253/@ports.0" targets="//@children.256/@ports.1"/>
+  <containedEdges identifier="E332" sources="//@children.254/@ports.1" targets="//@children.253/@ports.4"/>
+  <containedEdges identifier="E333" sources="//@children.254/@ports.1" targets="//@children.255/@ports.0"/>
+  <containedEdges identifier="E334" sources="//@children.254/@ports.1" targets="//@children.257/@ports.1"/>
+  <containedEdges identifier="E335" sources="//@children.255/@ports.1" targets="//@children.258/@ports.1"/>
+  <containedEdges identifier="E336" sources="//@children.257/@ports.0" targets="//@children.259/@ports.0"/>
+  <containedEdges identifier="E337" sources="//@children.260/@ports.0" targets="//@children.260/@ports.1"/>
+  <containedEdges identifier="E338" sources="//@children.261/@ports.0" targets="//@children.261/@ports.1"/>
+  <containedEdges identifier="E339" sources="//@children.262/@ports.0" targets="//@children.262/@ports.1"/>
+  <containedEdges identifier="E340" sources="//@children.262/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E341" sources="//@children.263/@ports.0" targets="//@children.263/@ports.1"/>
+  <containedEdges identifier="E342" sources="//@children.265/@ports.0" targets="//@children.264/@ports.2"/>
+  <containedEdges identifier="E343" sources="//@children.266/@ports.1" targets="//@children.271/@ports.1"/>
+  <containedEdges identifier="E344" sources="//@children.266/@ports.1" targets="//@children.274/@ports.0"/>
+  <containedEdges identifier="E345" sources="//@children.268/@ports.1" targets="//@children.270/@ports.1"/>
+  <containedEdges identifier="E346" sources="//@children.268/@ports.1" targets="//@children.273/@ports.0"/>
+  <containedEdges identifier="E347" sources="//@children.269/@ports.1" targets="//@children.270/@ports.0"/>
+  <containedEdges identifier="E348" sources="//@children.270/@ports.2" targets="//@children.266/@ports.0"/>
+  <containedEdges identifier="E349" sources="//@children.271/@ports.0" targets="//@children.274/@ports.0"/>
+  <containedEdges identifier="E350" sources="//@children.272/@ports.0" targets="//@children.274/@ports.2"/>
+  <containedEdges identifier="E351" sources="//@children.274/@ports.1" targets="//@children.267/@ports.0"/>
+  <containedEdges identifier="E352" sources="//@children.275/@ports.0" targets="//@children.275/@ports.1"/>
+  <containedEdges identifier="E353" sources="//@children.276/@ports.0" targets="//@children.276/@ports.1"/>
+  <containedEdges identifier="E354" sources="//@children.277/@ports.0" targets="//@children.277/@ports.1"/>
+  <containedEdges identifier="E355" sources="//@children.278/@ports.0" targets="//@children.278/@ports.1"/>
+  <containedEdges identifier="E356" sources="//@children.278/@ports.1" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E357" sources="//@children.280/@ports.0" targets="//@children.279/@ports.2"/>
+  <containedEdges identifier="E358" sources="//@children.281/@ports.1" targets="//@children.285/@ports.1"/>
+  <containedEdges identifier="E359" sources="//@children.281/@ports.1" targets="//@children.289/@ports.0"/>
+  <containedEdges identifier="E360" sources="//@children.282/@ports.1" targets="//@children.284/@ports.1"/>
+  <containedEdges identifier="E361" sources="//@children.282/@ports.1" targets="//@children.287/@ports.0"/>
+  <containedEdges identifier="E362" sources="//@children.283/@ports.1" targets="//@children.284/@ports.0"/>
+  <containedEdges identifier="E363" sources="//@children.284/@ports.2" targets="//@children.281/@ports.0"/>
+  <containedEdges identifier="E364" sources="//@children.285/@ports.0" targets="//@children.289/@ports.0"/>
+  <containedEdges identifier="E365" sources="//@children.286/@ports.0" targets="//@children.289/@ports.2"/>
+  <containedEdges identifier="E366" sources="//@children.289/@ports.1" targets="//@children.288/@ports.0"/>
+  <containedEdges identifier="E367" sources="//@children.290/@ports.0" targets="//@children.290/@ports.1"/>
+  <containedEdges identifier="E368" sources="//@children.292/@ports.1" targets="//@children.291/@ports.0"/>
+  <containedEdges identifier="E369" sources="//@children.293/@ports.0" targets="//@children.292/@ports.2"/>
+  <containedEdges identifier="E370" sources="//@children.294/@ports.0" targets="//@children.294/@ports.1"/>
+  <containedEdges identifier="E371" sources="//@children.295/@ports.0" targets="//@children.295/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_ramprollback_RampRollback.elkg
+++ b/realworld/ptolemy/flattened/de_ramprollback_RampRollback.elkg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.12 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_router_Router.elkg
+++ b/realworld/ptolemy/flattened/de_router_Router.elkg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="107.0" text="Record Assembler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="Sequence Count"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="36.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Square"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="Master Clock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="97.0" text="String Sequence"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="Record Disassembler"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="63.0" text="Sequencer"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="119.0" text="Display As Received"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="127.0" text="Display Resequenced"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="82.0" text="ChannelModel"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_simpletrafficlight_SimpleTrafficLightDECTA.elkg
+++ b/realworld/ptolemy/flattened/de_simpletrafficlight_SimpleTrafficLightDECTA.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="89.0" text="CarLightNormal"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="0.1666666716337204" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="32.83333206176758" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="131.0" text="PedestrianLightNormal"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.1/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_tcppackettxrx_TCPPacketTXRX.elkg
+++ b/realworld/ptolemy/flattened/de_tcppackettxrx_TCPPacketTXRX.elkg
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="116.0" text="TCPPacketReceiver"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="123.0" text="TCPPacketReceiver2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_timingparadox_TimingParadox.elkg
+++ b/realworld/ptolemy/flattened/de_timingparadox_TimingParadox.elkg
@@ -1,0 +1,553 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Clock2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19 //@containedEdges.24 //@containedEdges.29 //@containedEdges.34 //@containedEdges.39 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Rician"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="44.0" text="Rician2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.7/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.7/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.7/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.7/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.9/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.10/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.11/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.12/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.13/@ports.0" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.14/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.15/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.16/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.17/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E33" sources="//@children.18/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.19/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.20/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.21/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.21/@ports.0" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E38" sources="//@children.22/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.23/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.24/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.25/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.25/@ports.0" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E43" sources="//@children.26/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.27/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.28/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.29/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.29/@ports.0" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.30/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.31/@ports.1" targets="//@children.28/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/de_trilateration_Trilateration.elkg
+++ b/realworld/ptolemy/flattened/de_trilateration_Trilateration.elkg
@@ -1,0 +1,7476 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.6 //@containedEdges.7 //@containedEdges.10 //@containedEdges.11 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.8 //@containedEdges.9 //@containedEdges.12 //@containedEdges.13 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.73 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.45 //@containedEdges.46 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.43 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.55 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.60 //@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.58 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.70 //@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="103.0" y="8.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.75 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="121.0" text="UnaryMathFunction8"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.84 //@containedEdges.85 //@containedEdges.86 //@containedEdges.87 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="121.0" text="UnaryMathFunction9"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.89 //@containedEdges.90 //@containedEdges.91 //@containedEdges.92 //@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="127.0" text="UnaryMathFunction11"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="128.0" text="UnaryMathFunction12"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.96 //@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="86.0" text="AddSubtract11"/>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.97 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.100 //@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="87.0" text="AddSubtract12"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.102 //@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="87.0" text="AddSubtract13"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.104 //@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.106 //@containedEdges.107 //@containedEdges.108 //@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.110 //@containedEdges.111 //@containedEdges.112 //@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="49.0" text="Const14"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="49.0" text="Const15"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="128.0" text="UnaryMathFunction13"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="128.0" text="UnaryMathFunction14"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.102 //@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.104 //@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="87.0" text="AddSubtract14"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.118 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.120 //@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="128.0" text="UnaryMathFunction15"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="128.0" text="UnaryMathFunction16"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="87.0" text="MultiplyDivide6"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="87.0" text="AddSubtract15"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.126 //@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="128.0" text="UnaryMathFunction17"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="87.0" text="MultiplyDivide7"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.128 //@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="87.0" text="AddSubtract16"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="128.0" text="UnaryMathFunction18"/>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="87.0" text="AddSubtract17"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="87.0" text="MultiplyDivide8"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.135 //@containedEdges.136 //@containedEdges.137 //@containedEdges.138 //@containedEdges.139 //@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="41.0" text="Scale6"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="87.0" text="AddSubtract19"/>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="128.0" text="UnaryMathFunction19"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.145 //@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="128.0" text="UnaryMathFunction20"/>
+    <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="87.0" text="AddSubtract20"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.88 //@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="87.0" text="AddSubtract21"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="128.0" text="UnaryMathFunction21"/>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P234" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="87.0" text="AddSubtract22"/>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.93 //@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="41.0" text="Scale7"/>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="41.0" text="Scale8"/>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P242" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P244" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="87.0" text="MultiplyDivide9"/>
+    <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.156 //@containedEdges.157 //@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="94.0" text="MultiplyDivide10"/>
+    <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.159 //@containedEdges.160 //@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P252" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.162 //@containedEdges.163 //@containedEdges.164 //@containedEdges.165 //@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.450">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.167 //@containedEdges.168 //@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.514">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.574">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.451 //@containedEdges.515 //@containedEdges.575">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.173 //@containedEdges.174 //@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="93.0" text="MultiplyDivide11"/>
+    <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P273" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="94.0" text="MultiplyDivide13"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.178 //@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P278" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="94.0" text="MultiplyDivide14"/>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.180 //@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.182 //@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.184 //@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="78.0" text="MostRecent4"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.176 //@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.187 //@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P297" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.191 //@containedEdges.192 //@containedEdges.193 //@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P305" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P309" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P311" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P312" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P314" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P316" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.198 //@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P319" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.201 //@containedEdges.202 //@containedEdges.203 //@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="41.0" width="320.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P325" height="8.0" width="8.0" x="320.0" y="16.5" outgoingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="40.0" width="403.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P327" height="8.0" width="8.0" x="403.0" y="16.0" outgoingEdges="//@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.262">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="111.0" text="RecordAssembler3"/>
+    <ports identifier="P332" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="111.0" text="RecordAssembler4"/>
+    <ports identifier="P335" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="111.0" text="RecordAssembler5"/>
+    <ports identifier="P338" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="67.0" text="XYPlotPath"/>
+    <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.212 //@containedEdges.213 //@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.214 //@containedEdges.215 //@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P345" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P347" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P348" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="128.0" text="RecordDisassembler3"/>
+    <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P350" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P351" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="25.0" width="134.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P352" height="8.0" width="8.0" x="134.0" y="8.5" outgoingEdges="//@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="40.0" width="431.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="76.0" text="StringConst6"/>
+    <ports identifier="P354" height="8.0" width="8.0" x="431.0" y="16.0" outgoingEdges="//@containedEdges.219">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="78.0" text="MostRecent4"/>
+    <ports identifier="P356" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.606">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P357" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P358" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="128.0" text="RecordDisassembler4"/>
+    <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P360" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P361" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="59.0" text="ErrorStats"/>
+    <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.205 //@containedEdges.206 //@containedEdges.207 //@containedEdges.208 //@containedEdges.218 //@containedEdges.219 //@containedEdges.221 //@containedEdges.222 //@containedEdges.224 //@containedEdges.225 //@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="78.0" text="MostRecent5"/>
+    <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.390">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P364" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P365" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="128.0" text="RecordDisassembler5"/>
+    <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P367" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P368" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P369" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P370" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P372" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P373" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.228 //@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P374" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="81.0" text="Accumulator2"/>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P377" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P378" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P380" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.231 //@containedEdges.232 //@containedEdges.233 //@containedEdges.234 //@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P382" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P383" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P384" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P385" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.237 //@containedEdges.238 //@containedEdges.239 //@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P386" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.229 //@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P388" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P389" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P390" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P392" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.243 //@containedEdges.244 //@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P394" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="81.0" text="Accumulator3"/>
+    <ports identifier="P395" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P396" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P399" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P400" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P401" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.238 //@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P403" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P404" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P406" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P408" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P411" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P412" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P413" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P415" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P416" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P418" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P420" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P421" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P424" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.258 //@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P425" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="81.0" text="Accumulator2"/>
+    <ports identifier="P426" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P427" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P430" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P431" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.261 //@containedEdges.262 //@containedEdges.263 //@containedEdges.264 //@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P433" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P434" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.273">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P436" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.267 //@containedEdges.268 //@containedEdges.269 //@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P437" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P438" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.259 //@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P439" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P440" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P442" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P443" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.273 //@containedEdges.274 //@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P444" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P445" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N176" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L176" height="15.0" width="81.0" text="Accumulator3"/>
+    <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P447" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P448" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N177" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P450" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P451" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.268 //@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P453" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P454" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P457" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P459" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N181" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L181" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P461" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P462" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N182" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L182" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P463" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N183" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L183" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P465" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P467" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N184" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L184" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P469" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N185" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L185" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P471" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N186" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L186" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P472" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.287 //@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P473" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P475" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P476" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N187" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L187" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P478" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N188" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L188" height="15.0" width="66.0" text="Sequence2"/>
+    <ports identifier="P479" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P480" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N189" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L189" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.287 //@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P482" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.291 //@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N190" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L190" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P483" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P484" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N191" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L191" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P485" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.294 //@containedEdges.295 //@containedEdges.296 //@containedEdges.297 //@containedEdges.298 //@containedEdges.299 //@containedEdges.300 //@containedEdges.301 //@containedEdges.302 //@containedEdges.303 //@containedEdges.304 //@containedEdges.305 //@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N192" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L192" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P486" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.307 //@containedEdges.308 //@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P487" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N193" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L193" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.307">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P489" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N194" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L194" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P490" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P491" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N195" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P492" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P493" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N196" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L196" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P494" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N197" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L197" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P496" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.312 //@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P497" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.295">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N198" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L198" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P498" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P499" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.314 //@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N199" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L199" height="15.0" width="61.0" text="TrueGate2"/>
+    <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P501" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.316 //@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N200" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L200" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P502" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P503" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N201" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L201" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P504" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.310 //@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P505" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N202" height="25.0" width="90.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L202" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P506" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@containedEdges.320 //@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P507" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N203" height="25.0" width="74.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L203" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P508" height="8.0" width="8.0" x="74.0" y="8.5" outgoingEdges="//@containedEdges.322 //@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N204" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L204" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P510" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P511" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N205" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L205" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P512" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P513" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N206" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L206" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P514" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.329">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N207" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L207" height="15.0" width="61.0" text="TrueGate3"/>
+    <ports identifier="P516" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.320">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P517" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.327 //@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N208" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L208" height="15.0" width="61.0" text="TrueGate4"/>
+    <ports identifier="P518" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P519" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.329 //@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N209" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L209" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P520" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P521" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N210" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L210" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.325 //@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P523" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N211" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L211" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P524" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P525" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N212" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L212" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P526" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.322 //@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P527" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N213" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L213" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P528" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P529" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.334 //@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N214" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L214" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P531" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P532" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N215" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L215" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P533" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P534" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N216" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L216" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P535" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P536" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N217" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L217" height="15.0" width="61.0" text="TrueGate5"/>
+    <ports identifier="P537" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P538" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N218" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L218" height="15.0" width="93.0" text="ThrowException"/>
+    <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N219" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L219" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P540" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N220" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L220" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P541" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N221" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L221" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P542" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P544" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N222" height="25.0" width="108.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L222" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P545" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.301">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N223" height="25.0" width="153.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L223" height="15.0" width="49.0" text="Const13"/>
+    <ports identifier="P547" height="8.0" width="8.0" x="153.0" y="8.5" outgoingEdges="//@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P548" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N224" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L224" height="15.0" width="61.0" text="TrueGate6"/>
+    <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P550" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N225" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L225" height="15.0" width="100.0" text="ThrowException2"/>
+    <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N226" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L226" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.335 //@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P553" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N227" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L227" height="15.0" width="69.0" text="LogicalNot4"/>
+    <ports identifier="P554" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P555" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N228" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L228" height="15.0" width="49.0" text="Const14"/>
+    <ports identifier="P556" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N229" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L229" height="15.0" width="49.0" text="Const15"/>
+    <ports identifier="P558" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P559" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N230" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L230" height="15.0" width="49.0" text="Const16"/>
+    <ports identifier="P560" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N231" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L231" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P562" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.350">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P563" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N232" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L232" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P564" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P565" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N233" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L233" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.358">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P567" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N234" height="25.0" width="113.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L234" height="15.0" width="49.0" text="Const17"/>
+    <ports identifier="P568" height="8.0" width="8.0" x="113.0" y="8.5" outgoingEdges="//@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N235" height="25.0" width="208.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L235" height="15.0" width="49.0" text="Const18"/>
+    <ports identifier="P570" height="8.0" width="8.0" x="208.0" y="8.5" outgoingEdges="//@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P571" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N236" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L236" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P572" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.353">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N237" height="25.0" width="94.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L237" height="15.0" width="49.0" text="Const19"/>
+    <ports identifier="P574" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N238" height="25.0" width="196.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L238" height="15.0" width="49.0" text="Const20"/>
+    <ports identifier="P576" height="8.0" width="8.0" x="196.0" y="8.5" outgoingEdges="//@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N239" height="25.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L239" height="15.0" width="76.0" text="StringConst3"/>
+    <ports identifier="P578" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P579" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N240" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L240" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.349 //@containedEdges.352 //@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P581" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N241" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L241" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P582" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.348 //@containedEdges.351 //@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P583" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.358">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N242" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L242" height="15.0" width="44.0" text="Merge5"/>
+    <ports identifier="P584" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.350 //@containedEdges.353 //@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P585" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N243" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L243" height="15.0" width="61.0" text="TrueGate7"/>
+    <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P587" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.360 //@containedEdges.361 //@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N244" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L244" height="15.0" width="61.0" text="TrueGate8"/>
+    <ports identifier="P588" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P589" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.363 //@containedEdges.364 //@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N245" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L245" height="15.0" width="61.0" text="TrueGate9"/>
+    <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P591" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.366 //@containedEdges.367 //@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N246" height="25.0" width="245.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L246" height="15.0" width="76.0" text="StringConst4"/>
+    <ports identifier="P592" height="8.0" width="8.0" x="245.0" y="8.5" outgoingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N247" height="25.0" width="194.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L247" height="15.0" width="76.0" text="StringConst5"/>
+    <ports identifier="P594" height="8.0" width="8.0" x="194.0" y="8.5" outgoingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P595" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N248" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L248" height="15.0" width="44.0" text="Merge6"/>
+    <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.369 //@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P597" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.371 //@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N249" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L249" height="15.0" width="76.0" text="StringConst6"/>
+    <ports identifier="P598" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.373">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N250" height="25.0" width="102.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L250" height="15.0" width="76.0" text="StringConst7"/>
+    <ports identifier="P600" height="8.0" width="8.0" x="102.0" y="8.5" outgoingEdges="//@containedEdges.374">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N251" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L251" height="15.0" width="44.0" text="Merge7"/>
+    <ports identifier="P602" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.373 //@containedEdges.374">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P603" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N252" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L252" height="15.0" width="68.0" text="TrueGate10"/>
+    <ports identifier="P604" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P605" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N253" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L253" height="15.0" width="69.0" text="LogicalNot5"/>
+    <ports identifier="P606" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P607" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.377">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N254" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L254" height="15.0" width="67.0" text="TrueGate11"/>
+    <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.377">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P609" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.378">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N255" height="25.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L255" height="15.0" width="76.0" text="StringConst8"/>
+    <ports identifier="P610" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@containedEdges.379">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N256" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L256" height="15.0" width="76.0" text="StringConst9"/>
+    <ports identifier="P612" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.380">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P613" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.378">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N257" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L257" height="15.0" width="44.0" text="Merge8"/>
+    <ports identifier="P614" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.379 //@containedEdges.380">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P615" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.381 //@containedEdges.382">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N258" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L258" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P616" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.383">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.384">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P618" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.385">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.386">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N259" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L259" height="15.0" width="83.0" text="StringConst10"/>
+    <ports identifier="P620" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.384">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.304">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N260" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L260" height="15.0" width="49.0" text="Const21"/>
+    <ports identifier="P622" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.385">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P623" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N261" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L261" height="15.0" width="49.0" text="Const22"/>
+    <ports identifier="P624" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.386">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P625" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N262" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L262" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P626" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.387">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.388">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P628" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P629" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.381">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N263" height="25.0" width="86.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L263" height="15.0" width="82.0" text="StringConst11"/>
+    <ports identifier="P630" height="8.0" width="8.0" x="86.0" y="8.5" outgoingEdges="//@containedEdges.388">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P631" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.382">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N264" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L264" height="15.0" width="83.0" text="StringConst12"/>
+    <ports identifier="P632" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.389">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P633" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.371">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N265" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L265" height="15.0" width="111.0" text="RecordAssembler4"/>
+    <ports identifier="P634" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.390">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.383">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P636" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.387">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P637" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.391">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N266" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L266" height="15.0" width="111.0" text="RecordAssembler3"/>
+    <ports identifier="P638" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.391">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P639" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.389">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P641" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N267" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L267" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P642" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.417">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P643" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.392">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N268" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L268" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.418">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P645" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.393">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P646" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.396">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N269" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L269" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P647" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.403">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P648" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.394">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P649" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.397">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N270" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L270" height="15.0" width="63.0" text="IsPresent2"/>
+    <ports identifier="P650" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.404">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P651" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.395">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N271" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L271" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.392 //@containedEdges.395">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P653" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.396 //@containedEdges.397">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N272" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L272" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P654" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.393 //@containedEdges.394">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P655" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P656" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.398 //@containedEdges.399">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N273" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L273" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P657" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.400">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P658" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.398">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N274" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L274" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P659" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.400 //@containedEdges.416">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P660" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P661" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.401">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N275" height="25.0" width="77.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L275" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P662" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@containedEdges.402">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P663" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.443">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N276" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L276" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P664" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.402 //@containedEdges.408">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P665" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P666" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.403 //@containedEdges.404">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N277" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L277" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P667" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.405 //@containedEdges.406 //@containedEdges.407">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P670" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P671" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N278" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L278" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P672" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.409 //@containedEdges.444">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P673" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P674" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.408">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N279" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L279" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.426">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P676" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.409">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P677" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.445">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N280" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L280" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P678" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.410 //@containedEdges.411 //@containedEdges.412 //@containedEdges.413">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P679" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P680" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P681" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P682" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N281" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L281" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P683" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.422">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P684" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.415 //@containedEdges.446">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P685" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.414">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N282" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L282" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P686" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@containedEdges.415">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P687" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.421">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N283" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L283" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P688" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.401">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P689" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N284" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L284" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P690" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.399">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P691" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.416">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N285" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L285" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P692" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.414">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P693" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.417 //@containedEdges.418">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.423">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N286" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L286" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P695" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.419">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P696" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.410">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N287" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L287" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P697" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.420">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P698" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.411">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N288" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L288" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P699" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.420">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.419">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P701" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P702" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.421">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P703" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.424">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P704" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.422">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P705" height="8.0" width="8.0" x="61.0" y="31.200000762939453" outgoingEdges="//@containedEdges.423">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N289" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L289" height="15.0" width="78.0" text="ModalModel2"/>
+    <ports identifier="P706" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P707" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.412">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P708" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.425">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N290" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L290" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P709" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.425">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P710" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N291" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L291" height="15.0" width="73.0" text="LookupTable"/>
+    <ports identifier="P711" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.428">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P712" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.426">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N292" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L292" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P713" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.427">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P714" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.405">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P715" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N293" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L293" height="15.0" width="38.0" text="Round"/>
+    <ports identifier="P717" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.427">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P718" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.428">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N294" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L294" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P719" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.429">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P720" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.439">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N295" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L295" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P721" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.440">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P722" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.430">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P723" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N296" height="25.0" width="282.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L296" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P724" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@containedEdges.431">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P725" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.430">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N297" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L297" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P726" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.432">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P727" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.433">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N298" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L298" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P728" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.441">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P729" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.433">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P730" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N299" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L299" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P731" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.434">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P732" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.437">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N300" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L300" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P733" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.438">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P734" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.435">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P735" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N301" height="25.0" width="282.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L301" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P736" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@containedEdges.436">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P737" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.435">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N302" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L302" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P738" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.406">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P739" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.442">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P740" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.439 //@containedEdges.440 //@containedEdges.441">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P741" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.437 //@containedEdges.438">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N303" height="25.0" width="93.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L303" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P742" height="8.0" width="8.0" x="93.0" y="8.5" outgoingEdges="//@containedEdges.442">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P743" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.407">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N304" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L304" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P744" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.429 //@containedEdges.431 //@containedEdges.432 //@containedEdges.434 //@containedEdges.436">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P745" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.443 //@containedEdges.444 //@containedEdges.445">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N305" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L305" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P746" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.446">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P747" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.424">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N306" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L306" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P748" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.447 //@containedEdges.448">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P749" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.413">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N307" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L307" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P750" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.449">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P751" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.579">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N308" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L308" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P752" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.450 //@containedEdges.451">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P753" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N309" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L309" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P754" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.452 //@containedEdges.453">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P755" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N310" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L310" height="15.0" width="78.0" text="CurrentTime4"/>
+    <ports identifier="P756" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.454 //@containedEdges.455">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N311" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L311" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P758" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.481">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P759" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.456">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N312" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L312" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P760" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.482">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P761" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.457">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P762" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.460">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N313" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L313" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P763" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.467">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P764" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.458">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P765" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.461">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N314" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L314" height="15.0" width="63.0" text="IsPresent2"/>
+    <ports identifier="P766" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.468">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P767" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.459">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N315" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L315" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P768" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.456 //@containedEdges.459">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P769" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.460 //@containedEdges.461">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N316" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L316" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P770" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.457 //@containedEdges.458">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P771" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P772" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.462 //@containedEdges.463">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N317" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L317" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P773" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.464">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P774" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.462">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N318" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L318" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P775" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.464 //@containedEdges.480">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P776" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P777" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.465">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N319" height="25.0" width="77.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L319" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P778" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@containedEdges.466">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P779" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.507">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N320" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L320" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P780" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.466 //@containedEdges.472">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P781" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P782" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.467 //@containedEdges.468">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N321" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L321" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P783" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.469 //@containedEdges.470 //@containedEdges.471">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P784" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P785" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P786" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P787" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N322" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L322" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P788" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.473 //@containedEdges.508">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P789" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P790" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.472">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N323" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L323" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P791" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.490">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P792" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.473">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P793" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.509">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N324" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L324" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P794" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.474 //@containedEdges.475 //@containedEdges.476 //@containedEdges.477">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P795" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P796" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P797" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P798" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N325" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L325" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P799" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.486">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P800" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.479 //@containedEdges.510">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P801" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.478">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N326" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L326" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P802" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@containedEdges.479">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P803" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.485">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N327" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L327" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P804" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.465">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P805" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N328" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L328" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P806" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.463">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P807" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.480">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N329" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L329" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P808" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.478">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P809" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.481 //@containedEdges.482">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P810" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.487">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N330" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L330" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P811" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.483">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P812" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.474">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N331" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L331" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P813" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.484">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P814" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.475">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N332" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L332" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P815" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.484">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P816" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.483">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P817" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.447">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P818" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.485">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P819" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.488">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P820" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.486">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P821" height="8.0" width="8.0" x="61.0" y="31.200000762939453" outgoingEdges="//@containedEdges.487">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N333" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L333" height="15.0" width="78.0" text="ModalModel2"/>
+    <ports identifier="P822" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.448">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P823" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.476">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P824" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.489">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N334" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L334" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P825" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.489">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P826" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N335" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L335" height="15.0" width="73.0" text="LookupTable"/>
+    <ports identifier="P827" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.492">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P828" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.490">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N336" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L336" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P829" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.491">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P830" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.469">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P831" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P832" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N337" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L337" height="15.0" width="38.0" text="Round"/>
+    <ports identifier="P833" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.491">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P834" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.492">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N338" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L338" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P835" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.493">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P836" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.503">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N339" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L339" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P837" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.504">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P838" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.494">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P839" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N340" height="25.0" width="282.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L340" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P840" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@containedEdges.495">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P841" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.494">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N341" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L341" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P842" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.496">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P843" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.497">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N342" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L342" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P844" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.505">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P845" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.497">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P846" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N343" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L343" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P847" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.498">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P848" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.501">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N344" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L344" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P849" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.502">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P850" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.499">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P851" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N345" height="25.0" width="282.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L345" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P852" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@containedEdges.500">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P853" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.499">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N346" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L346" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P854" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.470">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P855" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.506">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P856" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.503 //@containedEdges.504 //@containedEdges.505">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P857" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.501 //@containedEdges.502">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N347" height="25.0" width="93.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L347" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P858" height="8.0" width="8.0" x="93.0" y="8.5" outgoingEdges="//@containedEdges.506">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P859" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.471">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N348" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L348" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P860" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.493 //@containedEdges.495 //@containedEdges.496 //@containedEdges.498 //@containedEdges.500">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P861" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.507 //@containedEdges.508 //@containedEdges.509">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N349" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L349" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P862" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.510">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P863" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.488">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N350" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L350" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P864" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.511 //@containedEdges.512">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P865" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.477">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N351" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L351" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P866" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.513">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P867" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.580">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N352" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L352" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P868" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.514 //@containedEdges.515 //@containedEdges.516 //@containedEdges.517">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P869" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N353" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L353" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P870" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.543">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P871" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.518">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N354" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L354" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P872" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.544">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P873" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.519">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P874" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.522">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N355" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L355" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P875" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.529">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P876" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.520">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P877" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.523">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N356" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L356" height="15.0" width="63.0" text="IsPresent2"/>
+    <ports identifier="P878" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.530">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P879" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.521">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N357" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L357" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P880" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.518 //@containedEdges.521">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P881" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.522 //@containedEdges.523">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N358" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L358" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P882" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.519 //@containedEdges.520">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P883" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P884" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.524 //@containedEdges.525">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N359" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L359" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P885" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.526">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P886" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.524">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N360" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L360" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P887" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.526 //@containedEdges.542">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P888" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P889" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.527">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N361" height="25.0" width="77.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L361" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P890" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@containedEdges.528">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P891" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.569">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N362" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L362" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P892" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.528 //@containedEdges.534">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P893" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P894" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.529 //@containedEdges.530">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N363" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L363" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P895" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.531 //@containedEdges.532 //@containedEdges.533">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P896" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P897" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P898" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P899" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N364" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L364" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P900" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.535 //@containedEdges.570">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P901" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P902" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.534">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N365" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L365" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P903" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.552">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P904" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.535">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P905" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.571">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N366" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L366" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P906" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.536 //@containedEdges.537 //@containedEdges.538 //@containedEdges.539">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P907" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P908" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P909" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P910" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N367" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L367" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P911" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.548">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P912" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.541 //@containedEdges.572">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P913" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.540">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N368" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L368" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P914" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@containedEdges.541">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P915" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.547">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N369" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L369" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P916" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.527">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P917" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N370" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L370" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P918" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.525">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P919" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.542">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N371" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L371" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P920" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.540">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P921" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.543 //@containedEdges.544">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P922" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.549">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N372" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L372" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P923" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.545">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P924" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.536">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N373" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L373" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P925" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.546">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P926" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.537">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N374" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L374" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P927" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.546">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P928" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.545">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P929" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.511">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P930" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.547">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P931" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.550">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P932" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.548">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P933" height="8.0" width="8.0" x="61.0" y="31.200000762939453" outgoingEdges="//@containedEdges.549">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N375" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L375" height="15.0" width="78.0" text="ModalModel2"/>
+    <ports identifier="P934" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.512">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P935" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.538">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P936" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.551">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N376" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L376" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P937" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.551">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P938" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N377" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L377" height="15.0" width="73.0" text="LookupTable"/>
+    <ports identifier="P939" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.554">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P940" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.552">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N378" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L378" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P941" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.553">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P942" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.531">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P943" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P944" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N379" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L379" height="15.0" width="38.0" text="Round"/>
+    <ports identifier="P945" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.553">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P946" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.554">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N380" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L380" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P947" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.555">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P948" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.565">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N381" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L381" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P949" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.566">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P950" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.556">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P951" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N382" height="25.0" width="282.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L382" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P952" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@containedEdges.557">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P953" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.556">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N383" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L383" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P954" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.558">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P955" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.559">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N384" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L384" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P956" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.567">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P957" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.559">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P958" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N385" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L385" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P959" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.560">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P960" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.563">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N386" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L386" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P961" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.564">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P962" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.561">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P963" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N387" height="25.0" width="282.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L387" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P964" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@containedEdges.562">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P965" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.561">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N388" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L388" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P966" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.532">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P967" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.568">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P968" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.565 //@containedEdges.566 //@containedEdges.567">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P969" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.563 //@containedEdges.564">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N389" height="25.0" width="93.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L389" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P970" height="8.0" width="8.0" x="93.0" y="8.5" outgoingEdges="//@containedEdges.568">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P971" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.533">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N390" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L390" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P972" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.555 //@containedEdges.557 //@containedEdges.558 //@containedEdges.560 //@containedEdges.562">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P973" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.569 //@containedEdges.570 //@containedEdges.571">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N391" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L391" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P974" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.572">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P975" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.550">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N392" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L392" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P976" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P977" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.539">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N393" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L393" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P978" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.573">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P979" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.581">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N394" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L394" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P980" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.574 //@containedEdges.575 //@containedEdges.576 //@containedEdges.577">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P981" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N395" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L395" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P982" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.578 //@containedEdges.579 //@containedEdges.580 //@containedEdges.581">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P983" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P984" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P985" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P986" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N396" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L396" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P987" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.582 //@containedEdges.583 //@containedEdges.584">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P988" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.578">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N397" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L397" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P989" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.449">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P990" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.582">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P991" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.585">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N398" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L398" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P992" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.513">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P993" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.583">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P994" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.586">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N399" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L399" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P995" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.573">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P996" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.584">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P997" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.587">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N400" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L400" height="15.0" width="117.0" text="DetectorClockTimes"/>
+    <ports identifier="P998" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.585 //@containedEdges.586 //@containedEdges.587">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N401" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L401" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P999" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.452">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1000" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.588">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1001" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.589">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N402" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L402" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P1002" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.453">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1003" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.516">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1004" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.589 //@containedEdges.590">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N403" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L403" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P1005" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.517">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1006" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.591">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1007" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.590">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N404" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L404" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1008" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.588">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1009" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.591">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1010" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.592 //@containedEdges.593 //@containedEdges.594 //@containedEdges.595">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N405" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L405" height="15.0" width="78.0" text="ModalModel2"/>
+    <ports identifier="P1011" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.454">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1012" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.576">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1013" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.596 //@containedEdges.597">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N406" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L406" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P1014" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.455">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1015" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.598">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1016" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.596">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N407" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L407" height="15.0" width="78.0" text="MostRecent4"/>
+    <ports identifier="P1017" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.577">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1018" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.599">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1019" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.597">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N408" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L408" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P1020" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.598">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1021" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.599">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1022" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.600 //@containedEdges.601 //@containedEdges.602 //@containedEdges.603">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N409" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L409" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P1023" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.604">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1024" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.612">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1025" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.633">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N410" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L410" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P1026" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.605">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1027" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.639">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1028" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.660">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N411" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L411" height="15.0" width="111.0" text="RecordAssembler3"/>
+    <ports identifier="P1029" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.606">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1030" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.604">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1031" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.605">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N412" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L412" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P1032" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.607">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1033" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.592">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N413" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L413" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P1034" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.607">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1035" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.608 //@containedEdges.609">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1036" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N414" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L414" height="15.0" width="81.0" text="Accumulator2"/>
+    <ports identifier="P1037" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.593">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1038" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.610">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1039" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N415" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L415" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P1040" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.613">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1041" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.614">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1042" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.611 //@containedEdges.612">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N416" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L416" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P1043" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.610">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1044" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.613">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1045" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.620">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N417" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L417" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P1046" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.608">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1047" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.614 //@containedEdges.615 //@containedEdges.616 //@containedEdges.617">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1048" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.621">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N418" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L418" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P1049" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.609 //@containedEdges.619">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1050" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.618">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N419" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L419" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P1051" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.619">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1052" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.594">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N420" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L420" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P1053" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.618">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1054" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.620 //@containedEdges.621 //@containedEdges.622">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N421" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L421" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P1055" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.595">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1056" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.623">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N422" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L422" height="15.0" width="81.0" text="Accumulator3"/>
+    <ports identifier="P1057" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.623">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1058" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.624">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1059" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N423" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L423" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P1060" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.624">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1061" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.625">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1062" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.622">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N424" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L424" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P1063" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.615 //@containedEdges.628">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1064" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1065" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.626">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N425" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L425" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1066" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.625">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1067" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.626">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1068" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.627">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N426" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L426" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P1069" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.611">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1070" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.628">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N427" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L427" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P1071" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.616">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1072" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.630">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1073" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.629">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N428" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L428" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P1074" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.630">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1075" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.617">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N429" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L429" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P1076" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.627">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1077" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.632">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1078" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.631">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N430" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L430" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P1079" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.629">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1080" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.632">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N431" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L431" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P1081" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.631">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1082" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.633">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N432" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L432" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P1083" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.634">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1084" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.600">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N433" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L433" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P1085" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.634">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1086" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.635 //@containedEdges.636">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1087" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N434" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L434" height="15.0" width="81.0" text="Accumulator2"/>
+    <ports identifier="P1088" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.601">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1089" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.637">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1090" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N435" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L435" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P1091" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.640">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1092" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.641">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1093" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.638 //@containedEdges.639">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N436" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L436" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P1094" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.637">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1095" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.640">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1096" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.647">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N437" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L437" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P1097" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.635">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1098" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.641 //@containedEdges.642 //@containedEdges.643 //@containedEdges.644">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1099" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.648">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N438" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L438" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P1100" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.636 //@containedEdges.646">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1101" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.645">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N439" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L439" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P1102" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.646">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1103" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.602">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N440" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L440" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P1104" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.645">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1105" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.647 //@containedEdges.648 //@containedEdges.649">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N441" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L441" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P1106" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.603">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1107" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.650">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N442" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L442" height="15.0" width="81.0" text="Accumulator3"/>
+    <ports identifier="P1108" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.650">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1109" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.651">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1110" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N443" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L443" height="15.0" width="78.0" text="MostRecent3"/>
+    <ports identifier="P1111" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.651">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1112" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.652">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1113" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.649">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N444" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L444" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P1114" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.642 //@containedEdges.655">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1115" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1116" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.653">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N445" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L445" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.652">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.653">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1119" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.654">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N446" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L446" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P1120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.638">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1121" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.655">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N447" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L447" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P1122" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.643">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1123" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.657">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1124" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.656">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N448" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L448" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P1125" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.657">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P1126" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.644">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N449" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L449" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P1127" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.654">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1128" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.659">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1129" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.658">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N450" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L450" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P1130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.656">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1131" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.659">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N451" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L451" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P1132" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.658">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1133" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.660">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.3" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.3" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.2" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.3" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.3" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.2" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.3" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.1/@ports.3" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.1/@ports.2" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.1/@ports.2" targets="//@children.131/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.1/@ports.3" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.1/@ports.3" targets="//@children.132/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.2/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.5/@ports.2" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.5/@ports.2" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.5/@ports.2" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.5/@ports.3" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.5/@ports.3" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.5/@ports.3" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.6/@ports.0" targets="//@children.3/@ports.3"/>
+  <containedEdges identifier="E30" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.8/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.9/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.9/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.10/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.11/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.12/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.13/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.14/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.15/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.16/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.17/@ports.1" targets="//@children.307/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.18/@ports.1" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E44" sources="//@children.19/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.20/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.21/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.21/@ports.1" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.21/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.22/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.23/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.24/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.25/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.26/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.27/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.28/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.29/@ports.1" targets="//@children.309/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.29/@ports.1" targets="//@children.393/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.30/@ports.1" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E59" sources="//@children.31/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.32/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.33/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.33/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.33/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.34/@ports.2" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.35/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.36/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.37/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.38/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.39/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.40/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.41/@ports.1" targets="//@children.308/@ports.1"/>
+  <containedEdges identifier="E72" sources="//@children.41/@ports.1" targets="//@children.351/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.42/@ports.1" targets="//@children.41/@ports.2"/>
+  <containedEdges identifier="E74" sources="//@children.43/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.44/@ports.0" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.45/@ports.1" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E77" sources="//@children.45/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.46/@ports.2" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.47/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.48/@ports.1" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.49/@ports.1" targets="//@children.43/@ports.3"/>
+  <containedEdges identifier="E82" sources="//@children.50/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.51/@ports.0" targets="//@children.50/@ports.2"/>
+  <containedEdges identifier="E84" sources="//@children.52/@ports.0" targets="//@children.50/@ports.3"/>
+  <containedEdges identifier="E85" sources="//@children.53/@ports.1" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.53/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.53/@ports.1" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.53/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.53/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.54/@ports.1" targets="//@children.58/@ports.1"/>
+  <containedEdges identifier="E91" sources="//@children.54/@ports.1" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.54/@ports.1" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E93" sources="//@children.54/@ports.1" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.54/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.55/@ports.1" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E96" sources="//@children.56/@ports.1" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E97" sources="//@children.57/@ports.2" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E98" sources="//@children.57/@ports.2" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E99" sources="//@children.58/@ports.2" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.59/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.60/@ports.2" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.60/@ports.2" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.61/@ports.2" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.61/@ports.2" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.62/@ports.2" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.62/@ports.2" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.63/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.63/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.63/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.63/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.63/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.63/@ports.2" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.63/@ports.2" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.63/@ports.2" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.64/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.65/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.66/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.67/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.68/@ports.2" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.69/@ports.2" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E121" sources="//@children.70/@ports.2" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.70/@ports.2" targets="//@children.83/@ports.1"/>
+  <containedEdges identifier="E123" sources="//@children.71/@ports.1" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.72/@ports.1" targets="//@children.75/@ports.1"/>
+  <containedEdges identifier="E125" sources="//@children.73/@ports.1" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.74/@ports.1" targets="//@children.76/@ports.1"/>
+  <containedEdges identifier="E127" sources="//@children.75/@ports.2" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E128" sources="//@children.76/@ports.2" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E129" sources="//@children.77/@ports.2" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.78/@ports.1" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.79/@ports.2" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E132" sources="//@children.80/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.81/@ports.2" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.82/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E135" sources="//@children.83/@ports.2" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.84/@ports.2" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E137" sources="//@children.84/@ports.2" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.84/@ports.2" targets="//@children.92/@ports.1"/>
+  <containedEdges identifier="E139" sources="//@children.84/@ports.2" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.84/@ports.2" targets="//@children.108/@ports.1"/>
+  <containedEdges identifier="E141" sources="//@children.84/@ports.2" targets="//@children.115/@ports.2"/>
+  <containedEdges identifier="E142" sources="//@children.85/@ports.1" targets="//@children.84/@ports.1"/>
+  <containedEdges identifier="E143" sources="//@children.86/@ports.1" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.87/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E145" sources="//@children.88/@ports.2" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.89/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.89/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.90/@ports.1" targets="//@children.91/@ports.1"/>
+  <containedEdges identifier="E149" sources="//@children.91/@ports.2" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.92/@ports.2" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.93/@ports.1" targets="//@children.94/@ports.1"/>
+  <containedEdges identifier="E152" sources="//@children.94/@ports.2" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.95/@ports.1" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E154" sources="//@children.96/@ports.1" targets="//@children.100/@ports.1"/>
+  <containedEdges identifier="E155" sources="//@children.97/@ports.0" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.98/@ports.0" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.99/@ports.2" targets="//@children.117/@ports.1"/>
+  <containedEdges identifier="E158" sources="//@children.99/@ports.2" targets="//@children.120/@ports.2"/>
+  <containedEdges identifier="E159" sources="//@children.99/@ports.2" targets="//@children.131/@ports.2"/>
+  <containedEdges identifier="E160" sources="//@children.100/@ports.2" targets="//@children.118/@ports.1"/>
+  <containedEdges identifier="E161" sources="//@children.100/@ports.2" targets="//@children.121/@ports.2"/>
+  <containedEdges identifier="E162" sources="//@children.100/@ports.2" targets="//@children.132/@ports.2"/>
+  <containedEdges identifier="E163" sources="//@children.101/@ports.0" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E164" sources="//@children.101/@ports.0" targets="//@children.64/@ports.1"/>
+  <containedEdges identifier="E165" sources="//@children.101/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E166" sources="//@children.101/@ports.0" targets="//@children.97/@ports.1"/>
+  <containedEdges identifier="E167" sources="//@children.101/@ports.0" targets="//@children.98/@ports.1"/>
+  <containedEdges identifier="E168" sources="//@children.102/@ports.1" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E169" sources="//@children.102/@ports.1" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E170" sources="//@children.102/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E171" sources="//@children.103/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E172" sources="//@children.104/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.105/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E174" sources="//@children.106/@ports.1" targets="//@children.102/@ports.2"/>
+  <containedEdges identifier="E175" sources="//@children.106/@ports.1" targets="//@children.103/@ports.2"/>
+  <containedEdges identifier="E176" sources="//@children.106/@ports.1" targets="//@children.104/@ports.2"/>
+  <containedEdges identifier="E177" sources="//@children.107/@ports.2" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E178" sources="//@children.108/@ports.0" targets="//@children.107/@ports.1"/>
+  <containedEdges identifier="E179" sources="//@children.109/@ports.0" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E180" sources="//@children.110/@ports.2" targets="//@children.101/@ports.1"/>
+  <containedEdges identifier="E181" sources="//@children.111/@ports.0" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E182" sources="//@children.112/@ports.2" targets="//@children.101/@ports.2"/>
+  <containedEdges identifier="E183" sources="//@children.113/@ports.2" targets="//@children.111/@ports.1"/>
+  <containedEdges identifier="E184" sources="//@children.113/@ports.2" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E185" sources="//@children.114/@ports.2" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E186" sources="//@children.114/@ports.2" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E187" sources="//@children.115/@ports.1" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E188" sources="//@children.116/@ports.2" targets="//@children.119/@ports.1"/>
+  <containedEdges identifier="E189" sources="//@children.116/@ports.2" targets="//@children.122/@ports.2"/>
+  <containedEdges identifier="E190" sources="//@children.117/@ports.2" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E191" sources="//@children.118/@ports.2" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.119/@ports.2" targets="//@children.165/@ports.1"/>
+  <containedEdges identifier="E193" sources="//@children.119/@ports.2" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E194" sources="//@children.119/@ports.2" targets="//@children.172/@ports.1"/>
+  <containedEdges identifier="E195" sources="//@children.119/@ports.2" targets="//@children.174/@ports.0"/>
+  <containedEdges identifier="E196" sources="//@children.120/@ports.1" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E197" sources="//@children.121/@ports.1" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E198" sources="//@children.122/@ports.1" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E199" sources="//@children.123/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E200" sources="//@children.124/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E201" sources="//@children.125/@ports.2" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E202" sources="//@children.126/@ports.1" targets="//@children.145/@ports.1"/>
+  <containedEdges identifier="E203" sources="//@children.126/@ports.1" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E204" sources="//@children.126/@ports.1" targets="//@children.152/@ports.1"/>
+  <containedEdges identifier="E205" sources="//@children.126/@ports.1" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E206" sources="//@children.127/@ports.0" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E207" sources="//@children.128/@ports.0" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E208" sources="//@children.129/@ports.0" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E209" sources="//@children.130/@ports.0" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E210" sources="//@children.131/@ports.0" targets="//@children.135/@ports.0"/>
+  <containedEdges identifier="E211" sources="//@children.132/@ports.0" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E212" sources="//@children.133/@ports.0" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E213" sources="//@children.135/@ports.1" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E214" sources="//@children.135/@ports.2" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E215" sources="//@children.136/@ports.1" targets="//@children.134/@ports.1"/>
+  <containedEdges identifier="E216" sources="//@children.136/@ports.2" targets="//@children.134/@ports.1"/>
+  <containedEdges identifier="E217" sources="//@children.137/@ports.1" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E218" sources="//@children.137/@ports.2" targets="//@children.134/@ports.1"/>
+  <containedEdges identifier="E219" sources="//@children.138/@ports.0" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E220" sources="//@children.139/@ports.0" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E221" sources="//@children.140/@ports.1" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E222" sources="//@children.141/@ports.1" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E223" sources="//@children.141/@ports.2" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E224" sources="//@children.143/@ports.1" targets="//@children.144/@ports.0"/>
+  <containedEdges identifier="E225" sources="//@children.144/@ports.1" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E226" sources="//@children.144/@ports.2" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E227" sources="//@children.144/@ports.3" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E228" sources="//@children.145/@ports.0" targets="//@children.146/@ports.0"/>
+  <containedEdges identifier="E229" sources="//@children.146/@ports.1" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E230" sources="//@children.146/@ports.1" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E231" sources="//@children.147/@ports.1" targets="//@children.149/@ports.0"/>
+  <containedEdges identifier="E232" sources="//@children.148/@ports.2" targets="//@children.159/@ports.0"/>
+  <containedEdges identifier="E233" sources="//@children.148/@ports.2" targets="//@children.127/@ports.1"/>
+  <containedEdges identifier="E234" sources="//@children.148/@ports.2" targets="//@children.128/@ports.1"/>
+  <containedEdges identifier="E235" sources="//@children.148/@ports.2" targets="//@children.138/@ports.1"/>
+  <containedEdges identifier="E236" sources="//@children.148/@ports.2" targets="//@children.143/@ports.2"/>
+  <containedEdges identifier="E237" sources="//@children.149/@ports.1" targets="//@children.148/@ports.0"/>
+  <containedEdges identifier="E238" sources="//@children.150/@ports.1" targets="//@children.148/@ports.1"/>
+  <containedEdges identifier="E239" sources="//@children.150/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E240" sources="//@children.150/@ports.1" targets="//@children.160/@ports.0"/>
+  <containedEdges identifier="E241" sources="//@children.150/@ports.1" targets="//@children.161/@ports.1"/>
+  <containedEdges identifier="E242" sources="//@children.151/@ports.1" targets="//@children.153/@ports.0"/>
+  <containedEdges identifier="E243" sources="//@children.152/@ports.0" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E244" sources="//@children.153/@ports.1" targets="//@children.149/@ports.2"/>
+  <containedEdges identifier="E245" sources="//@children.153/@ports.1" targets="//@children.150/@ports.2"/>
+  <containedEdges identifier="E246" sources="//@children.153/@ports.1" targets="//@children.156/@ports.2"/>
+  <containedEdges identifier="E247" sources="//@children.154/@ports.1" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E248" sources="//@children.155/@ports.1" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E249" sources="//@children.156/@ports.1" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E250" sources="//@children.157/@ports.2" targets="//@children.158/@ports.1"/>
+  <containedEdges identifier="E251" sources="//@children.158/@ports.2" targets="//@children.162/@ports.0"/>
+  <containedEdges identifier="E252" sources="//@children.159/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E253" sources="//@children.160/@ports.2" targets="//@children.163/@ports.0"/>
+  <containedEdges identifier="E254" sources="//@children.161/@ports.0" targets="//@children.160/@ports.1"/>
+  <containedEdges identifier="E255" sources="//@children.162/@ports.2" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E256" sources="//@children.163/@ports.1" targets="//@children.162/@ports.1"/>
+  <containedEdges identifier="E257" sources="//@children.164/@ports.1" targets="//@children.127/@ports.2"/>
+  <containedEdges identifier="E258" sources="//@children.165/@ports.0" targets="//@children.166/@ports.0"/>
+  <containedEdges identifier="E259" sources="//@children.166/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E260" sources="//@children.166/@ports.1" targets="//@children.171/@ports.0"/>
+  <containedEdges identifier="E261" sources="//@children.167/@ports.1" targets="//@children.169/@ports.0"/>
+  <containedEdges identifier="E262" sources="//@children.168/@ports.2" targets="//@children.179/@ports.0"/>
+  <containedEdges identifier="E263" sources="//@children.168/@ports.2" targets="//@children.129/@ports.1"/>
+  <containedEdges identifier="E264" sources="//@children.168/@ports.2" targets="//@children.130/@ports.1"/>
+  <containedEdges identifier="E265" sources="//@children.168/@ports.2" targets="//@children.139/@ports.1"/>
+  <containedEdges identifier="E266" sources="//@children.168/@ports.2" targets="//@children.140/@ports.2"/>
+  <containedEdges identifier="E267" sources="//@children.169/@ports.1" targets="//@children.168/@ports.0"/>
+  <containedEdges identifier="E268" sources="//@children.170/@ports.1" targets="//@children.168/@ports.1"/>
+  <containedEdges identifier="E269" sources="//@children.170/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E270" sources="//@children.170/@ports.1" targets="//@children.180/@ports.0"/>
+  <containedEdges identifier="E271" sources="//@children.170/@ports.1" targets="//@children.181/@ports.1"/>
+  <containedEdges identifier="E272" sources="//@children.171/@ports.1" targets="//@children.173/@ports.0"/>
+  <containedEdges identifier="E273" sources="//@children.172/@ports.0" targets="//@children.171/@ports.0"/>
+  <containedEdges identifier="E274" sources="//@children.173/@ports.1" targets="//@children.169/@ports.2"/>
+  <containedEdges identifier="E275" sources="//@children.173/@ports.1" targets="//@children.170/@ports.2"/>
+  <containedEdges identifier="E276" sources="//@children.173/@ports.1" targets="//@children.176/@ports.2"/>
+  <containedEdges identifier="E277" sources="//@children.174/@ports.1" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E278" sources="//@children.175/@ports.1" targets="//@children.176/@ports.0"/>
+  <containedEdges identifier="E279" sources="//@children.176/@ports.1" targets="//@children.178/@ports.0"/>
+  <containedEdges identifier="E280" sources="//@children.177/@ports.2" targets="//@children.178/@ports.1"/>
+  <containedEdges identifier="E281" sources="//@children.178/@ports.2" targets="//@children.182/@ports.0"/>
+  <containedEdges identifier="E282" sources="//@children.179/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E283" sources="//@children.180/@ports.2" targets="//@children.183/@ports.0"/>
+  <containedEdges identifier="E284" sources="//@children.181/@ports.0" targets="//@children.180/@ports.1"/>
+  <containedEdges identifier="E285" sources="//@children.182/@ports.2" targets="//@children.184/@ports.0"/>
+  <containedEdges identifier="E286" sources="//@children.183/@ports.1" targets="//@children.182/@ports.1"/>
+  <containedEdges identifier="E287" sources="//@children.184/@ports.1" targets="//@children.130/@ports.2"/>
+  <containedEdges identifier="E288" sources="//@children.185/@ports.0" targets="//@children.188/@ports.0"/>
+  <containedEdges identifier="E289" sources="//@children.185/@ports.0" targets="//@children.189/@ports.1"/>
+  <containedEdges identifier="E290" sources="//@children.186/@ports.1" targets="//@children.133/@ports.1"/>
+  <containedEdges identifier="E291" sources="//@children.187/@ports.1" targets="//@children.133/@ports.2"/>
+  <containedEdges identifier="E292" sources="//@children.188/@ports.1" targets="//@children.186/@ports.0"/>
+  <containedEdges identifier="E293" sources="//@children.188/@ports.1" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E294" sources="//@children.189/@ports.0" targets="//@children.188/@ports.0"/>
+  <containedEdges identifier="E295" sources="//@children.190/@ports.0" targets="//@children.191/@ports.1"/>
+  <containedEdges identifier="E296" sources="//@children.190/@ports.0" targets="//@children.196/@ports.1"/>
+  <containedEdges identifier="E297" sources="//@children.190/@ports.0" targets="//@children.201/@ports.1"/>
+  <containedEdges identifier="E298" sources="//@children.190/@ports.0" targets="//@children.202/@ports.1"/>
+  <containedEdges identifier="E299" sources="//@children.190/@ports.0" targets="//@children.203/@ports.1"/>
+  <containedEdges identifier="E300" sources="//@children.190/@ports.0" targets="//@children.214/@ports.1"/>
+  <containedEdges identifier="E301" sources="//@children.190/@ports.0" targets="//@children.215/@ports.1"/>
+  <containedEdges identifier="E302" sources="//@children.190/@ports.0" targets="//@children.221/@ports.1"/>
+  <containedEdges identifier="E303" sources="//@children.190/@ports.0" targets="//@children.222/@ports.1"/>
+  <containedEdges identifier="E304" sources="//@children.190/@ports.0" targets="//@children.227/@ports.1"/>
+  <containedEdges identifier="E305" sources="//@children.190/@ports.0" targets="//@children.258/@ports.1"/>
+  <containedEdges identifier="E306" sources="//@children.190/@ports.0" targets="//@children.259/@ports.1"/>
+  <containedEdges identifier="E307" sources="//@children.190/@ports.0" targets="//@children.260/@ports.1"/>
+  <containedEdges identifier="E308" sources="//@children.191/@ports.0" targets="//@children.192/@ports.0"/>
+  <containedEdges identifier="E309" sources="//@children.191/@ports.0" targets="//@children.251/@ports.0"/>
+  <containedEdges identifier="E310" sources="//@children.191/@ports.0" targets="//@children.252/@ports.0"/>
+  <containedEdges identifier="E311" sources="//@children.194/@ports.0" targets="//@children.200/@ports.0"/>
+  <containedEdges identifier="E312" sources="//@children.195/@ports.0" targets="//@children.200/@ports.0"/>
+  <containedEdges identifier="E313" sources="//@children.196/@ports.0" targets="//@children.197/@ports.0"/>
+  <containedEdges identifier="E314" sources="//@children.196/@ports.0" targets="//@children.199/@ports.0"/>
+  <containedEdges identifier="E315" sources="//@children.197/@ports.1" targets="//@children.194/@ports.1"/>
+  <containedEdges identifier="E316" sources="//@children.197/@ports.1" targets="//@children.248/@ports.1"/>
+  <containedEdges identifier="E317" sources="//@children.198/@ports.1" targets="//@children.195/@ports.1"/>
+  <containedEdges identifier="E318" sources="//@children.198/@ports.1" targets="//@children.249/@ports.1"/>
+  <containedEdges identifier="E319" sources="//@children.199/@ports.1" targets="//@children.198/@ports.0"/>
+  <containedEdges identifier="E320" sources="//@children.200/@ports.1" targets="//@children.193/@ports.0"/>
+  <containedEdges identifier="E321" sources="//@children.201/@ports.0" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E322" sources="//@children.201/@ports.0" targets="//@children.208/@ports.0"/>
+  <containedEdges identifier="E323" sources="//@children.202/@ports.0" targets="//@children.211/@ports.0"/>
+  <containedEdges identifier="E324" sources="//@children.202/@ports.0" targets="//@children.226/@ports.0"/>
+  <containedEdges identifier="E325" sources="//@children.203/@ports.0" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E326" sources="//@children.204/@ports.0" targets="//@children.209/@ports.0"/>
+  <containedEdges identifier="E327" sources="//@children.205/@ports.0" targets="//@children.209/@ports.0"/>
+  <containedEdges identifier="E328" sources="//@children.206/@ports.1" targets="//@children.204/@ports.1"/>
+  <containedEdges identifier="E329" sources="//@children.206/@ports.1" targets="//@children.245/@ports.1"/>
+  <containedEdges identifier="E330" sources="//@children.207/@ports.1" targets="//@children.205/@ports.1"/>
+  <containedEdges identifier="E331" sources="//@children.207/@ports.1" targets="//@children.246/@ports.1"/>
+  <containedEdges identifier="E332" sources="//@children.208/@ports.1" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E333" sources="//@children.209/@ports.1" targets="//@children.210/@ports.0"/>
+  <containedEdges identifier="E334" sources="//@children.211/@ports.1" targets="//@children.244/@ports.0"/>
+  <containedEdges identifier="E335" sources="//@children.212/@ports.1" targets="//@children.211/@ports.0"/>
+  <containedEdges identifier="E336" sources="//@children.212/@ports.1" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E337" sources="//@children.213/@ports.2" targets="//@children.216/@ports.0"/>
+  <containedEdges identifier="E338" sources="//@children.214/@ports.0" targets="//@children.213/@ports.0"/>
+  <containedEdges identifier="E339" sources="//@children.215/@ports.0" targets="//@children.213/@ports.1"/>
+  <containedEdges identifier="E340" sources="//@children.216/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E341" sources="//@children.219/@ports.0" targets="//@children.218/@ports.0"/>
+  <containedEdges identifier="E342" sources="//@children.220/@ports.2" targets="//@children.223/@ports.0"/>
+  <containedEdges identifier="E343" sources="//@children.221/@ports.0" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E344" sources="//@children.222/@ports.0" targets="//@children.220/@ports.1"/>
+  <containedEdges identifier="E345" sources="//@children.223/@ports.1" targets="//@children.224/@ports.0"/>
+  <containedEdges identifier="E346" sources="//@children.225/@ports.1" targets="//@children.243/@ports.0"/>
+  <containedEdges identifier="E347" sources="//@children.226/@ports.1" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E348" sources="//@children.227/@ports.0" targets="//@children.242/@ports.0"/>
+  <containedEdges identifier="E349" sources="//@children.228/@ports.0" targets="//@children.240/@ports.0"/>
+  <containedEdges identifier="E350" sources="//@children.229/@ports.0" targets="//@children.239/@ports.0"/>
+  <containedEdges identifier="E351" sources="//@children.230/@ports.0" targets="//@children.241/@ports.0"/>
+  <containedEdges identifier="E352" sources="//@children.233/@ports.0" targets="//@children.240/@ports.0"/>
+  <containedEdges identifier="E353" sources="//@children.234/@ports.0" targets="//@children.239/@ports.0"/>
+  <containedEdges identifier="E354" sources="//@children.235/@ports.0" targets="//@children.241/@ports.0"/>
+  <containedEdges identifier="E355" sources="//@children.236/@ports.0" targets="//@children.240/@ports.0"/>
+  <containedEdges identifier="E356" sources="//@children.237/@ports.0" targets="//@children.239/@ports.0"/>
+  <containedEdges identifier="E357" sources="//@children.238/@ports.0" targets="//@children.241/@ports.0"/>
+  <containedEdges identifier="E358" sources="//@children.239/@ports.1" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E359" sources="//@children.240/@ports.1" targets="//@children.232/@ports.0"/>
+  <containedEdges identifier="E360" sources="//@children.241/@ports.1" targets="//@children.265/@ports.3"/>
+  <containedEdges identifier="E361" sources="//@children.242/@ports.1" targets="//@children.228/@ports.1"/>
+  <containedEdges identifier="E362" sources="//@children.242/@ports.1" targets="//@children.229/@ports.1"/>
+  <containedEdges identifier="E363" sources="//@children.242/@ports.1" targets="//@children.230/@ports.1"/>
+  <containedEdges identifier="E364" sources="//@children.243/@ports.1" targets="//@children.233/@ports.1"/>
+  <containedEdges identifier="E365" sources="//@children.243/@ports.1" targets="//@children.234/@ports.1"/>
+  <containedEdges identifier="E366" sources="//@children.243/@ports.1" targets="//@children.235/@ports.1"/>
+  <containedEdges identifier="E367" sources="//@children.244/@ports.1" targets="//@children.236/@ports.1"/>
+  <containedEdges identifier="E368" sources="//@children.244/@ports.1" targets="//@children.237/@ports.1"/>
+  <containedEdges identifier="E369" sources="//@children.244/@ports.1" targets="//@children.238/@ports.1"/>
+  <containedEdges identifier="E370" sources="//@children.245/@ports.0" targets="//@children.247/@ports.0"/>
+  <containedEdges identifier="E371" sources="//@children.246/@ports.0" targets="//@children.247/@ports.0"/>
+  <containedEdges identifier="E372" sources="//@children.247/@ports.1" targets="//@children.263/@ports.1"/>
+  <containedEdges identifier="E373" sources="//@children.247/@ports.1" targets="//@children.265/@ports.2"/>
+  <containedEdges identifier="E374" sources="//@children.248/@ports.0" targets="//@children.250/@ports.0"/>
+  <containedEdges identifier="E375" sources="//@children.249/@ports.0" targets="//@children.250/@ports.0"/>
+  <containedEdges identifier="E376" sources="//@children.250/@ports.1" targets="//@children.261/@ports.2"/>
+  <containedEdges identifier="E377" sources="//@children.251/@ports.1" targets="//@children.254/@ports.1"/>
+  <containedEdges identifier="E378" sources="//@children.252/@ports.1" targets="//@children.253/@ports.0"/>
+  <containedEdges identifier="E379" sources="//@children.253/@ports.1" targets="//@children.255/@ports.1"/>
+  <containedEdges identifier="E380" sources="//@children.254/@ports.0" targets="//@children.256/@ports.0"/>
+  <containedEdges identifier="E381" sources="//@children.255/@ports.0" targets="//@children.256/@ports.0"/>
+  <containedEdges identifier="E382" sources="//@children.256/@ports.1" targets="//@children.261/@ports.3"/>
+  <containedEdges identifier="E383" sources="//@children.256/@ports.1" targets="//@children.262/@ports.1"/>
+  <containedEdges identifier="E384" sources="//@children.257/@ports.0" targets="//@children.264/@ports.1"/>
+  <containedEdges identifier="E385" sources="//@children.258/@ports.0" targets="//@children.257/@ports.1"/>
+  <containedEdges identifier="E386" sources="//@children.259/@ports.0" targets="//@children.257/@ports.2"/>
+  <containedEdges identifier="E387" sources="//@children.260/@ports.0" targets="//@children.257/@ports.3"/>
+  <containedEdges identifier="E388" sources="//@children.261/@ports.0" targets="//@children.264/@ports.2"/>
+  <containedEdges identifier="E389" sources="//@children.262/@ports.0" targets="//@children.261/@ports.1"/>
+  <containedEdges identifier="E390" sources="//@children.263/@ports.0" targets="//@children.265/@ports.1"/>
+  <containedEdges identifier="E391" sources="//@children.264/@ports.0" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E392" sources="//@children.265/@ports.0" targets="//@children.264/@ports.3"/>
+  <containedEdges identifier="E393" sources="//@children.266/@ports.1" targets="//@children.270/@ports.0"/>
+  <containedEdges identifier="E394" sources="//@children.267/@ports.1" targets="//@children.271/@ports.0"/>
+  <containedEdges identifier="E395" sources="//@children.268/@ports.1" targets="//@children.271/@ports.0"/>
+  <containedEdges identifier="E396" sources="//@children.269/@ports.1" targets="//@children.270/@ports.0"/>
+  <containedEdges identifier="E397" sources="//@children.270/@ports.1" targets="//@children.267/@ports.2"/>
+  <containedEdges identifier="E398" sources="//@children.270/@ports.1" targets="//@children.268/@ports.2"/>
+  <containedEdges identifier="E399" sources="//@children.271/@ports.2" targets="//@children.272/@ports.1"/>
+  <containedEdges identifier="E400" sources="//@children.271/@ports.2" targets="//@children.283/@ports.0"/>
+  <containedEdges identifier="E401" sources="//@children.272/@ports.0" targets="//@children.273/@ports.0"/>
+  <containedEdges identifier="E402" sources="//@children.273/@ports.2" targets="//@children.282/@ports.0"/>
+  <containedEdges identifier="E403" sources="//@children.274/@ports.0" targets="//@children.275/@ports.0"/>
+  <containedEdges identifier="E404" sources="//@children.275/@ports.2" targets="//@children.268/@ports.0"/>
+  <containedEdges identifier="E405" sources="//@children.275/@ports.2" targets="//@children.269/@ports.0"/>
+  <containedEdges identifier="E406" sources="//@children.276/@ports.0" targets="//@children.291/@ports.1"/>
+  <containedEdges identifier="E407" sources="//@children.276/@ports.0" targets="//@children.301/@ports.0"/>
+  <containedEdges identifier="E408" sources="//@children.276/@ports.0" targets="//@children.302/@ports.1"/>
+  <containedEdges identifier="E409" sources="//@children.277/@ports.2" targets="//@children.275/@ports.0"/>
+  <containedEdges identifier="E410" sources="//@children.278/@ports.1" targets="//@children.277/@ports.0"/>
+  <containedEdges identifier="E411" sources="//@children.279/@ports.0" targets="//@children.285/@ports.1"/>
+  <containedEdges identifier="E412" sources="//@children.279/@ports.0" targets="//@children.286/@ports.1"/>
+  <containedEdges identifier="E413" sources="//@children.279/@ports.0" targets="//@children.288/@ports.1"/>
+  <containedEdges identifier="E414" sources="//@children.279/@ports.0" targets="//@children.305/@ports.1"/>
+  <containedEdges identifier="E415" sources="//@children.280/@ports.2" targets="//@children.284/@ports.0"/>
+  <containedEdges identifier="E416" sources="//@children.281/@ports.0" targets="//@children.280/@ports.1"/>
+  <containedEdges identifier="E417" sources="//@children.283/@ports.1" targets="//@children.273/@ports.0"/>
+  <containedEdges identifier="E418" sources="//@children.284/@ports.1" targets="//@children.266/@ports.0"/>
+  <containedEdges identifier="E419" sources="//@children.284/@ports.1" targets="//@children.267/@ports.0"/>
+  <containedEdges identifier="E420" sources="//@children.285/@ports.0" targets="//@children.287/@ports.1"/>
+  <containedEdges identifier="E421" sources="//@children.286/@ports.0" targets="//@children.287/@ports.0"/>
+  <containedEdges identifier="E422" sources="//@children.287/@ports.3" targets="//@children.281/@ports.1"/>
+  <containedEdges identifier="E423" sources="//@children.287/@ports.5" targets="//@children.280/@ports.0"/>
+  <containedEdges identifier="E424" sources="//@children.287/@ports.6" targets="//@children.284/@ports.2"/>
+  <containedEdges identifier="E425" sources="//@children.287/@ports.4" targets="//@children.304/@ports.1"/>
+  <containedEdges identifier="E426" sources="//@children.288/@ports.2" targets="//@children.289/@ports.0"/>
+  <containedEdges identifier="E427" sources="//@children.290/@ports.1" targets="//@children.278/@ports.0"/>
+  <containedEdges identifier="E428" sources="//@children.291/@ports.0" targets="//@children.292/@ports.0"/>
+  <containedEdges identifier="E429" sources="//@children.292/@ports.1" targets="//@children.290/@ports.0"/>
+  <containedEdges identifier="E430" sources="//@children.293/@ports.0" targets="//@children.303/@ports.0"/>
+  <containedEdges identifier="E431" sources="//@children.294/@ports.1" targets="//@children.295/@ports.1"/>
+  <containedEdges identifier="E432" sources="//@children.295/@ports.0" targets="//@children.303/@ports.0"/>
+  <containedEdges identifier="E433" sources="//@children.296/@ports.0" targets="//@children.303/@ports.0"/>
+  <containedEdges identifier="E434" sources="//@children.297/@ports.1" targets="//@children.296/@ports.1"/>
+  <containedEdges identifier="E435" sources="//@children.298/@ports.0" targets="//@children.303/@ports.0"/>
+  <containedEdges identifier="E436" sources="//@children.299/@ports.1" targets="//@children.300/@ports.1"/>
+  <containedEdges identifier="E437" sources="//@children.300/@ports.0" targets="//@children.303/@ports.0"/>
+  <containedEdges identifier="E438" sources="//@children.301/@ports.3" targets="//@children.298/@ports.1"/>
+  <containedEdges identifier="E439" sources="//@children.301/@ports.3" targets="//@children.299/@ports.0"/>
+  <containedEdges identifier="E440" sources="//@children.301/@ports.2" targets="//@children.293/@ports.1"/>
+  <containedEdges identifier="E441" sources="//@children.301/@ports.2" targets="//@children.294/@ports.0"/>
+  <containedEdges identifier="E442" sources="//@children.301/@ports.2" targets="//@children.297/@ports.0"/>
+  <containedEdges identifier="E443" sources="//@children.302/@ports.0" targets="//@children.301/@ports.1"/>
+  <containedEdges identifier="E444" sources="//@children.303/@ports.1" targets="//@children.274/@ports.1"/>
+  <containedEdges identifier="E445" sources="//@children.303/@ports.1" targets="//@children.277/@ports.0"/>
+  <containedEdges identifier="E446" sources="//@children.303/@ports.1" targets="//@children.278/@ports.2"/>
+  <containedEdges identifier="E447" sources="//@children.304/@ports.0" targets="//@children.280/@ports.1"/>
+  <containedEdges identifier="E448" sources="//@children.305/@ports.0" targets="//@children.331/@ports.2"/>
+  <containedEdges identifier="E449" sources="//@children.305/@ports.0" targets="//@children.332/@ports.0"/>
+  <containedEdges identifier="E450" sources="//@children.306/@ports.0" targets="//@children.396/@ports.0"/>
+  <containedEdges identifier="E451" sources="//@children.307/@ports.0" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E452" sources="//@children.307/@ports.0" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E453" sources="//@children.308/@ports.0" targets="//@children.400/@ports.0"/>
+  <containedEdges identifier="E454" sources="//@children.308/@ports.0" targets="//@children.401/@ports.0"/>
+  <containedEdges identifier="E455" sources="//@children.309/@ports.0" targets="//@children.404/@ports.0"/>
+  <containedEdges identifier="E456" sources="//@children.309/@ports.0" targets="//@children.405/@ports.0"/>
+  <containedEdges identifier="E457" sources="//@children.310/@ports.1" targets="//@children.314/@ports.0"/>
+  <containedEdges identifier="E458" sources="//@children.311/@ports.1" targets="//@children.315/@ports.0"/>
+  <containedEdges identifier="E459" sources="//@children.312/@ports.1" targets="//@children.315/@ports.0"/>
+  <containedEdges identifier="E460" sources="//@children.313/@ports.1" targets="//@children.314/@ports.0"/>
+  <containedEdges identifier="E461" sources="//@children.314/@ports.1" targets="//@children.311/@ports.2"/>
+  <containedEdges identifier="E462" sources="//@children.314/@ports.1" targets="//@children.312/@ports.2"/>
+  <containedEdges identifier="E463" sources="//@children.315/@ports.2" targets="//@children.316/@ports.1"/>
+  <containedEdges identifier="E464" sources="//@children.315/@ports.2" targets="//@children.327/@ports.0"/>
+  <containedEdges identifier="E465" sources="//@children.316/@ports.0" targets="//@children.317/@ports.0"/>
+  <containedEdges identifier="E466" sources="//@children.317/@ports.2" targets="//@children.326/@ports.0"/>
+  <containedEdges identifier="E467" sources="//@children.318/@ports.0" targets="//@children.319/@ports.0"/>
+  <containedEdges identifier="E468" sources="//@children.319/@ports.2" targets="//@children.312/@ports.0"/>
+  <containedEdges identifier="E469" sources="//@children.319/@ports.2" targets="//@children.313/@ports.0"/>
+  <containedEdges identifier="E470" sources="//@children.320/@ports.0" targets="//@children.335/@ports.1"/>
+  <containedEdges identifier="E471" sources="//@children.320/@ports.0" targets="//@children.345/@ports.0"/>
+  <containedEdges identifier="E472" sources="//@children.320/@ports.0" targets="//@children.346/@ports.1"/>
+  <containedEdges identifier="E473" sources="//@children.321/@ports.2" targets="//@children.319/@ports.0"/>
+  <containedEdges identifier="E474" sources="//@children.322/@ports.1" targets="//@children.321/@ports.0"/>
+  <containedEdges identifier="E475" sources="//@children.323/@ports.0" targets="//@children.329/@ports.1"/>
+  <containedEdges identifier="E476" sources="//@children.323/@ports.0" targets="//@children.330/@ports.1"/>
+  <containedEdges identifier="E477" sources="//@children.323/@ports.0" targets="//@children.332/@ports.1"/>
+  <containedEdges identifier="E478" sources="//@children.323/@ports.0" targets="//@children.349/@ports.1"/>
+  <containedEdges identifier="E479" sources="//@children.324/@ports.2" targets="//@children.328/@ports.0"/>
+  <containedEdges identifier="E480" sources="//@children.325/@ports.0" targets="//@children.324/@ports.1"/>
+  <containedEdges identifier="E481" sources="//@children.327/@ports.1" targets="//@children.317/@ports.0"/>
+  <containedEdges identifier="E482" sources="//@children.328/@ports.1" targets="//@children.310/@ports.0"/>
+  <containedEdges identifier="E483" sources="//@children.328/@ports.1" targets="//@children.311/@ports.0"/>
+  <containedEdges identifier="E484" sources="//@children.329/@ports.0" targets="//@children.331/@ports.1"/>
+  <containedEdges identifier="E485" sources="//@children.330/@ports.0" targets="//@children.331/@ports.0"/>
+  <containedEdges identifier="E486" sources="//@children.331/@ports.3" targets="//@children.325/@ports.1"/>
+  <containedEdges identifier="E487" sources="//@children.331/@ports.5" targets="//@children.324/@ports.0"/>
+  <containedEdges identifier="E488" sources="//@children.331/@ports.6" targets="//@children.328/@ports.2"/>
+  <containedEdges identifier="E489" sources="//@children.331/@ports.4" targets="//@children.348/@ports.1"/>
+  <containedEdges identifier="E490" sources="//@children.332/@ports.2" targets="//@children.333/@ports.0"/>
+  <containedEdges identifier="E491" sources="//@children.334/@ports.1" targets="//@children.322/@ports.0"/>
+  <containedEdges identifier="E492" sources="//@children.335/@ports.0" targets="//@children.336/@ports.0"/>
+  <containedEdges identifier="E493" sources="//@children.336/@ports.1" targets="//@children.334/@ports.0"/>
+  <containedEdges identifier="E494" sources="//@children.337/@ports.0" targets="//@children.347/@ports.0"/>
+  <containedEdges identifier="E495" sources="//@children.338/@ports.1" targets="//@children.339/@ports.1"/>
+  <containedEdges identifier="E496" sources="//@children.339/@ports.0" targets="//@children.347/@ports.0"/>
+  <containedEdges identifier="E497" sources="//@children.340/@ports.0" targets="//@children.347/@ports.0"/>
+  <containedEdges identifier="E498" sources="//@children.341/@ports.1" targets="//@children.340/@ports.1"/>
+  <containedEdges identifier="E499" sources="//@children.342/@ports.0" targets="//@children.347/@ports.0"/>
+  <containedEdges identifier="E500" sources="//@children.343/@ports.1" targets="//@children.344/@ports.1"/>
+  <containedEdges identifier="E501" sources="//@children.344/@ports.0" targets="//@children.347/@ports.0"/>
+  <containedEdges identifier="E502" sources="//@children.345/@ports.3" targets="//@children.342/@ports.1"/>
+  <containedEdges identifier="E503" sources="//@children.345/@ports.3" targets="//@children.343/@ports.0"/>
+  <containedEdges identifier="E504" sources="//@children.345/@ports.2" targets="//@children.337/@ports.1"/>
+  <containedEdges identifier="E505" sources="//@children.345/@ports.2" targets="//@children.338/@ports.0"/>
+  <containedEdges identifier="E506" sources="//@children.345/@ports.2" targets="//@children.341/@ports.0"/>
+  <containedEdges identifier="E507" sources="//@children.346/@ports.0" targets="//@children.345/@ports.1"/>
+  <containedEdges identifier="E508" sources="//@children.347/@ports.1" targets="//@children.318/@ports.1"/>
+  <containedEdges identifier="E509" sources="//@children.347/@ports.1" targets="//@children.321/@ports.0"/>
+  <containedEdges identifier="E510" sources="//@children.347/@ports.1" targets="//@children.322/@ports.2"/>
+  <containedEdges identifier="E511" sources="//@children.348/@ports.0" targets="//@children.324/@ports.1"/>
+  <containedEdges identifier="E512" sources="//@children.349/@ports.0" targets="//@children.373/@ports.2"/>
+  <containedEdges identifier="E513" sources="//@children.349/@ports.0" targets="//@children.374/@ports.0"/>
+  <containedEdges identifier="E514" sources="//@children.350/@ports.0" targets="//@children.397/@ports.0"/>
+  <containedEdges identifier="E515" sources="//@children.351/@ports.0" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E516" sources="//@children.351/@ports.0" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E517" sources="//@children.351/@ports.0" targets="//@children.401/@ports.1"/>
+  <containedEdges identifier="E518" sources="//@children.351/@ports.0" targets="//@children.402/@ports.0"/>
+  <containedEdges identifier="E519" sources="//@children.352/@ports.1" targets="//@children.356/@ports.0"/>
+  <containedEdges identifier="E520" sources="//@children.353/@ports.1" targets="//@children.357/@ports.0"/>
+  <containedEdges identifier="E521" sources="//@children.354/@ports.1" targets="//@children.357/@ports.0"/>
+  <containedEdges identifier="E522" sources="//@children.355/@ports.1" targets="//@children.356/@ports.0"/>
+  <containedEdges identifier="E523" sources="//@children.356/@ports.1" targets="//@children.353/@ports.2"/>
+  <containedEdges identifier="E524" sources="//@children.356/@ports.1" targets="//@children.354/@ports.2"/>
+  <containedEdges identifier="E525" sources="//@children.357/@ports.2" targets="//@children.358/@ports.1"/>
+  <containedEdges identifier="E526" sources="//@children.357/@ports.2" targets="//@children.369/@ports.0"/>
+  <containedEdges identifier="E527" sources="//@children.358/@ports.0" targets="//@children.359/@ports.0"/>
+  <containedEdges identifier="E528" sources="//@children.359/@ports.2" targets="//@children.368/@ports.0"/>
+  <containedEdges identifier="E529" sources="//@children.360/@ports.0" targets="//@children.361/@ports.0"/>
+  <containedEdges identifier="E530" sources="//@children.361/@ports.2" targets="//@children.354/@ports.0"/>
+  <containedEdges identifier="E531" sources="//@children.361/@ports.2" targets="//@children.355/@ports.0"/>
+  <containedEdges identifier="E532" sources="//@children.362/@ports.0" targets="//@children.377/@ports.1"/>
+  <containedEdges identifier="E533" sources="//@children.362/@ports.0" targets="//@children.387/@ports.0"/>
+  <containedEdges identifier="E534" sources="//@children.362/@ports.0" targets="//@children.388/@ports.1"/>
+  <containedEdges identifier="E535" sources="//@children.363/@ports.2" targets="//@children.361/@ports.0"/>
+  <containedEdges identifier="E536" sources="//@children.364/@ports.1" targets="//@children.363/@ports.0"/>
+  <containedEdges identifier="E537" sources="//@children.365/@ports.0" targets="//@children.371/@ports.1"/>
+  <containedEdges identifier="E538" sources="//@children.365/@ports.0" targets="//@children.372/@ports.1"/>
+  <containedEdges identifier="E539" sources="//@children.365/@ports.0" targets="//@children.374/@ports.1"/>
+  <containedEdges identifier="E540" sources="//@children.365/@ports.0" targets="//@children.391/@ports.1"/>
+  <containedEdges identifier="E541" sources="//@children.366/@ports.2" targets="//@children.370/@ports.0"/>
+  <containedEdges identifier="E542" sources="//@children.367/@ports.0" targets="//@children.366/@ports.1"/>
+  <containedEdges identifier="E543" sources="//@children.369/@ports.1" targets="//@children.359/@ports.0"/>
+  <containedEdges identifier="E544" sources="//@children.370/@ports.1" targets="//@children.352/@ports.0"/>
+  <containedEdges identifier="E545" sources="//@children.370/@ports.1" targets="//@children.353/@ports.0"/>
+  <containedEdges identifier="E546" sources="//@children.371/@ports.0" targets="//@children.373/@ports.1"/>
+  <containedEdges identifier="E547" sources="//@children.372/@ports.0" targets="//@children.373/@ports.0"/>
+  <containedEdges identifier="E548" sources="//@children.373/@ports.3" targets="//@children.367/@ports.1"/>
+  <containedEdges identifier="E549" sources="//@children.373/@ports.5" targets="//@children.366/@ports.0"/>
+  <containedEdges identifier="E550" sources="//@children.373/@ports.6" targets="//@children.370/@ports.2"/>
+  <containedEdges identifier="E551" sources="//@children.373/@ports.4" targets="//@children.390/@ports.1"/>
+  <containedEdges identifier="E552" sources="//@children.374/@ports.2" targets="//@children.375/@ports.0"/>
+  <containedEdges identifier="E553" sources="//@children.376/@ports.1" targets="//@children.364/@ports.0"/>
+  <containedEdges identifier="E554" sources="//@children.377/@ports.0" targets="//@children.378/@ports.0"/>
+  <containedEdges identifier="E555" sources="//@children.378/@ports.1" targets="//@children.376/@ports.0"/>
+  <containedEdges identifier="E556" sources="//@children.379/@ports.0" targets="//@children.389/@ports.0"/>
+  <containedEdges identifier="E557" sources="//@children.380/@ports.1" targets="//@children.381/@ports.1"/>
+  <containedEdges identifier="E558" sources="//@children.381/@ports.0" targets="//@children.389/@ports.0"/>
+  <containedEdges identifier="E559" sources="//@children.382/@ports.0" targets="//@children.389/@ports.0"/>
+  <containedEdges identifier="E560" sources="//@children.383/@ports.1" targets="//@children.382/@ports.1"/>
+  <containedEdges identifier="E561" sources="//@children.384/@ports.0" targets="//@children.389/@ports.0"/>
+  <containedEdges identifier="E562" sources="//@children.385/@ports.1" targets="//@children.386/@ports.1"/>
+  <containedEdges identifier="E563" sources="//@children.386/@ports.0" targets="//@children.389/@ports.0"/>
+  <containedEdges identifier="E564" sources="//@children.387/@ports.3" targets="//@children.384/@ports.1"/>
+  <containedEdges identifier="E565" sources="//@children.387/@ports.3" targets="//@children.385/@ports.0"/>
+  <containedEdges identifier="E566" sources="//@children.387/@ports.2" targets="//@children.379/@ports.1"/>
+  <containedEdges identifier="E567" sources="//@children.387/@ports.2" targets="//@children.380/@ports.0"/>
+  <containedEdges identifier="E568" sources="//@children.387/@ports.2" targets="//@children.383/@ports.0"/>
+  <containedEdges identifier="E569" sources="//@children.388/@ports.0" targets="//@children.387/@ports.1"/>
+  <containedEdges identifier="E570" sources="//@children.389/@ports.1" targets="//@children.360/@ports.1"/>
+  <containedEdges identifier="E571" sources="//@children.389/@ports.1" targets="//@children.363/@ports.0"/>
+  <containedEdges identifier="E572" sources="//@children.389/@ports.1" targets="//@children.364/@ports.2"/>
+  <containedEdges identifier="E573" sources="//@children.390/@ports.0" targets="//@children.366/@ports.1"/>
+  <containedEdges identifier="E574" sources="//@children.392/@ports.0" targets="//@children.398/@ports.0"/>
+  <containedEdges identifier="E575" sources="//@children.393/@ports.0" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E576" sources="//@children.393/@ports.0" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E577" sources="//@children.393/@ports.0" targets="//@children.404/@ports.1"/>
+  <containedEdges identifier="E578" sources="//@children.393/@ports.0" targets="//@children.406/@ports.0"/>
+  <containedEdges identifier="E579" sources="//@children.394/@ports.0" targets="//@children.395/@ports.1"/>
+  <containedEdges identifier="E580" sources="//@children.394/@ports.0" targets="//@children.306/@ports.1"/>
+  <containedEdges identifier="E581" sources="//@children.394/@ports.0" targets="//@children.350/@ports.1"/>
+  <containedEdges identifier="E582" sources="//@children.394/@ports.0" targets="//@children.392/@ports.1"/>
+  <containedEdges identifier="E583" sources="//@children.395/@ports.0" targets="//@children.396/@ports.1"/>
+  <containedEdges identifier="E584" sources="//@children.395/@ports.0" targets="//@children.397/@ports.1"/>
+  <containedEdges identifier="E585" sources="//@children.395/@ports.0" targets="//@children.398/@ports.1"/>
+  <containedEdges identifier="E586" sources="//@children.396/@ports.2" targets="//@children.399/@ports.0"/>
+  <containedEdges identifier="E587" sources="//@children.397/@ports.2" targets="//@children.399/@ports.0"/>
+  <containedEdges identifier="E588" sources="//@children.398/@ports.2" targets="//@children.399/@ports.0"/>
+  <containedEdges identifier="E589" sources="//@children.400/@ports.1" targets="//@children.403/@ports.0"/>
+  <containedEdges identifier="E590" sources="//@children.401/@ports.2" targets="//@children.400/@ports.2"/>
+  <containedEdges identifier="E591" sources="//@children.401/@ports.2" targets="//@children.402/@ports.2"/>
+  <containedEdges identifier="E592" sources="//@children.402/@ports.1" targets="//@children.403/@ports.1"/>
+  <containedEdges identifier="E593" sources="//@children.403/@ports.2" targets="//@children.411/@ports.1"/>
+  <containedEdges identifier="E594" sources="//@children.403/@ports.2" targets="//@children.413/@ports.0"/>
+  <containedEdges identifier="E595" sources="//@children.403/@ports.2" targets="//@children.418/@ports.1"/>
+  <containedEdges identifier="E596" sources="//@children.403/@ports.2" targets="//@children.420/@ports.0"/>
+  <containedEdges identifier="E597" sources="//@children.404/@ports.2" targets="//@children.405/@ports.2"/>
+  <containedEdges identifier="E598" sources="//@children.404/@ports.2" targets="//@children.406/@ports.2"/>
+  <containedEdges identifier="E599" sources="//@children.405/@ports.1" targets="//@children.407/@ports.0"/>
+  <containedEdges identifier="E600" sources="//@children.406/@ports.1" targets="//@children.407/@ports.1"/>
+  <containedEdges identifier="E601" sources="//@children.407/@ports.2" targets="//@children.431/@ports.1"/>
+  <containedEdges identifier="E602" sources="//@children.407/@ports.2" targets="//@children.433/@ports.0"/>
+  <containedEdges identifier="E603" sources="//@children.407/@ports.2" targets="//@children.438/@ports.1"/>
+  <containedEdges identifier="E604" sources="//@children.407/@ports.2" targets="//@children.440/@ports.0"/>
+  <containedEdges identifier="E605" sources="//@children.408/@ports.0" targets="//@children.410/@ports.1"/>
+  <containedEdges identifier="E606" sources="//@children.409/@ports.0" targets="//@children.410/@ports.2"/>
+  <containedEdges identifier="E607" sources="//@children.410/@ports.0" targets="//@children.140/@ports.0"/>
+  <containedEdges identifier="E608" sources="//@children.411/@ports.0" targets="//@children.412/@ports.0"/>
+  <containedEdges identifier="E609" sources="//@children.412/@ports.1" targets="//@children.416/@ports.0"/>
+  <containedEdges identifier="E610" sources="//@children.412/@ports.1" targets="//@children.417/@ports.0"/>
+  <containedEdges identifier="E611" sources="//@children.413/@ports.1" targets="//@children.415/@ports.0"/>
+  <containedEdges identifier="E612" sources="//@children.414/@ports.2" targets="//@children.425/@ports.0"/>
+  <containedEdges identifier="E613" sources="//@children.414/@ports.2" targets="//@children.408/@ports.1"/>
+  <containedEdges identifier="E614" sources="//@children.415/@ports.1" targets="//@children.414/@ports.0"/>
+  <containedEdges identifier="E615" sources="//@children.416/@ports.1" targets="//@children.414/@ports.1"/>
+  <containedEdges identifier="E616" sources="//@children.416/@ports.1" targets="//@children.423/@ports.0"/>
+  <containedEdges identifier="E617" sources="//@children.416/@ports.1" targets="//@children.426/@ports.0"/>
+  <containedEdges identifier="E618" sources="//@children.416/@ports.1" targets="//@children.427/@ports.1"/>
+  <containedEdges identifier="E619" sources="//@children.417/@ports.1" targets="//@children.419/@ports.0"/>
+  <containedEdges identifier="E620" sources="//@children.418/@ports.0" targets="//@children.417/@ports.0"/>
+  <containedEdges identifier="E621" sources="//@children.419/@ports.1" targets="//@children.415/@ports.2"/>
+  <containedEdges identifier="E622" sources="//@children.419/@ports.1" targets="//@children.416/@ports.2"/>
+  <containedEdges identifier="E623" sources="//@children.419/@ports.1" targets="//@children.422/@ports.2"/>
+  <containedEdges identifier="E624" sources="//@children.420/@ports.1" targets="//@children.421/@ports.0"/>
+  <containedEdges identifier="E625" sources="//@children.421/@ports.1" targets="//@children.422/@ports.0"/>
+  <containedEdges identifier="E626" sources="//@children.422/@ports.1" targets="//@children.424/@ports.0"/>
+  <containedEdges identifier="E627" sources="//@children.423/@ports.2" targets="//@children.424/@ports.1"/>
+  <containedEdges identifier="E628" sources="//@children.424/@ports.2" targets="//@children.428/@ports.0"/>
+  <containedEdges identifier="E629" sources="//@children.425/@ports.1" targets="//@children.423/@ports.0"/>
+  <containedEdges identifier="E630" sources="//@children.426/@ports.2" targets="//@children.429/@ports.0"/>
+  <containedEdges identifier="E631" sources="//@children.427/@ports.0" targets="//@children.426/@ports.1"/>
+  <containedEdges identifier="E632" sources="//@children.428/@ports.2" targets="//@children.430/@ports.0"/>
+  <containedEdges identifier="E633" sources="//@children.429/@ports.1" targets="//@children.428/@ports.1"/>
+  <containedEdges identifier="E634" sources="//@children.430/@ports.1" targets="//@children.408/@ports.2"/>
+  <containedEdges identifier="E635" sources="//@children.431/@ports.0" targets="//@children.432/@ports.0"/>
+  <containedEdges identifier="E636" sources="//@children.432/@ports.1" targets="//@children.436/@ports.0"/>
+  <containedEdges identifier="E637" sources="//@children.432/@ports.1" targets="//@children.437/@ports.0"/>
+  <containedEdges identifier="E638" sources="//@children.433/@ports.1" targets="//@children.435/@ports.0"/>
+  <containedEdges identifier="E639" sources="//@children.434/@ports.2" targets="//@children.445/@ports.0"/>
+  <containedEdges identifier="E640" sources="//@children.434/@ports.2" targets="//@children.409/@ports.1"/>
+  <containedEdges identifier="E641" sources="//@children.435/@ports.1" targets="//@children.434/@ports.0"/>
+  <containedEdges identifier="E642" sources="//@children.436/@ports.1" targets="//@children.434/@ports.1"/>
+  <containedEdges identifier="E643" sources="//@children.436/@ports.1" targets="//@children.443/@ports.0"/>
+  <containedEdges identifier="E644" sources="//@children.436/@ports.1" targets="//@children.446/@ports.0"/>
+  <containedEdges identifier="E645" sources="//@children.436/@ports.1" targets="//@children.447/@ports.1"/>
+  <containedEdges identifier="E646" sources="//@children.437/@ports.1" targets="//@children.439/@ports.0"/>
+  <containedEdges identifier="E647" sources="//@children.438/@ports.0" targets="//@children.437/@ports.0"/>
+  <containedEdges identifier="E648" sources="//@children.439/@ports.1" targets="//@children.435/@ports.2"/>
+  <containedEdges identifier="E649" sources="//@children.439/@ports.1" targets="//@children.436/@ports.2"/>
+  <containedEdges identifier="E650" sources="//@children.439/@ports.1" targets="//@children.442/@ports.2"/>
+  <containedEdges identifier="E651" sources="//@children.440/@ports.1" targets="//@children.441/@ports.0"/>
+  <containedEdges identifier="E652" sources="//@children.441/@ports.1" targets="//@children.442/@ports.0"/>
+  <containedEdges identifier="E653" sources="//@children.442/@ports.1" targets="//@children.444/@ports.0"/>
+  <containedEdges identifier="E654" sources="//@children.443/@ports.2" targets="//@children.444/@ports.1"/>
+  <containedEdges identifier="E655" sources="//@children.444/@ports.2" targets="//@children.448/@ports.0"/>
+  <containedEdges identifier="E656" sources="//@children.445/@ports.1" targets="//@children.443/@ports.0"/>
+  <containedEdges identifier="E657" sources="//@children.446/@ports.2" targets="//@children.449/@ports.0"/>
+  <containedEdges identifier="E658" sources="//@children.447/@ports.0" targets="//@children.446/@ports.1"/>
+  <containedEdges identifier="E659" sources="//@children.448/@ports.2" targets="//@children.450/@ports.0"/>
+  <containedEdges identifier="E660" sources="//@children.449/@ports.1" targets="//@children.448/@ports.1"/>
+  <containedEdges identifier="E661" sources="//@children.450/@ports.1" targets="//@children.409/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/dt_pickstates_pickstates.elkg
+++ b/realworld/ptolemy/flattened/dt_pickstates_pickstates.elkg
@@ -1,0 +1,2315 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="97.0" text="Pulse keyframes"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="Current time"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="ViewScreen2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="44.0" text="red ring"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="58.0" text="green ring"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="63.0" text="Switch3D1"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.181 //@containedEdges.182 //@containedEdges.183 //@containedEdges.184 //@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="64.0" text="Scale3D23"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22 //@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="62.0" text="Rotate3D1"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="63.0" text="Switch3D2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.180 //@containedEdges.185 //@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="57.0" text="Scale3D5"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.27 //@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.23 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.25 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24 //@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.30 //@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.31 //@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="107.0" text="CircularSweep3D0"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="107.0" text="CircularSweep3D1"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="84.0" text="Translate3D14"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="107.0" text="CircularSweep3D6"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="107.0" text="CircularSweep3D2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="31.0" text="Box3"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.38 //@containedEdges.42 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="31.0" text="Box2"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="31.0" text="Box4"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="77.0" text="Translate3D8"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32 //@containedEdges.36 //@containedEdges.37 //@containedEdges.44 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="57.0" text="Scale3D0"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.55 //@containedEdges.58 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63 //@containedEdges.67 //@containedEdges.68 //@containedEdges.69 //@containedEdges.72 //@containedEdges.73 //@containedEdges.77 //@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="31.0" text="Box4"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="31.0" text="Box2"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="31.0" text="Box3"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="31.0" text="Box5"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="84.0" text="Translate3D15"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="84.0" text="Translate3D22"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="38.0" text="Box23"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="31.0" text="Box7"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="31.0" text="Box8"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="31.0" text="Box9"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="38.0" text="Box10"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.75 //@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="84.0" text="Translate3D13"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="55.0" text="Cylinder0"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="53.0" text="Rotate24"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="107.0" text="CircularSweep3D0"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="45.0" text="PolyCyl"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="46.0" text="Rotate8"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="107.0" text="CircularSweep3D1"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="57.0" text="Scale3D4"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="103.0" text="PolyCylinder3D11"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="53.0" text="Rotate12"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="53.0" text="Rotate13"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="84.0" text="Translate3D14"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="84.0" text="Translate3D15"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.90 //@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="38.0" text="Box28"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="46.0" text="Rotate9"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.86 //@containedEdges.87 //@containedEdges.95 //@containedEdges.98 //@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="53.0" text="Rotate10"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="64.0" text="Scale3D15"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.100 //@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="53.0" text="Rotate27"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="84.0" text="Translate3D22"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="45.0" text="PolyCyl"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="46.0" text="Rotate1"/>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.108 //@containedEdges.116 //@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="46.0" text="Rotate6"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.109 //@containedEdges.123 //@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="53.0" text="Rotate13"/>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="31.0" text="Box7"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.114 //@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="38.0" text="Box10"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="38.0" text="Box14"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.119 //@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="97.0" text="PolyCylinder3D1"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.124 //@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="46.0" text="Rotate5"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="97.0" text="PolyCylinder3D2"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="104.0" text="PolyCylinder3D24"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.129 //@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="46.0" text="Rotate7"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="104.0" text="PolyCylinder3D27"/>
+    <ports identifier="P213" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="84.0" text="Translate3D28"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.110 //@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="53.0" text="Rotate14"/>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="53.0" text="Rotate30"/>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="97.0" text="PolyCylinder3D4"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="31.0" text="Box5"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="77.0" text="Translate3D8"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.137 //@containedEdges.139 //@containedEdges.141 //@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="104.0" text="PolyCylinder3D13"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="64.0" text="Scale3D10"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="53.0" text="Rotate17"/>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="57.0" text="Scale3D0"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.150 //@containedEdges.155 //@containedEdges.157 //@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P248" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P249" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.152 //@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="47.0" text="Box3D0"/>
+    <ports identifier="P256" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="54.0" text="table_top"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.160 //@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="61.0" text="slot_stand"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.162 //@containedEdges.167 //@containedEdges.168 //@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="68.0" text="slot1_stand"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="68.0" text="slot2_stand"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="68.0" text="slot3_stand"/>
+    <ports identifier="P267" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="84.0" text="Translate3D16"/>
+    <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.164 //@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="84.0" text="Translate3D19"/>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.165 //@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="84.0" text="Translate3D22"/>
+    <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.166 //@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P275" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P279" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="47.0" text="Switch1"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.174 //@containedEdges.175 //@containedEdges.176 //@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="119.0" text="FSM_motor_number"/>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="119.0" text="FSM_motor_number"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="54.0" text="controller"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P290" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="92.0" text="red_refinements"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P293" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="42.0" text="Const0"/>
+    <ports identifier="P299" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P301" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P303" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.163/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.165/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.166/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.168/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.169/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.170/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.171/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.172/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.173/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.174/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.3/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.5/@ports.1" targets="//@children.160/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.5/@ports.1" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.6/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.7/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.8/@ports.1" targets="//@children.159/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.9/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.14/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.15/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.17/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.19/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.20/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.21/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E35" sources="//@children.22/@ports.3" targets="//@children.24/@ports.3"/>
+  <containedEdges identifier="E36" sources="//@children.23/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.24/@ports.4" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.25/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.26/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.27/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.28/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.29/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.30/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.31/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.32/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.33/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.34/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.35/@ports.0" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.36/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.37/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.38/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.39/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.40/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.41/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.42/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.43/@ports.0" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.44/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.45/@ports.0" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.46/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.47/@ports.0" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.48/@ports.0" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.49/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.50/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.51/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.52/@ports.0" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.53/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.54/@ports.0" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.55/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.56/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.57/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.58/@ports.0" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.59/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.60/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.61/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.62/@ports.0" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.63/@ports.0" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.64/@ports.0" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.65/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.66/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.67/@ports.0" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.68/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.69/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.70/@ports.0" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.71/@ports.0" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.72/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.73/@ports.1" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.74/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.75/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.76/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.77/@ports.1" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.78/@ports.1" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.79/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.80/@ports.1" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.81/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.82/@ports.1" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.83/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.84/@ports.0" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.85/@ports.0" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.86/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.87/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.88/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.89/@ports.1" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.90/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.91/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.92/@ports.0" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.93/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.94/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.95/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.96/@ports.0" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.97/@ports.0" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.98/@ports.1" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.99/@ports.1" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.100/@ports.1" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.101/@ports.1" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.102/@ports.0" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.103/@ports.1" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.104/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.105/@ports.0" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.106/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.107/@ports.0" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.108/@ports.0" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.109/@ports.1" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.110/@ports.1" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.111/@ports.1" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.112/@ports.0" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.113/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.114/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.115/@ports.0" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.116/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.117/@ports.0" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.118/@ports.1" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.119/@ports.1" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.120/@ports.0" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.121/@ports.1" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E135" sources="//@children.122/@ports.1" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.123/@ports.1" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E137" sources="//@children.124/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.125/@ports.0" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E139" sources="//@children.126/@ports.0" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.127/@ports.1" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.128/@ports.0" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.129/@ports.1" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.130/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.131/@ports.0" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E145" sources="//@children.132/@ports.1" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.133/@ports.0" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.134/@ports.1" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.135/@ports.1" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E149" sources="//@children.136/@ports.1" targets="//@children.135/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.137/@ports.1" targets="//@children.138/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.138/@ports.1" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.139/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.140/@ports.0" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.141/@ports.0" targets="//@children.144/@ports.0"/>
+  <containedEdges identifier="E155" sources="//@children.142/@ports.0" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.143/@ports.1" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.144/@ports.1" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E158" sources="//@children.145/@ports.1" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.146/@ports.0" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E160" sources="//@children.147/@ports.1" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E161" sources="//@children.148/@ports.0" targets="//@children.149/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.149/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.150/@ports.0" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E164" sources="//@children.151/@ports.1" targets="//@children.149/@ports.0"/>
+  <containedEdges identifier="E165" sources="//@children.152/@ports.0" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E166" sources="//@children.153/@ports.0" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E167" sources="//@children.154/@ports.0" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E168" sources="//@children.155/@ports.1" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E169" sources="//@children.156/@ports.1" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E170" sources="//@children.157/@ports.1" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E171" sources="//@children.158/@ports.1" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E172" sources="//@children.159/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.160/@ports.1" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E174" sources="//@children.161/@ports.1" targets="//@children.162/@ports.0"/>
+  <containedEdges identifier="E175" sources="//@children.162/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E176" sources="//@children.162/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E177" sources="//@children.162/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E178" sources="//@children.162/@ports.1" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E179" sources="//@children.163/@ports.1" targets="//@children.162/@ports.2"/>
+  <containedEdges identifier="E180" sources="//@children.164/@ports.1" targets="//@children.161/@ports.0"/>
+  <containedEdges identifier="E181" sources="//@children.166/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E182" sources="//@children.168/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E183" sources="//@children.169/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E184" sources="//@children.170/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E185" sources="//@children.171/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E186" sources="//@children.172/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E187" sources="//@children.173/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E188" sources="//@children.174/@ports.0" targets="//@children.8/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/fmi_fmutwoballcollision_CollisionNoFMU.elkg
+++ b/realworld/ptolemy/flattened/fmi_fmutwoballcollision_CollisionNoFMU.elkg
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="LeftBall"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="52.0" text="RightBall"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="71.0" text="PlotPosition"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="69.0" text="PlotVelocity"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="141.0" text="CalculateImpulsiveForce"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13 //@containedEdges.19 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.1" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.10/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.4" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.2" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.0" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/fmi_fmutwoballcollision_FMUTwoBallCollision.elkg
+++ b/realworld/ptolemy/flattened/fmi_fmutwoballcollision_FMUTwoBallCollision.elkg
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="LeftBall"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="71.0" text="PlotPosition"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="69.0" text="PlotVelocity"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="141.0" text="CalculateImpulsiveForce"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.15 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="78.0" text="ballDynamics"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.4" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.3" targets="//@children.9/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/fmipp_generatorcontactorload_GeneratorContactorLoad.elkg
+++ b/realworld/ptolemy/flattened/fmipp_generatorcontactorload_GeneratorContactorLoad.elkg
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="174.0" text="GeneratorContractorLoadFMU"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/g4ltl_errorhandling_ErrorHandlingSynthesized.elkg
+++ b/realworld/ptolemy/flattened/g4ltl_errorhandling_ErrorHandlingSynthesized.elkg
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Client2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Client1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="29.0" text="Error"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="51.0" text="Operator"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="SetVariable7"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="23.0" text="Sec"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="43.0" text="model1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.1" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.4" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.5" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.6" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/g4ltl_numerical_Numerical.elkg
+++ b/realworld/ptolemy/flattened/g4ltl_numerical_Numerical.elkg
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Pulse"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="9.0" text="X"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="9.0" text="Y"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="8.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="94.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="91.0" text="Display Results"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="82.0" text="Display Inputs"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="42.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Expression5"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6 //@containedEdges.14 //@containedEdges.22 //@containedEdges.23 //@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="35.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="35.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="45.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="45.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29 //@containedEdges.30 //@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.2/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.3" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.4/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.5/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.5/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.8/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.10/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.12/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.13/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.14/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.15/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.16/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.19/@ports.2" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gr_inversekinematics_InverseKinematics.elkg
+++ b/realworld/ptolemy/flattened/gr_inversekinematics_InverseKinematics.elkg
@@ -1,0 +1,4433 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="ViewScreen0"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="25.0" text="floor"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="MouseInput"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="orig_endx"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="56.0" text="orig_endy"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="62.0" text="orig_wristx"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="62.0" text="orig_wristy"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.29 //@containedEdges.30 //@containedEdges.31 //@containedEdges.32 //@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="orig_elbowx"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="68.0" text="orig_elbowy"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.43 //@containedEdges.44 //@containedEdges.45 //@containedEdges.46 //@containedEdges.47 //@containedEdges.48 //@containedEdges.49 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="48.0" text="Delay46"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="48.0" text="Delay47"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="48.0" text="Delay48"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="48.0" text="Delay49"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="48.0" text="Delay50"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="48.0" text="Delay51"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="63.0" text="Sampler64"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.57 //@containedEdges.58 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="63.0" text="Sampler65"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.60 //@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="63.0" text="Sampler66"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.63 //@containedEdges.64 //@containedEdges.65 //@containedEdges.66 //@containedEdges.67 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.295">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="63.0" text="Sampler67"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.69 //@containedEdges.70 //@containedEdges.71 //@containedEdges.72 //@containedEdges.73 //@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="63.0" text="Sampler68"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.75 //@containedEdges.76 //@containedEdges.77 //@containedEdges.78 //@containedEdges.79 //@containedEdges.80 //@containedEdges.81 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="63.0" text="Sampler69"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.83 //@containedEdges.84 //@containedEdges.85 //@containedEdges.86 //@containedEdges.87 //@containedEdges.88 //@containedEdges.89 //@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="41.0" text="Delay0"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="41.0" text="Delay1"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="56.0" text="Sampler3"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="51.0" text="Merge20"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.95 //@containedEdges.96 //@containedEdges.97 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="51.0" text="Merge21"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.99 //@containedEdges.100 //@containedEdges.101 //@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="88.0" text="shoulder_angle"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.103 //@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="80.0" text="AddSubtract6"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.104 //@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="41.0" text="Delay7"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.106 //@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="63.0" text="Sampler14"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.301">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="44.0" text="Merge1"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.109 //@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="32.0" text="zerox"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.111 //@containedEdges.112 //@containedEdges.113 //@containedEdges.114 //@containedEdges.115 //@containedEdges.116 //@containedEdges.117 //@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="32.0" text="zeroy"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.119 //@containedEdges.120 //@containedEdges.121 //@containedEdges.122 //@containedEdges.123 //@containedEdges.124 //@containedEdges.125 //@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="80.0" text="AddSubtract7"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.128 //@containedEdges.129 //@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract8"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.131 //@containedEdges.132 //@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="80.0" text="AddSubtract1"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.134 //@containedEdges.135 //@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.137 //@containedEdges.138 //@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="79.0" text="TrigFunction1"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="180.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="71.0" text="AxBx_AyBy"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="72.0" text="Maximum10"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.143 //@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="67.0" text="Minimum11"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.141 //@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="49.0" text="Const13"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="106.0" text="CartesianToPolar1"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="31.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="106.0" text="CartesianToPolar2"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="31.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="68.0" text="AxBy-AyBx"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="94.0" text="MultiplyDivide12"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.140 //@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.149 //@containedEdges.150 //@containedEdges.151 //@containedEdges.152 //@containedEdges.153 //@containedEdges.154 //@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="36.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="87.0" text="MathFunction1"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="79.0" text="TrigFunction5"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.157 //@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="79.0" text="TrigFunction6"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.159 //@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="25.0" width="234.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="80.0" text="Expression15"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="80.0" text="Expression16"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="79.0" text="TrigFunction5"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.163 //@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="79.0" text="TrigFunction6"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.165 //@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="25.0" width="234.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="80.0" text="Expression15"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="80.0" text="Expression16"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="79.0" text="TrigFunction5"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.169 //@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="79.0" text="TrigFunction6"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.171 //@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="25.0" width="234.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="80.0" text="Expression15"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.35 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.43 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="25.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="80.0" text="Expression16"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.36 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.44 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="72.0" text="elbow_angle"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.175 //@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.176 //@containedEdges.177 //@containedEdges.178 //@containedEdges.179 //@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="80.0" text="AddSubtract6"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.176 //@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="41.0" text="Delay7"/>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.182 //@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="63.0" text="Sampler14"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="41.0" text="Scale1"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="61.0" text="Minimum3"/>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.193 //@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.186 //@containedEdges.187 //@containedEdges.188 //@containedEdges.189 //@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="22.0" text="min"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="72.0" text="Maximum21"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.191 //@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="25.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="25.0" text="max"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="34.0" y="8.5" outgoingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="87.0" text="AddSubtract27"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="80.0" text="AddSubtract7"/>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.37 //@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.196 //@containedEdges.197 //@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="80.0" text="AddSubtract8"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.45 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.199 //@containedEdges.200 //@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="80.0" text="AddSubtract1"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38 //@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.202 //@containedEdges.203 //@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.46 //@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.205 //@containedEdges.206 //@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="79.0" text="TrigFunction1"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="25.0" width="180.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="71.0" text="AxBx_AyBy"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="72.0" text="Maximum10"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.211 //@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="67.0" text="Minimum11"/>
+    <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.209 //@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="49.0" text="Const13"/>
+    <ports identifier="P249" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="106.0" text="CartesianToPolar1"/>
+    <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="31.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="106.0" text="CartesianToPolar2"/>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="31.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="68.0" text="AxBy-AyBx"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="94.0" text="MultiplyDivide12"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.208 //@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="36.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="87.0" text="MathFunction1"/>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="79.0" text="TrigFunction5"/>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.219 //@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="79.0" text="TrigFunction6"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.221 //@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="25.0" width="234.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="80.0" text="Expression15"/>
+    <ports identifier="P273" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@containedEdges.223 //@containedEdges.224 //@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.39 //@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.47 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.287">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.219">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="25.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="80.0" text="Expression16"/>
+    <ports identifier="P280" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@containedEdges.226 //@containedEdges.227 //@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.40 //@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.48 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="79.0" text="TrigFunction5"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.229 //@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="79.0" text="TrigFunction6"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.231 //@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="25.0" width="234.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="80.0" text="Expression15"/>
+    <ports identifier="P291" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@containedEdges.233 //@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.41 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.49 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.23 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.29 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="25.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="80.0" text="Expression16"/>
+    <ports identifier="P298" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@containedEdges.235 //@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.42 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.50 //@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.24 //@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.30 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="25.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="66.0" text="wrist_angle"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="34.0" y="8.5" outgoingEdges="//@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.237 //@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.238 //@containedEdges.239 //@containedEdges.240 //@containedEdges.241 //@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="80.0" text="AddSubtract6"/>
+    <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.238 //@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P311" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="41.0" text="Delay7"/>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.244 //@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="63.0" text="Sampler14"/>
+    <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P316" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.304">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="61.0" text="Minimum3"/>
+    <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.253 //@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P320" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.248 //@containedEdges.249 //@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="22.0" text="min"/>
+    <ports identifier="P325" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="72.0" text="Maximum21"/>
+    <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.251 //@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P329" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="25.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="25.0" text="max"/>
+    <ports identifier="P330" height="8.0" width="8.0" x="34.0" y="8.5" outgoingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="87.0" text="AddSubtract27"/>
+    <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="80.0" text="AddSubtract7"/>
+    <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.25 //@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.256 //@containedEdges.257 //@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="80.0" text="AddSubtract8"/>
+    <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.31 //@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.259 //@containedEdges.260 //@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="80.0" text="AddSubtract1"/>
+    <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P343" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.262 //@containedEdges.263 //@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.32 //@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P346" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.265 //@containedEdges.266 //@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="79.0" text="TrigFunction1"/>
+    <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P348" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="25.0" width="180.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="71.0" text="AxBx_AyBy"/>
+    <ports identifier="P349" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.262">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="72.0" text="Maximum10"/>
+    <ports identifier="P356" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.271 //@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P357" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P358" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="67.0" text="Minimum11"/>
+    <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.269 //@containedEdges.273">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P360" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P361" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P362" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="49.0" text="Const13"/>
+    <ports identifier="P364" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.273">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="106.0" text="CartesianToPolar1"/>
+    <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P367" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P368" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P369" height="8.0" width="8.0" x="31.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="106.0" text="CartesianToPolar2"/>
+    <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P372" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P373" height="8.0" width="8.0" x="31.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="68.0" text="AxBy-AyBx"/>
+    <ports identifier="P374" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P377" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P378" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="94.0" text="MultiplyDivide12"/>
+    <ports identifier="P379" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.268 //@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P380" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P381" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="36.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="87.0" text="MathFunction1"/>
+    <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P383" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="79.0" text="TrigFunction5"/>
+    <ports identifier="P384" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P385" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.279 //@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="79.0" text="TrigFunction6"/>
+    <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P387" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.281 //@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="25.0" width="234.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="80.0" text="Expression15"/>
+    <ports identifier="P388" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@containedEdges.283 //@containedEdges.284 //@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.27 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P390" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.33 //@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.18 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.21 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="25.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="80.0" text="Expression16"/>
+    <ports identifier="P395" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@containedEdges.286 //@containedEdges.287 //@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P396" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@containedEdges.28 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@containedEdges.34 //@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@containedEdges.19 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@containedEdges.22 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P401" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P402" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P404" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.289 //@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P405" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="41.0" text="Delay5"/>
+    <ports identifier="P406" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P407" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.291 //@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P408" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P409" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.293 //@containedEdges.294 //@containedEdges.295 //@containedEdges.296 //@containedEdges.297 //@containedEdges.298 //@containedEdges.299 //@containedEdges.300 //@containedEdges.301 //@containedEdges.302 //@containedEdges.303 //@containedEdges.304">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="165.0" text="decrement and check if Zero"/>
+    <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P411" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="57.0" text="Scale3D5"/>
+    <ports identifier="P412" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.311 //@containedEdges.425">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P413" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P415" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.307">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P416" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.307 //@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P417" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P418" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P420" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.309 //@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P422" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P424" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.308 //@containedEdges.434">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P425" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P426" height="8.0" width="8.0" x="-8.0" y="24.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P427" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.314 //@containedEdges.386">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P428" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P430" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P431" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.419">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P433" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="107.0" text="CircularSweep3D0"/>
+    <ports identifier="P434" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P435" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="107.0" text="CircularSweep3D1"/>
+    <ports identifier="P436" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P437" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P438" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P439" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P440" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P441" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P442" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P443" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P444" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P445" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P447" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P448" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="84.0" text="Translate3D14"/>
+    <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P450" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.320">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="107.0" text="CircularSweep3D6"/>
+    <ports identifier="P451" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="107.0" text="CircularSweep3D2"/>
+    <ports identifier="P452" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="31.0" text="Box3"/>
+    <ports identifier="P453" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P454" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P455" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P457" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P459" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.321 //@containedEdges.325 //@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P461" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P462" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P463" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.329">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="31.0" text="Box2"/>
+    <ports identifier="P464" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="31.0" text="Box4"/>
+    <ports identifier="P465" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="77.0" text="Translate3D8"/>
+    <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P467" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.329">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P469" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P471" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P472" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P473" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.315 //@containedEdges.319 //@containedEdges.320 //@containedEdges.327 //@containedEdges.332 //@containedEdges.333 //@containedEdges.334 //@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P475" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P476" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P477" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P478" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="57.0" text="Scale3D0"/>
+    <ports identifier="P479" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.338 //@containedEdges.341 //@containedEdges.344 //@containedEdges.345 //@containedEdges.346 //@containedEdges.350 //@containedEdges.351 //@containedEdges.352 //@containedEdges.355 //@containedEdges.356 //@containedEdges.360 //@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P480" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="31.0" text="Box4"/>
+    <ports identifier="P481" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P482" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P483" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P484" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="31.0" text="Box2"/>
+    <ports identifier="P485" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N176" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L176" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P486" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P487" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N177" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P489" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P490" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P491" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="31.0" text="Box3"/>
+    <ports identifier="P492" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="31.0" text="Box5"/>
+    <ports identifier="P493" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N181" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L181" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P494" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N182" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L182" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P496" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.350">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N183" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L183" height="15.0" width="84.0" text="Translate3D15"/>
+    <ports identifier="P497" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P498" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N184" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L184" height="15.0" width="84.0" text="Translate3D22"/>
+    <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.353">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P500" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N185" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L185" height="15.0" width="38.0" text="Box23"/>
+    <ports identifier="P501" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.353">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N186" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L186" height="15.0" width="31.0" text="Box7"/>
+    <ports identifier="P502" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N187" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L187" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P503" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P504" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N188" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L188" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P505" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P506" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N189" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L189" height="15.0" width="31.0" text="Box8"/>
+    <ports identifier="P507" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N190" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L190" height="15.0" width="31.0" text="Box9"/>
+    <ports identifier="P508" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.358">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N191" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L191" height="15.0" width="38.0" text="Box10"/>
+    <ports identifier="P509" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N192" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L192" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.358 //@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P511" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N193" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L193" height="15.0" width="84.0" text="Translate3D13"/>
+    <ports identifier="P512" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P513" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N194" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L194" height="15.0" width="55.0" text="Cylinder0"/>
+    <ports identifier="P514" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N195" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P516" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N196" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L196" height="15.0" width="53.0" text="Rotate24"/>
+    <ports identifier="P517" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P518" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N197" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L197" height="15.0" width="107.0" text="CircularSweep3D0"/>
+    <ports identifier="P519" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N198" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L198" height="15.0" width="45.0" text="PolyCyl"/>
+    <ports identifier="P520" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N199" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L199" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P522" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N200" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L200" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P523" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P524" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N201" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L201" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P525" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P526" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N202" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L202" height="15.0" width="46.0" text="Rotate8"/>
+    <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P528" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N203" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L203" height="15.0" width="107.0" text="CircularSweep3D1"/>
+    <ports identifier="P529" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.371">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N204" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L204" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.371">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P531" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N205" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L205" height="15.0" width="57.0" text="Scale3D4"/>
+    <ports identifier="P532" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P533" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.373">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N206" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L206" height="15.0" width="103.0" text="PolyCylinder3D11"/>
+    <ports identifier="P534" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.374">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N207" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L207" height="15.0" width="53.0" text="Rotate12"/>
+    <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.374">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P536" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N208" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L208" height="15.0" width="53.0" text="Rotate13"/>
+    <ports identifier="P537" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P538" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N209" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L209" height="15.0" width="84.0" text="Translate3D14"/>
+    <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P540" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.377">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N210" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L210" height="15.0" width="84.0" text="Translate3D15"/>
+    <ports identifier="P541" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.373 //@containedEdges.377">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P542" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.378">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N211" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L211" height="15.0" width="38.0" text="Box28"/>
+    <ports identifier="P543" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.379">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N212" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L212" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P544" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.380">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N213" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L213" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.379">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P546" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.381">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N214" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L214" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P547" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.380">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P548" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.382">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N215" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L215" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.385">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P550" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.383">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N216" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L216" height="15.0" width="46.0" text="Rotate9"/>
+    <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.369 //@containedEdges.370 //@containedEdges.378 //@containedEdges.381 //@containedEdges.382">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P552" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.384">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N217" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L217" height="15.0" width="53.0" text="Rotate10"/>
+    <ports identifier="P553" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.384">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P554" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.385">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N218" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L218" height="15.0" width="64.0" text="Scale3D15"/>
+    <ports identifier="P555" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.383 //@containedEdges.390">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P556" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.386">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N219" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L219" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P557" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.387">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N220" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L220" height="15.0" width="53.0" text="Rotate27"/>
+    <ports identifier="P558" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.387">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P559" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.388">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N221" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L221" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P560" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.388">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P561" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.389">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N222" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L222" height="15.0" width="84.0" text="Translate3D22"/>
+    <ports identifier="P562" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.389">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P563" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.390">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N223" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L223" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P564" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.391">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N224" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L224" height="15.0" width="45.0" text="PolyCyl"/>
+    <ports identifier="P565" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.392">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N225" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L225" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.396">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P567" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.393">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N226" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L226" height="15.0" width="46.0" text="Rotate1"/>
+    <ports identifier="P568" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.391 //@containedEdges.399 //@containedEdges.409">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P569" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.394">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N227" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L227" height="15.0" width="46.0" text="Rotate6"/>
+    <ports identifier="P570" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.392 //@containedEdges.406 //@containedEdges.414">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P571" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.395">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N228" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L228" height="15.0" width="53.0" text="Rotate13"/>
+    <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.395">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P573" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.396">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N229" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L229" height="15.0" width="31.0" text="Box7"/>
+    <ports identifier="P574" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.397">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N230" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L230" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.397 //@containedEdges.401">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P576" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.398">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N231" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L231" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.398">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P578" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.399">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N232" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L232" height="15.0" width="38.0" text="Box10"/>
+    <ports identifier="P579" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.400">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N233" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L233" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.400">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P581" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.401">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N234" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L234" height="15.0" width="38.0" text="Box14"/>
+    <ports identifier="P582" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.402">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N235" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L235" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P583" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.403">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N236" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L236" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P584" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.402 //@containedEdges.405">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P585" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.404">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N237" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L237" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.403">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P587" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.405">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N238" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L238" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P588" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.404">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P589" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.406">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N239" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L239" height="15.0" width="97.0" text="PolyCylinder3D1"/>
+    <ports identifier="P590" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.407">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N240" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L240" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.407 //@containedEdges.411">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P592" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.408">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N241" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L241" height="15.0" width="46.0" text="Rotate5"/>
+    <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.408">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P594" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.409">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N242" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L242" height="15.0" width="97.0" text="PolyCylinder3D2"/>
+    <ports identifier="P595" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.410">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N243" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L243" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.410">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P597" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.411">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N244" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L244" height="15.0" width="104.0" text="PolyCylinder3D24"/>
+    <ports identifier="P598" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.412">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N245" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L245" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.412 //@containedEdges.416">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P600" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.413">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N246" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L246" height="15.0" width="46.0" text="Rotate7"/>
+    <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.413">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P602" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.414">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N247" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L247" height="15.0" width="104.0" text="PolyCylinder3D27"/>
+    <ports identifier="P603" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.415">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N248" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L248" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P604" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.415">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P605" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.416">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N249" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L249" height="15.0" width="84.0" text="Translate3D28"/>
+    <ports identifier="P606" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.393 //@containedEdges.394">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P607" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.417">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N250" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L250" height="15.0" width="53.0" text="Rotate14"/>
+    <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.417">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P609" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.418">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N251" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L251" height="15.0" width="53.0" text="Rotate30"/>
+    <ports identifier="P610" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.418">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P611" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.419">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N252" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L252" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P612" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.420">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N253" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L253" height="15.0" width="97.0" text="PolyCylinder3D4"/>
+    <ports identifier="P613" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.421">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N254" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L254" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P614" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.421">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P615" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.422">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N255" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L255" height="15.0" width="31.0" text="Box5"/>
+    <ports identifier="P616" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.423">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N256" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L256" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.423">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P618" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.424">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N257" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L257" height="15.0" width="77.0" text="Translate3D8"/>
+    <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.420 //@containedEdges.422 //@containedEdges.424 //@containedEdges.427">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P620" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.425">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N258" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L258" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P621" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.426">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N259" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L259" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P622" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.426">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P623" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.427">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N260" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L260" height="15.0" width="104.0" text="PolyCylinder3D13"/>
+    <ports identifier="P624" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.428">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N261" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L261" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P625" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.428">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P626" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.429">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N262" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L262" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.431">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P628" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.430">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N263" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L263" height="15.0" width="64.0" text="Scale3D10"/>
+    <ports identifier="P629" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.429">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P630" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.431">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N264" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L264" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P631" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.430">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P632" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.432">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N265" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L265" height="15.0" width="53.0" text="Rotate17"/>
+    <ports identifier="P633" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.432">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P634" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.433">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N266" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L266" height="15.0" width="57.0" text="Scale3D0"/>
+    <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.433 //@containedEdges.438 //@containedEdges.440 //@containedEdges.442">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P636" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.434">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N267" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L267" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P637" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.435">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N268" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L268" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P638" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.436">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N269" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L269" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P639" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.437">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N270" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L270" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.435 //@containedEdges.439">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P641" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.438">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N271" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L271" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P642" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.436">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P643" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.439">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N272" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L272" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.437">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P645" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.440">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N273" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L273" height="15.0" width="47.0" text="Box3D0"/>
+    <ports identifier="P646" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.441">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N274" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L274" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P647" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.441">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P648" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.442">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.5/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.5/@ports.1" targets="//@children.66/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.5/@ports.1" targets="//@children.101/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.5/@ports.1" targets="//@children.132/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.6/@ports.0" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.6/@ports.0" targets="//@children.130/@ports.3"/>
+  <containedEdges identifier="E20" sources="//@children.6/@ports.0" targets="//@children.131/@ports.3"/>
+  <containedEdges identifier="E21" sources="//@children.7/@ports.0" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.7/@ports.0" targets="//@children.130/@ports.4"/>
+  <containedEdges identifier="E23" sources="//@children.7/@ports.0" targets="//@children.131/@ports.4"/>
+  <containedEdges identifier="E24" sources="//@children.8/@ports.0" targets="//@children.99/@ports.3"/>
+  <containedEdges identifier="E25" sources="//@children.8/@ports.0" targets="//@children.100/@ports.3"/>
+  <containedEdges identifier="E26" sources="//@children.8/@ports.0" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.8/@ports.0" targets="//@children.115/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.8/@ports.0" targets="//@children.130/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.8/@ports.0" targets="//@children.131/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.9/@ports.0" targets="//@children.99/@ports.4"/>
+  <containedEdges identifier="E31" sources="//@children.9/@ports.0" targets="//@children.100/@ports.4"/>
+  <containedEdges identifier="E32" sources="//@children.9/@ports.0" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.9/@ports.0" targets="//@children.116/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.9/@ports.0" targets="//@children.130/@ports.2"/>
+  <containedEdges identifier="E35" sources="//@children.9/@ports.0" targets="//@children.131/@ports.2"/>
+  <containedEdges identifier="E36" sources="//@children.10/@ports.0" targets="//@children.64/@ports.3"/>
+  <containedEdges identifier="E37" sources="//@children.10/@ports.0" targets="//@children.65/@ports.3"/>
+  <containedEdges identifier="E38" sources="//@children.10/@ports.0" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.10/@ports.0" targets="//@children.80/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.10/@ports.0" targets="//@children.95/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.10/@ports.0" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.10/@ports.0" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.10/@ports.0" targets="//@children.100/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.11/@ports.0" targets="//@children.64/@ports.4"/>
+  <containedEdges identifier="E45" sources="//@children.11/@ports.0" targets="//@children.65/@ports.4"/>
+  <containedEdges identifier="E46" sources="//@children.11/@ports.0" targets="//@children.79/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.11/@ports.0" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.11/@ports.0" targets="//@children.95/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.11/@ports.0" targets="//@children.96/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.11/@ports.0" targets="//@children.99/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.11/@ports.0" targets="//@children.100/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.12/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.13/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.14/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.15/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.16/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.17/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.18/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.18/@ports.1" targets="//@children.130/@ports.3"/>
+  <containedEdges identifier="E60" sources="//@children.18/@ports.1" targets="//@children.131/@ports.3"/>
+  <containedEdges identifier="E61" sources="//@children.19/@ports.1" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.19/@ports.1" targets="//@children.130/@ports.4"/>
+  <containedEdges identifier="E63" sources="//@children.19/@ports.1" targets="//@children.131/@ports.4"/>
+  <containedEdges identifier="E64" sources="//@children.20/@ports.1" targets="//@children.99/@ports.3"/>
+  <containedEdges identifier="E65" sources="//@children.20/@ports.1" targets="//@children.100/@ports.3"/>
+  <containedEdges identifier="E66" sources="//@children.20/@ports.1" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.20/@ports.1" targets="//@children.115/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.20/@ports.1" targets="//@children.130/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.20/@ports.1" targets="//@children.131/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.21/@ports.1" targets="//@children.99/@ports.4"/>
+  <containedEdges identifier="E71" sources="//@children.21/@ports.1" targets="//@children.100/@ports.4"/>
+  <containedEdges identifier="E72" sources="//@children.21/@ports.1" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.21/@ports.1" targets="//@children.116/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.21/@ports.1" targets="//@children.130/@ports.2"/>
+  <containedEdges identifier="E75" sources="//@children.21/@ports.1" targets="//@children.131/@ports.2"/>
+  <containedEdges identifier="E76" sources="//@children.22/@ports.1" targets="//@children.64/@ports.3"/>
+  <containedEdges identifier="E77" sources="//@children.22/@ports.1" targets="//@children.65/@ports.3"/>
+  <containedEdges identifier="E78" sources="//@children.22/@ports.1" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E79" sources="//@children.22/@ports.1" targets="//@children.80/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.22/@ports.1" targets="//@children.95/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.22/@ports.1" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E82" sources="//@children.22/@ports.1" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E83" sources="//@children.22/@ports.1" targets="//@children.100/@ports.1"/>
+  <containedEdges identifier="E84" sources="//@children.23/@ports.1" targets="//@children.64/@ports.4"/>
+  <containedEdges identifier="E85" sources="//@children.23/@ports.1" targets="//@children.65/@ports.4"/>
+  <containedEdges identifier="E86" sources="//@children.23/@ports.1" targets="//@children.79/@ports.1"/>
+  <containedEdges identifier="E87" sources="//@children.23/@ports.1" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.23/@ports.1" targets="//@children.95/@ports.2"/>
+  <containedEdges identifier="E89" sources="//@children.23/@ports.1" targets="//@children.96/@ports.2"/>
+  <containedEdges identifier="E90" sources="//@children.23/@ports.1" targets="//@children.99/@ports.2"/>
+  <containedEdges identifier="E91" sources="//@children.23/@ports.1" targets="//@children.100/@ports.2"/>
+  <containedEdges identifier="E92" sources="//@children.24/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.25/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.26/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.27/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.28/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.28/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.28/@ports.1" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.28/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.29/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.29/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.29/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.29/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.30/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.31/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.32/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.33/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.33/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.34/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.35/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.35/@ports.1" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E112" sources="//@children.36/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E113" sources="//@children.36/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E114" sources="//@children.36/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E115" sources="//@children.36/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E116" sources="//@children.36/@ports.0" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E117" sources="//@children.36/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E118" sources="//@children.36/@ports.0" targets="//@children.64/@ports.1"/>
+  <containedEdges identifier="E119" sources="//@children.36/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.37/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E121" sources="//@children.37/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E122" sources="//@children.37/@ports.0" targets="//@children.56/@ports.2"/>
+  <containedEdges identifier="E123" sources="//@children.37/@ports.0" targets="//@children.57/@ports.2"/>
+  <containedEdges identifier="E124" sources="//@children.37/@ports.0" targets="//@children.60/@ports.2"/>
+  <containedEdges identifier="E125" sources="//@children.37/@ports.0" targets="//@children.61/@ports.2"/>
+  <containedEdges identifier="E126" sources="//@children.37/@ports.0" targets="//@children.64/@ports.2"/>
+  <containedEdges identifier="E127" sources="//@children.37/@ports.0" targets="//@children.65/@ports.2"/>
+  <containedEdges identifier="E128" sources="//@children.38/@ports.1" targets="//@children.139/@ports.2"/>
+  <containedEdges identifier="E129" sources="//@children.39/@ports.2" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E130" sources="//@children.39/@ports.2" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.39/@ports.2" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E132" sources="//@children.40/@ports.2" targets="//@children.44/@ports.2"/>
+  <containedEdges identifier="E133" sources="//@children.40/@ports.2" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E134" sources="//@children.40/@ports.2" targets="//@children.51/@ports.2"/>
+  <containedEdges identifier="E135" sources="//@children.41/@ports.2" targets="//@children.44/@ports.3"/>
+  <containedEdges identifier="E136" sources="//@children.41/@ports.2" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E137" sources="//@children.41/@ports.2" targets="//@children.51/@ports.3"/>
+  <containedEdges identifier="E138" sources="//@children.42/@ports.2" targets="//@children.44/@ports.4"/>
+  <containedEdges identifier="E139" sources="//@children.42/@ports.2" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E140" sources="//@children.42/@ports.2" targets="//@children.51/@ports.4"/>
+  <containedEdges identifier="E141" sources="//@children.43/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.44/@ports.0" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.45/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.46/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E145" sources="//@children.47/@ports.0" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.48/@ports.0" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.49/@ports.2" targets="//@children.44/@ports.6"/>
+  <containedEdges identifier="E148" sources="//@children.50/@ports.2" targets="//@children.44/@ports.5"/>
+  <containedEdges identifier="E149" sources="//@children.51/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.52/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.52/@ports.2" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.52/@ports.2" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.52/@ports.2" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.52/@ports.2" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E155" sources="//@children.52/@ports.2" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.52/@ports.2" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.53/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E158" sources="//@children.54/@ports.1" targets="//@children.56/@ports.5"/>
+  <containedEdges identifier="E159" sources="//@children.54/@ports.1" targets="//@children.57/@ports.5"/>
+  <containedEdges identifier="E160" sources="//@children.55/@ports.1" targets="//@children.56/@ports.6"/>
+  <containedEdges identifier="E161" sources="//@children.55/@ports.1" targets="//@children.57/@ports.6"/>
+  <containedEdges identifier="E162" sources="//@children.56/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.57/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E164" sources="//@children.58/@ports.1" targets="//@children.60/@ports.5"/>
+  <containedEdges identifier="E165" sources="//@children.58/@ports.1" targets="//@children.61/@ports.5"/>
+  <containedEdges identifier="E166" sources="//@children.59/@ports.1" targets="//@children.60/@ports.6"/>
+  <containedEdges identifier="E167" sources="//@children.59/@ports.1" targets="//@children.61/@ports.6"/>
+  <containedEdges identifier="E168" sources="//@children.60/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E169" sources="//@children.61/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E170" sources="//@children.62/@ports.1" targets="//@children.64/@ports.5"/>
+  <containedEdges identifier="E171" sources="//@children.62/@ports.1" targets="//@children.65/@ports.5"/>
+  <containedEdges identifier="E172" sources="//@children.63/@ports.1" targets="//@children.64/@ports.6"/>
+  <containedEdges identifier="E173" sources="//@children.63/@ports.1" targets="//@children.65/@ports.6"/>
+  <containedEdges identifier="E174" sources="//@children.64/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E175" sources="//@children.65/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E176" sources="//@children.66/@ports.0" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E177" sources="//@children.67/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E178" sources="//@children.67/@ports.1" targets="//@children.73/@ports.1"/>
+  <containedEdges identifier="E179" sources="//@children.67/@ports.1" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E180" sources="//@children.67/@ports.1" targets="//@children.76/@ports.1"/>
+  <containedEdges identifier="E181" sources="//@children.67/@ports.1" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E182" sources="//@children.68/@ports.2" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E183" sources="//@children.69/@ports.1" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E184" sources="//@children.69/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E185" sources="//@children.70/@ports.1" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E186" sources="//@children.71/@ports.1" targets="//@children.141/@ports.2"/>
+  <containedEdges identifier="E187" sources="//@children.72/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E188" sources="//@children.72/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E189" sources="//@children.72/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E190" sources="//@children.72/@ports.1" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E191" sources="//@children.72/@ports.1" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.73/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E193" sources="//@children.74/@ports.0" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E194" sources="//@children.75/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E195" sources="//@children.76/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E196" sources="//@children.77/@ports.2" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E197" sources="//@children.78/@ports.2" targets="//@children.83/@ports.1"/>
+  <containedEdges identifier="E198" sources="//@children.78/@ports.2" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E199" sources="//@children.78/@ports.2" targets="//@children.90/@ports.1"/>
+  <containedEdges identifier="E200" sources="//@children.79/@ports.2" targets="//@children.83/@ports.2"/>
+  <containedEdges identifier="E201" sources="//@children.79/@ports.2" targets="//@children.89/@ports.1"/>
+  <containedEdges identifier="E202" sources="//@children.79/@ports.2" targets="//@children.90/@ports.2"/>
+  <containedEdges identifier="E203" sources="//@children.80/@ports.2" targets="//@children.83/@ports.3"/>
+  <containedEdges identifier="E204" sources="//@children.80/@ports.2" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E205" sources="//@children.80/@ports.2" targets="//@children.90/@ports.3"/>
+  <containedEdges identifier="E206" sources="//@children.81/@ports.2" targets="//@children.83/@ports.4"/>
+  <containedEdges identifier="E207" sources="//@children.81/@ports.2" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E208" sources="//@children.81/@ports.2" targets="//@children.90/@ports.4"/>
+  <containedEdges identifier="E209" sources="//@children.82/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E210" sources="//@children.83/@ports.0" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E211" sources="//@children.84/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E212" sources="//@children.85/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E213" sources="//@children.86/@ports.0" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E214" sources="//@children.87/@ports.0" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E215" sources="//@children.88/@ports.2" targets="//@children.83/@ports.6"/>
+  <containedEdges identifier="E216" sources="//@children.89/@ports.2" targets="//@children.83/@ports.5"/>
+  <containedEdges identifier="E217" sources="//@children.90/@ports.0" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E218" sources="//@children.91/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E219" sources="//@children.92/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E220" sources="//@children.93/@ports.1" targets="//@children.95/@ports.5"/>
+  <containedEdges identifier="E221" sources="//@children.93/@ports.1" targets="//@children.96/@ports.5"/>
+  <containedEdges identifier="E222" sources="//@children.94/@ports.1" targets="//@children.95/@ports.6"/>
+  <containedEdges identifier="E223" sources="//@children.94/@ports.1" targets="//@children.96/@ports.6"/>
+  <containedEdges identifier="E224" sources="//@children.95/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E225" sources="//@children.95/@ports.0" targets="//@children.56/@ports.3"/>
+  <containedEdges identifier="E226" sources="//@children.95/@ports.0" targets="//@children.57/@ports.3"/>
+  <containedEdges identifier="E227" sources="//@children.96/@ports.0" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E228" sources="//@children.96/@ports.0" targets="//@children.56/@ports.4"/>
+  <containedEdges identifier="E229" sources="//@children.96/@ports.0" targets="//@children.57/@ports.4"/>
+  <containedEdges identifier="E230" sources="//@children.97/@ports.1" targets="//@children.99/@ports.5"/>
+  <containedEdges identifier="E231" sources="//@children.97/@ports.1" targets="//@children.100/@ports.5"/>
+  <containedEdges identifier="E232" sources="//@children.98/@ports.1" targets="//@children.99/@ports.6"/>
+  <containedEdges identifier="E233" sources="//@children.98/@ports.1" targets="//@children.100/@ports.6"/>
+  <containedEdges identifier="E234" sources="//@children.99/@ports.0" targets="//@children.60/@ports.3"/>
+  <containedEdges identifier="E235" sources="//@children.99/@ports.0" targets="//@children.61/@ports.3"/>
+  <containedEdges identifier="E236" sources="//@children.100/@ports.0" targets="//@children.60/@ports.4"/>
+  <containedEdges identifier="E237" sources="//@children.100/@ports.0" targets="//@children.61/@ports.4"/>
+  <containedEdges identifier="E238" sources="//@children.101/@ports.0" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E239" sources="//@children.102/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E240" sources="//@children.102/@ports.1" targets="//@children.108/@ports.1"/>
+  <containedEdges identifier="E241" sources="//@children.102/@ports.1" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E242" sources="//@children.102/@ports.1" targets="//@children.111/@ports.1"/>
+  <containedEdges identifier="E243" sources="//@children.102/@ports.1" targets="//@children.112/@ports.1"/>
+  <containedEdges identifier="E244" sources="//@children.103/@ports.2" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E245" sources="//@children.104/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E246" sources="//@children.104/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E247" sources="//@children.105/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E248" sources="//@children.106/@ports.1" targets="//@children.144/@ports.2"/>
+  <containedEdges identifier="E249" sources="//@children.107/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E250" sources="//@children.107/@ports.1" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E251" sources="//@children.107/@ports.1" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E252" sources="//@children.108/@ports.2" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E253" sources="//@children.109/@ports.0" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E254" sources="//@children.110/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E255" sources="//@children.111/@ports.0" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E256" sources="//@children.112/@ports.2" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E257" sources="//@children.113/@ports.2" targets="//@children.118/@ports.1"/>
+  <containedEdges identifier="E258" sources="//@children.113/@ports.2" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E259" sources="//@children.113/@ports.2" targets="//@children.125/@ports.1"/>
+  <containedEdges identifier="E260" sources="//@children.114/@ports.2" targets="//@children.118/@ports.2"/>
+  <containedEdges identifier="E261" sources="//@children.114/@ports.2" targets="//@children.124/@ports.1"/>
+  <containedEdges identifier="E262" sources="//@children.114/@ports.2" targets="//@children.125/@ports.2"/>
+  <containedEdges identifier="E263" sources="//@children.115/@ports.2" targets="//@children.118/@ports.3"/>
+  <containedEdges identifier="E264" sources="//@children.115/@ports.2" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E265" sources="//@children.115/@ports.2" targets="//@children.125/@ports.3"/>
+  <containedEdges identifier="E266" sources="//@children.116/@ports.2" targets="//@children.118/@ports.4"/>
+  <containedEdges identifier="E267" sources="//@children.116/@ports.2" targets="//@children.123/@ports.1"/>
+  <containedEdges identifier="E268" sources="//@children.116/@ports.2" targets="//@children.125/@ports.4"/>
+  <containedEdges identifier="E269" sources="//@children.117/@ports.1" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E270" sources="//@children.118/@ports.0" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E271" sources="//@children.119/@ports.1" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E272" sources="//@children.120/@ports.1" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E273" sources="//@children.121/@ports.0" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E274" sources="//@children.122/@ports.0" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E275" sources="//@children.123/@ports.2" targets="//@children.118/@ports.6"/>
+  <containedEdges identifier="E276" sources="//@children.124/@ports.2" targets="//@children.118/@ports.5"/>
+  <containedEdges identifier="E277" sources="//@children.125/@ports.0" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E278" sources="//@children.126/@ports.2" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E279" sources="//@children.127/@ports.1" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E280" sources="//@children.128/@ports.1" targets="//@children.130/@ports.5"/>
+  <containedEdges identifier="E281" sources="//@children.128/@ports.1" targets="//@children.131/@ports.5"/>
+  <containedEdges identifier="E282" sources="//@children.129/@ports.1" targets="//@children.130/@ports.6"/>
+  <containedEdges identifier="E283" sources="//@children.129/@ports.1" targets="//@children.131/@ports.6"/>
+  <containedEdges identifier="E284" sources="//@children.130/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E285" sources="//@children.130/@ports.0" targets="//@children.95/@ports.3"/>
+  <containedEdges identifier="E286" sources="//@children.130/@ports.0" targets="//@children.96/@ports.3"/>
+  <containedEdges identifier="E287" sources="//@children.131/@ports.0" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E288" sources="//@children.131/@ports.0" targets="//@children.95/@ports.4"/>
+  <containedEdges identifier="E289" sources="//@children.131/@ports.0" targets="//@children.96/@ports.4"/>
+  <containedEdges identifier="E290" sources="//@children.132/@ports.0" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E291" sources="//@children.133/@ports.1" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E292" sources="//@children.134/@ports.1" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E293" sources="//@children.134/@ports.1" targets="//@children.135/@ports.0"/>
+  <containedEdges identifier="E294" sources="//@children.135/@ports.1" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E295" sources="//@children.135/@ports.1" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E296" sources="//@children.135/@ports.1" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E297" sources="//@children.135/@ports.1" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E298" sources="//@children.135/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E299" sources="//@children.135/@ports.1" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E300" sources="//@children.135/@ports.1" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E301" sources="//@children.135/@ports.1" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E302" sources="//@children.135/@ports.1" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E303" sources="//@children.135/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E304" sources="//@children.135/@ports.1" targets="//@children.70/@ports.2"/>
+  <containedEdges identifier="E305" sources="//@children.135/@ports.1" targets="//@children.105/@ports.2"/>
+  <containedEdges identifier="E306" sources="//@children.136/@ports.1" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E307" sources="//@children.137/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E308" sources="//@children.138/@ports.1" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E309" sources="//@children.139/@ports.1" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E310" sources="//@children.140/@ports.1" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E311" sources="//@children.141/@ports.1" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E312" sources="//@children.142/@ports.1" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E313" sources="//@children.143/@ports.1" targets="//@children.144/@ports.0"/>
+  <containedEdges identifier="E314" sources="//@children.144/@ports.1" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E315" sources="//@children.145/@ports.1" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E316" sources="//@children.146/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E317" sources="//@children.147/@ports.1" targets="//@children.148/@ports.2"/>
+  <containedEdges identifier="E318" sources="//@children.148/@ports.3" targets="//@children.150/@ports.3"/>
+  <containedEdges identifier="E319" sources="//@children.149/@ports.1" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E320" sources="//@children.150/@ports.4" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E321" sources="//@children.151/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E322" sources="//@children.152/@ports.0" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E323" sources="//@children.153/@ports.0" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E324" sources="//@children.154/@ports.0" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E325" sources="//@children.155/@ports.1" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E326" sources="//@children.156/@ports.1" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E327" sources="//@children.157/@ports.1" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E328" sources="//@children.158/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E329" sources="//@children.159/@ports.0" targets="//@children.163/@ports.0"/>
+  <containedEdges identifier="E330" sources="//@children.160/@ports.0" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E331" sources="//@children.161/@ports.0" targets="//@children.165/@ports.0"/>
+  <containedEdges identifier="E332" sources="//@children.162/@ports.0" targets="//@children.166/@ports.0"/>
+  <containedEdges identifier="E333" sources="//@children.163/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E334" sources="//@children.164/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E335" sources="//@children.165/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E336" sources="//@children.166/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E337" sources="//@children.167/@ports.1" targets="//@children.168/@ports.0"/>
+  <containedEdges identifier="E338" sources="//@children.168/@ports.1" targets="//@children.138/@ports.0"/>
+  <containedEdges identifier="E339" sources="//@children.169/@ports.0" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E340" sources="//@children.170/@ports.1" targets="//@children.140/@ports.0"/>
+  <containedEdges identifier="E341" sources="//@children.171/@ports.0" targets="//@children.172/@ports.0"/>
+  <containedEdges identifier="E342" sources="//@children.172/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E343" sources="//@children.173/@ports.0" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E344" sources="//@children.174/@ports.0" targets="//@children.176/@ports.0"/>
+  <containedEdges identifier="E345" sources="//@children.175/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E346" sources="//@children.176/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E347" sources="//@children.177/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E348" sources="//@children.178/@ports.0" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E349" sources="//@children.179/@ports.0" targets="//@children.181/@ports.0"/>
+  <containedEdges identifier="E350" sources="//@children.180/@ports.0" targets="//@children.182/@ports.0"/>
+  <containedEdges identifier="E351" sources="//@children.181/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E352" sources="//@children.182/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E353" sources="//@children.183/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E354" sources="//@children.184/@ports.0" targets="//@children.183/@ports.0"/>
+  <containedEdges identifier="E355" sources="//@children.185/@ports.0" targets="//@children.186/@ports.0"/>
+  <containedEdges identifier="E356" sources="//@children.186/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E357" sources="//@children.187/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E358" sources="//@children.188/@ports.0" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E359" sources="//@children.189/@ports.0" targets="//@children.191/@ports.0"/>
+  <containedEdges identifier="E360" sources="//@children.190/@ports.0" targets="//@children.192/@ports.0"/>
+  <containedEdges identifier="E361" sources="//@children.191/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E362" sources="//@children.192/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E363" sources="//@children.193/@ports.0" targets="//@children.195/@ports.0"/>
+  <containedEdges identifier="E364" sources="//@children.194/@ports.1" targets="//@children.191/@ports.0"/>
+  <containedEdges identifier="E365" sources="//@children.195/@ports.1" targets="//@children.194/@ports.0"/>
+  <containedEdges identifier="E366" sources="//@children.196/@ports.0" targets="//@children.201/@ports.0"/>
+  <containedEdges identifier="E367" sources="//@children.197/@ports.0" targets="//@children.198/@ports.0"/>
+  <containedEdges identifier="E368" sources="//@children.198/@ports.1" targets="//@children.199/@ports.0"/>
+  <containedEdges identifier="E369" sources="//@children.199/@ports.1" targets="//@children.200/@ports.0"/>
+  <containedEdges identifier="E370" sources="//@children.200/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E371" sources="//@children.201/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E372" sources="//@children.202/@ports.0" targets="//@children.203/@ports.0"/>
+  <containedEdges identifier="E373" sources="//@children.203/@ports.1" targets="//@children.204/@ports.0"/>
+  <containedEdges identifier="E374" sources="//@children.204/@ports.1" targets="//@children.209/@ports.0"/>
+  <containedEdges identifier="E375" sources="//@children.205/@ports.0" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E376" sources="//@children.206/@ports.1" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E377" sources="//@children.207/@ports.1" targets="//@children.208/@ports.0"/>
+  <containedEdges identifier="E378" sources="//@children.208/@ports.1" targets="//@children.209/@ports.0"/>
+  <containedEdges identifier="E379" sources="//@children.209/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E380" sources="//@children.210/@ports.0" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E381" sources="//@children.211/@ports.0" targets="//@children.213/@ports.0"/>
+  <containedEdges identifier="E382" sources="//@children.212/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E383" sources="//@children.213/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E384" sources="//@children.214/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E385" sources="//@children.215/@ports.1" targets="//@children.216/@ports.0"/>
+  <containedEdges identifier="E386" sources="//@children.216/@ports.1" targets="//@children.214/@ports.0"/>
+  <containedEdges identifier="E387" sources="//@children.217/@ports.1" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E388" sources="//@children.218/@ports.0" targets="//@children.219/@ports.0"/>
+  <containedEdges identifier="E389" sources="//@children.219/@ports.1" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E390" sources="//@children.220/@ports.1" targets="//@children.221/@ports.0"/>
+  <containedEdges identifier="E391" sources="//@children.221/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E392" sources="//@children.222/@ports.0" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E393" sources="//@children.223/@ports.0" targets="//@children.226/@ports.0"/>
+  <containedEdges identifier="E394" sources="//@children.224/@ports.1" targets="//@children.248/@ports.0"/>
+  <containedEdges identifier="E395" sources="//@children.225/@ports.1" targets="//@children.248/@ports.0"/>
+  <containedEdges identifier="E396" sources="//@children.226/@ports.1" targets="//@children.227/@ports.0"/>
+  <containedEdges identifier="E397" sources="//@children.227/@ports.1" targets="//@children.224/@ports.0"/>
+  <containedEdges identifier="E398" sources="//@children.228/@ports.0" targets="//@children.229/@ports.0"/>
+  <containedEdges identifier="E399" sources="//@children.229/@ports.1" targets="//@children.230/@ports.0"/>
+  <containedEdges identifier="E400" sources="//@children.230/@ports.1" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E401" sources="//@children.231/@ports.0" targets="//@children.232/@ports.0"/>
+  <containedEdges identifier="E402" sources="//@children.232/@ports.1" targets="//@children.229/@ports.0"/>
+  <containedEdges identifier="E403" sources="//@children.233/@ports.0" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E404" sources="//@children.234/@ports.0" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E405" sources="//@children.235/@ports.1" targets="//@children.237/@ports.0"/>
+  <containedEdges identifier="E406" sources="//@children.236/@ports.1" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E407" sources="//@children.237/@ports.1" targets="//@children.226/@ports.0"/>
+  <containedEdges identifier="E408" sources="//@children.238/@ports.0" targets="//@children.239/@ports.0"/>
+  <containedEdges identifier="E409" sources="//@children.239/@ports.1" targets="//@children.240/@ports.0"/>
+  <containedEdges identifier="E410" sources="//@children.240/@ports.1" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E411" sources="//@children.241/@ports.0" targets="//@children.242/@ports.0"/>
+  <containedEdges identifier="E412" sources="//@children.242/@ports.1" targets="//@children.239/@ports.0"/>
+  <containedEdges identifier="E413" sources="//@children.243/@ports.0" targets="//@children.244/@ports.0"/>
+  <containedEdges identifier="E414" sources="//@children.244/@ports.1" targets="//@children.245/@ports.0"/>
+  <containedEdges identifier="E415" sources="//@children.245/@ports.1" targets="//@children.226/@ports.0"/>
+  <containedEdges identifier="E416" sources="//@children.246/@ports.0" targets="//@children.247/@ports.0"/>
+  <containedEdges identifier="E417" sources="//@children.247/@ports.1" targets="//@children.244/@ports.0"/>
+  <containedEdges identifier="E418" sources="//@children.248/@ports.1" targets="//@children.249/@ports.0"/>
+  <containedEdges identifier="E419" sources="//@children.249/@ports.1" targets="//@children.250/@ports.0"/>
+  <containedEdges identifier="E420" sources="//@children.250/@ports.1" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E421" sources="//@children.251/@ports.0" targets="//@children.256/@ports.0"/>
+  <containedEdges identifier="E422" sources="//@children.252/@ports.0" targets="//@children.253/@ports.0"/>
+  <containedEdges identifier="E423" sources="//@children.253/@ports.1" targets="//@children.256/@ports.0"/>
+  <containedEdges identifier="E424" sources="//@children.254/@ports.0" targets="//@children.255/@ports.0"/>
+  <containedEdges identifier="E425" sources="//@children.255/@ports.1" targets="//@children.256/@ports.0"/>
+  <containedEdges identifier="E426" sources="//@children.256/@ports.1" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E427" sources="//@children.257/@ports.0" targets="//@children.258/@ports.0"/>
+  <containedEdges identifier="E428" sources="//@children.258/@ports.1" targets="//@children.256/@ports.0"/>
+  <containedEdges identifier="E429" sources="//@children.259/@ports.0" targets="//@children.260/@ports.0"/>
+  <containedEdges identifier="E430" sources="//@children.260/@ports.1" targets="//@children.262/@ports.0"/>
+  <containedEdges identifier="E431" sources="//@children.261/@ports.1" targets="//@children.263/@ports.0"/>
+  <containedEdges identifier="E432" sources="//@children.262/@ports.1" targets="//@children.261/@ports.0"/>
+  <containedEdges identifier="E433" sources="//@children.263/@ports.1" targets="//@children.264/@ports.0"/>
+  <containedEdges identifier="E434" sources="//@children.264/@ports.1" targets="//@children.265/@ports.0"/>
+  <containedEdges identifier="E435" sources="//@children.265/@ports.1" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E436" sources="//@children.266/@ports.0" targets="//@children.269/@ports.0"/>
+  <containedEdges identifier="E437" sources="//@children.267/@ports.0" targets="//@children.270/@ports.0"/>
+  <containedEdges identifier="E438" sources="//@children.268/@ports.0" targets="//@children.271/@ports.0"/>
+  <containedEdges identifier="E439" sources="//@children.269/@ports.1" targets="//@children.265/@ports.0"/>
+  <containedEdges identifier="E440" sources="//@children.270/@ports.1" targets="//@children.269/@ports.0"/>
+  <containedEdges identifier="E441" sources="//@children.271/@ports.1" targets="//@children.265/@ports.0"/>
+  <containedEdges identifier="E442" sources="//@children.272/@ports.0" targets="//@children.273/@ports.0"/>
+  <containedEdges identifier="E443" sources="//@children.273/@ports.1" targets="//@children.265/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gr_microwave_microwave.elkg
+++ b/realworld/ptolemy/flattened/gr_microwave_microwave.elkg
@@ -1,0 +1,1605 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="92.0" text="Microwave body"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3 //@containedEdges.7 //@containedEdges.12 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="93.0" text="microwave_door"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="84.0" text="Translate3D13"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="64.0" text="Scale3D16"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="back_texture"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="32.0" text="scale"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="62.0" text="Rotate3D9"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="41.0" text="texture"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="57.0" text="Scale3D2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="69.0" text="Rotate3D10"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="84.0" text="Translate3D20"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="34.0" text="Pulse"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="8.0" text="1"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19 //@containedEdges.24 //@containedEdges.27 //@containedEdges.34 //@containedEdges.35 //@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.46 //@containedEdges.47 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="8.0" text="2"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="8.0" text="3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="8.0" text="6"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="8.0" text="4"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="8.0" text="5"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="77.0" text="Translate3D8"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="84.0" text="Translate3D13"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="84.0" text="Translate3D14"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="84.0" text="Translate3D15"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="8.0" text="7"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="8.0" text="9"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="8.0" text="8"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="57.0" text="Scale3D2"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="64.0" text="Scale3D37"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="64.0" text="Scale3D42"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="49.0" text="Const14"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="49.0" text="Const16"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="55.0" text="fsm actor"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="61.0" y="22.625" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="34.875" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.52 //@containedEdges.53 //@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="125.0" text="Copy1:Translate3D54"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="110.0" text="Copy1:Rotate3D31"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="125.0" text="Copy1:Translate3D49"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="110.0" text="Copy1:Rotate3D36"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="11.0" text="G"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="9.0" text="E"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="125.0" text="Copy1:Translate3D43"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="10.0" text="D"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="125.0" text="Copy1:Translate3D30"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="103.0" text="Copy1:Rotate3D2"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="10.0" text="C"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="125.0" text="Copy1:Translate3D45"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="9.0" text="B"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="125.0" text="Copy1:Translate3D52"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="8.0" text="F"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="125.0" text="Copy1:Translate3D35"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.69 //@containedEdges.72 //@containedEdges.76 //@containedEdges.78 //@containedEdges.81 //@containedEdges.84 //@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="125.0" text="Copy1:Translate3D54"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="110.0" text="Copy1:Rotate3D31"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="125.0" text="Copy1:Translate3D49"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="110.0" text="Copy1:Rotate3D36"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="11.0" text="G"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="9.0" text="E"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="125.0" text="Copy1:Translate3D43"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="10.0" text="D"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="125.0" text="Copy1:Translate3D30"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="103.0" text="Copy1:Rotate3D2"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="10.0" text="C"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="125.0" text="Copy1:Translate3D45"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="9.0" text="B"/>
+    <ports identifier="P177" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="125.0" text="Copy1:Translate3D52"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="8.0" text="F"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="125.0" text="Copy1:Translate3D35"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.88 //@containedEdges.91 //@containedEdges.95 //@containedEdges.97 //@containedEdges.100 //@containedEdges.103 //@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="125.0" text="Copy1:Translate3D54"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="110.0" text="Copy1:Rotate3D31"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="125.0" text="Copy1:Translate3D49"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="110.0" text="Copy1:Rotate3D36"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="11.0" text="G"/>
+    <ports identifier="P197" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="9.0" text="E"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="125.0" text="Copy1:Translate3D43"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="10.0" text="D"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="125.0" text="Copy1:Translate3D30"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="103.0" text="Copy1:Rotate3D2"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="10.0" text="C"/>
+    <ports identifier="P209" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="125.0" text="Copy1:Translate3D45"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="9.0" text="B"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="125.0" text="Copy1:Translate3D52"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="8.0" text="F"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="125.0" text="Copy1:Translate3D35"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.107 //@containedEdges.110 //@containedEdges.114 //@containedEdges.116 //@containedEdges.119 //@containedEdges.122 //@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.1" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.1" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.22/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.23/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.25/@ports.1" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.26/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.26/@ports.1" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.27/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.27/@ports.1" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.28/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.29/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.30/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.31/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.32/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.33/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.34/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.34/@ports.1" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.35/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.35/@ports.1" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.36/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.36/@ports.1" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.37/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.38/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.39/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.40/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.41/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.42/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.43/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.44/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.45/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.46/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.47/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.48/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.49/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.50/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.51/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.52/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.52/@ports.1" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.52/@ports.2" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.52/@ports.3" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.52/@ports.4" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.52/@ports.5" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.52/@ports.6" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.53/@ports.1" targets="//@children.52/@ports.7"/>
+  <containedEdges identifier="E70" sources="//@children.54/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.55/@ports.1" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.56/@ports.0" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.57/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.58/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.59/@ports.0" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.60/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.61/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.62/@ports.0" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.63/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.64/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.65/@ports.0" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.66/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.67/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.68/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.69/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.70/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.71/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.72/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.73/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.74/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.75/@ports.0" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.76/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.77/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.78/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.79/@ports.0" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.80/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.81/@ports.0" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.82/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.83/@ports.1" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.84/@ports.0" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.85/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.86/@ports.1" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.87/@ports.0" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.88/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.89/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.90/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.91/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.92/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.93/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.94/@ports.0" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.95/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.96/@ports.1" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.97/@ports.0" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.98/@ports.0" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.99/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.100/@ports.0" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.101/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.102/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.103/@ports.0" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.104/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.105/@ports.1" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.106/@ports.0" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.107/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.108/@ports.0" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.109/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.110/@ports.1" targets="//@children.42/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gr_pendulum_Pendulum.elkg
+++ b/realworld/ptolemy/flattened/gr_pendulum_Pendulum.elkg
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="Sphere"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="Translate"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3 //@containedEdges.6 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="48.0" text="Cylinder"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="39.0" text="Rotate"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="24.0" text="Text"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="61.0" text="Translate2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="114.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="114.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="100.0" text="Periodic Sampler"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="72.0" text="0:Translate0"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="78.0" text="0:Translate11"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="49.0" text="0:Box14"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="0:Translate6"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="49.0" text="0:Box15"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="49.0" text="0:Box12"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="49.0" text="0:Box13"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="72.0" text="0:Translate1"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="57.0" text="Scale3D0"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13 //@containedEdges.14 //@containedEdges.16 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.2" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gr_pong_Pong.elkg
+++ b/realworld/ptolemy/flattened/gr_pong_Pong.elkg
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="183.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="183.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="22.0" text="Ball"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="41.0" text="Paddle"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="253.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="75.0" text="Copy1:Const"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="253.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="254.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="254.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="245.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="245.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="245.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="245.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="51.0" text="Left Wall"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4 //@containedEdges.6 //@containedEdges.15 //@containedEdges.17 //@containedEdges.19 //@containedEdges.20 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="60.0" text="Right Wall"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="50.0" text="Top Wall"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="68.0" text="Intersection"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="66.0" text="Game Over"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="98.0" text="ArrowKeySensor"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="1.7999999523162842">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="74.0" text="Game Model"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="10.375">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="22.625">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="34.875">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="92.0" text="Paddle Position"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.37 //@containedEdges.38 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.2" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.21/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.22/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.23/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.24/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.25/@ports.3" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E26" sources="//@children.26/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.26/@ports.2" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.27/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.27/@ports.3" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.28/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.29/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.29/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.30/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.30/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.31/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.32/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.32/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.33/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.33/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.33/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.34/@ports.1" targets="//@children.27/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gr_robotarm_RobotArm.elkg
+++ b/realworld/ptolemy/flattened/gr_robotarm_RobotArm.elkg
@@ -1,0 +1,1881 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="ViewScreen2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="87.0" text="Keyboard Input"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="Scale3D5"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10 //@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="97.0" text="PolyCylinder3D4"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="31.0" text="Box5"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="77.0" text="Translate3D8"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11 //@containedEdges.13 //@containedEdges.15 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="104.0" text="PolyCylinder3D13"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="64.0" text="Scale3D10"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="53.0" text="Rotate17"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="57.0" text="Scale3D0"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24 //@containedEdges.29 //@containedEdges.31 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.26 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="47.0" text="Box3D0"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="107.0" text="CircularSweep3D0"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="107.0" text="CircularSweep3D1"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="84.0" text="Translate3D14"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="107.0" text="CircularSweep3D6"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="107.0" text="CircularSweep3D2"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="31.0" text="Box3"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40 //@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="31.0" text="Box2"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="31.0" text="Box4"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="77.0" text="Translate3D8"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.34 //@containedEdges.38 //@containedEdges.39 //@containedEdges.46 //@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="31.0" text="Box1"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="57.0" text="Scale3D0"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.57 //@containedEdges.60 //@containedEdges.63 //@containedEdges.64 //@containedEdges.65 //@containedEdges.69 //@containedEdges.70 //@containedEdges.71 //@containedEdges.74 //@containedEdges.75 //@containedEdges.79 //@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="31.0" text="Box4"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="31.0" text="Box2"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="31.0" text="Box3"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="31.0" text="Box5"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="31.0" text="Box6"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="84.0" text="Translate3D15"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="84.0" text="Translate3D22"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="38.0" text="Box23"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="31.0" text="Box7"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="31.0" text="Box8"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="31.0" text="Box9"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="38.0" text="Box10"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="83.0" text="Translate3D11"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.77 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="84.0" text="Translate3D13"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="55.0" text="Cylinder0"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="53.0" text="Rotate24"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="107.0" text="CircularSweep3D0"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="45.0" text="PolyCyl"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="46.0" text="Rotate2"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="46.0" text="Rotate8"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="107.0" text="CircularSweep3D1"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="57.0" text="Scale3D4"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="103.0" text="PolyCylinder3D11"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="53.0" text="Rotate12"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="53.0" text="Rotate13"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="84.0" text="Translate3D14"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="84.0" text="Translate3D15"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.92 //@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="38.0" text="Box28"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="46.0" text="Rotate9"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.88 //@containedEdges.89 //@containedEdges.97 //@containedEdges.100 //@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="53.0" text="Rotate10"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="64.0" text="Scale3D15"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.102 //@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="53.0" text="Rotate27"/>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="84.0" text="Translate3D22"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="45.0" text="PolyCyl"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="46.0" text="Rotate1"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.110 //@containedEdges.118 //@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="46.0" text="Rotate6"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.111 //@containedEdges.125 //@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="53.0" text="Rotate13"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="31.0" text="Box7"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.116 //@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="46.0" text="Rotate3"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="38.0" text="Box10"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="38.0" text="Box14"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="31.0" text="Box0"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.121 //@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="46.0" text="Rotate4"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="97.0" text="PolyCylinder3D1"/>
+    <ports identifier="P218" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.126 //@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="46.0" text="Rotate5"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="97.0" text="PolyCylinder3D2"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="104.0" text="PolyCylinder3D24"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.131 //@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="46.0" text="Rotate7"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="104.0" text="PolyCylinder3D27"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="77.0" text="Translate3D7"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="84.0" text="Translate3D28"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.112 //@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="53.0" text="Rotate14"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="53.0" text="Rotate30"/>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="47.0" text="Switch1"/>
+    <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.140 //@containedEdges.141 //@containedEdges.142 //@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="119.0" text="FSM_motor_number"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="119.0" text="FSM_motor_number"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.22/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.23/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.24/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.25/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.26/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.27/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.28/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.29/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.30/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.31/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.33/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.34/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.35/@ports.1" targets="//@children.36/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.36/@ports.3" targets="//@children.38/@ports.3"/>
+  <containedEdges identifier="E38" sources="//@children.37/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.38/@ports.4" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.39/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.40/@ports.0" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.41/@ports.0" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.42/@ports.0" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.43/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.44/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.45/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.46/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.47/@ports.0" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.48/@ports.0" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.49/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.50/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.51/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.52/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.53/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.54/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.55/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.56/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.57/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.58/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.59/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.60/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.61/@ports.0" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.62/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.63/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.64/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.65/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.66/@ports.0" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.67/@ports.0" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.68/@ports.0" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.69/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.70/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.71/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.72/@ports.0" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.73/@ports.0" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.74/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.75/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.76/@ports.0" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.77/@ports.0" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.78/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.79/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.80/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.81/@ports.0" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.82/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.83/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.84/@ports.0" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.85/@ports.0" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.86/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.87/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.88/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.89/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.90/@ports.0" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.91/@ports.1" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.92/@ports.1" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.93/@ports.0" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.94/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.95/@ports.1" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.96/@ports.1" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.97/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.98/@ports.0" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.99/@ports.0" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.100/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.101/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.102/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.103/@ports.1" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.104/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.105/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.106/@ports.0" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.107/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.108/@ports.1" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.109/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.110/@ports.0" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.111/@ports.0" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.112/@ports.1" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.113/@ports.1" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.114/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.115/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.116/@ports.0" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.117/@ports.1" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.118/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.119/@ports.0" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.120/@ports.1" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.121/@ports.0" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.122/@ports.0" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.123/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.124/@ports.1" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.125/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.126/@ports.0" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.127/@ports.1" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.128/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.129/@ports.0" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.130/@ports.1" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.131/@ports.0" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.132/@ports.1" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.133/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E135" sources="//@children.134/@ports.0" targets="//@children.135/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.135/@ports.1" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E137" sources="//@children.136/@ports.1" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.137/@ports.1" targets="//@children.138/@ports.0"/>
+  <containedEdges identifier="E139" sources="//@children.138/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.139/@ports.1" targets="//@children.140/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.140/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E142" sources="//@children.140/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E143" sources="//@children.140/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E144" sources="//@children.140/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E145" sources="//@children.141/@ports.1" targets="//@children.140/@ports.2"/>
+  <containedEdges identifier="E146" sources="//@children.142/@ports.1" targets="//@children.139/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gr_stickymasses_StickyMasses.elkg
+++ b/realworld/ptolemy/flattened/gr_stickymasses_StickyMasses.elkg
@@ -1,0 +1,1158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.96 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="57.0" text="Scale3D3"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="left wall"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="Translate3D26"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5 //@containedEdges.7 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="62.0" text="Rotate3D1"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="25.0" text="floor"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="51.0" text="right wall"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="Translate3D5"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="77.0" text="Translate3D6"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="55.0" text="Torus3D1"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="55.0" text="Torus3D2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.18 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="69.0" text="Rotate3D10"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="69.0" text="Rotate3D13"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="69.0" text="Rotate3D14"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="55.0" text="Torus3D3"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="62.0" text="Rotate3D4"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.21 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="62.0" text="Torus3D16"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="69.0" text="Rotate3D17"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="69.0" text="Rotate3D20"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="84.0" text="Translate3D24"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.25 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="62.0" text="Torus3D27"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="69.0" text="Rotate3D28"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="84.0" text="Translate3D33"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.28 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="62.0" text="Torus3D38"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="62.0" text="Torus3D39"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="69.0" text="Rotate3D40"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="69.0" text="Rotate3D41"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="84.0" text="Translate3D42"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.33 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="69.0" text="Rotate3D43"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="84.0" text="Translate3D52"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.35 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.37 //@containedEdges.38 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="65.0" text="Sphere3D1"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="85.0" text="Compute Twist"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.43 //@containedEdges.44 //@containedEdges.45 //@containedEdges.46 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.48 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51 //@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="55.0" text="Torus3D1"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="55.0" text="Torus3D2"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="77.0" text="Translate3D9"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.59 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="69.0" text="Rotate3D10"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="69.0" text="Rotate3D13"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="69.0" text="Rotate3D14"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="55.0" text="Torus3D3"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="62.0" text="Rotate3D4"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.62 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="62.0" text="Torus3D16"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="69.0" text="Rotate3D17"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="69.0" text="Rotate3D20"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="84.0" text="Translate3D24"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.66 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="62.0" text="Torus3D27"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="69.0" text="Rotate3D28"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="84.0" text="Translate3D33"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.69 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="62.0" text="Torus3D38"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="62.0" text="Torus3D39"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="69.0" text="Rotate3D40"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="69.0" text="Rotate3D41"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="84.0" text="Translate3D42"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.74 //@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="69.0" text="Rotate3D43"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="84.0" text="Translate3D52"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.76 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.78 //@containedEdges.79 //@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="65.0" text="Sphere3D1"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="77.0" text="Translate3D4"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.57 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="85.0" text="Compute Twist"/>
+    <ports identifier="P150" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.84 //@containedEdges.85 //@containedEdges.86 //@containedEdges.87 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.89 //@containedEdges.90 //@containedEdges.91 //@containedEdges.92 //@containedEdges.93 //@containedEdges.94 //@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.100 //@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.96 //@containedEdges.97 //@containedEdges.98 //@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="112.0" text="Sticky Mass model"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="61.0" y="-1.875">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="61.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="61.0" y="22.625">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="61.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="61.0" y="34.875">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.12/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.20/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.21/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.22/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.23/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.24/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.25/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.26/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.27/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.28/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.29/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.30/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.31/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.32/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.33/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.34/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.35/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.36/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.37/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.38/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.39/@ports.1" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.39/@ports.1" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.39/@ports.1" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E41" sources="//@children.40/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.41/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.42/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.43/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E45" sources="//@children.43/@ports.0" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E46" sources="//@children.43/@ports.0" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E47" sources="//@children.43/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.43/@ports.0" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.44/@ports.0" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.44/@ports.0" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.44/@ports.0" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.44/@ports.0" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.44/@ports.0" targets="//@children.36/@ports.2"/>
+  <containedEdges identifier="E54" sources="//@children.44/@ports.0" targets="//@children.38/@ports.2"/>
+  <containedEdges identifier="E55" sources="//@children.44/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.45/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.46/@ports.0" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.47/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.48/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.49/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.50/@ports.1" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.51/@ports.0" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.52/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.53/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.54/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.55/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.56/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.57/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.58/@ports.0" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.59/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.60/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.61/@ports.0" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.62/@ports.0" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.63/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.64/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.65/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.66/@ports.1" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.67/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.68/@ports.1" targets="//@children.49/@ports.2"/>
+  <containedEdges identifier="E80" sources="//@children.68/@ports.1" targets="//@children.56/@ports.2"/>
+  <containedEdges identifier="E81" sources="//@children.68/@ports.1" targets="//@children.64/@ports.2"/>
+  <containedEdges identifier="E82" sources="//@children.69/@ports.0" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.70/@ports.1" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.71/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.72/@ports.0" targets="//@children.48/@ports.2"/>
+  <containedEdges identifier="E86" sources="//@children.72/@ports.0" targets="//@children.52/@ports.2"/>
+  <containedEdges identifier="E87" sources="//@children.72/@ports.0" targets="//@children.59/@ports.2"/>
+  <containedEdges identifier="E88" sources="//@children.72/@ports.0" targets="//@children.66/@ports.2"/>
+  <containedEdges identifier="E89" sources="//@children.72/@ports.0" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.73/@ports.0" targets="//@children.47/@ports.2"/>
+  <containedEdges identifier="E91" sources="//@children.73/@ports.0" targets="//@children.53/@ports.2"/>
+  <containedEdges identifier="E92" sources="//@children.73/@ports.0" targets="//@children.57/@ports.2"/>
+  <containedEdges identifier="E93" sources="//@children.73/@ports.0" targets="//@children.60/@ports.2"/>
+  <containedEdges identifier="E94" sources="//@children.73/@ports.0" targets="//@children.65/@ports.2"/>
+  <containedEdges identifier="E95" sources="//@children.73/@ports.0" targets="//@children.67/@ports.2"/>
+  <containedEdges identifier="E96" sources="//@children.73/@ports.0" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E97" sources="//@children.74/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.74/@ports.1" targets="//@children.73/@ports.1"/>
+  <containedEdges identifier="E99" sources="//@children.74/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.74/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E101" sources="//@children.75/@ports.3" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.75/@ports.2" targets="//@children.74/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gr_universe_Universe.elkg
+++ b/realworld/ptolemy/flattened/gr_universe_Universe.elkg
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0 //@containedEdges.3 //@containedEdges.10 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="30.0" text="earth"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="22.0" text="sun"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="54.0" text="Translate"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="39.0" text="Rotate"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="49.0" text="Ramp21"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="33.0" text="venus"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="61.0" text="Translate2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="49.0" text="Ramp31"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="27.0" text="Sine"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="64.0" text="Scale3D46"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="41.0" text="Cosine"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Sine_"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="48.0" text="Cosine_"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="49.0" text="Ramp64"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="48.0" text="Scale69"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="48.0" text="Scale70"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="AddSubtract75"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="87.0" text="AddSubtract81"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="63.0" text="Orbit Trails"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.2" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.0" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gt_bouncingballx2_BouncingBallX2.elkg
+++ b/realworld/ptolemy/flattened/gt_bouncingballx2_BouncingBallX2.elkg
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="38.0" width="58.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="88.0" text="ModelExecutor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="25.0" y="38.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="58.0" y="15.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="38.0" width="58.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="95.0" text="ModelExecutor2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="25.0" y="38.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="58.0" y="15.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="425.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="65.0" text="Sphere3D2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="100.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="100.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.10/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gt_constoptimization_BaseModel.elkg
+++ b/realworld/ptolemy/flattened/gt_constoptimization_BaseModel.elkg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="17.0" text="C1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="17.0" text="C2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="17.0" text="C3"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="17.0" text="C4"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="17.0" text="C5"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="17.0" text="C6"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="17.0" text="C7"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="17.0" text="C8"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="31.0" text="Add1"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="31.0" text="Add2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="53.0" text="Multiply1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="53.0" text="Multiply2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="25.0" text="Max"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="53.0" text="Multiply3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="31.0" text="Add3"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.2" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gt_diningphilosophers_DiningPhilosophers.elkg
+++ b/realworld/ptolemy/flattened/gt_diningphilosophers_DiningPhilosophers.elkg
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="64.0" text="ModelView"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="19.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="121.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="121.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="89.0" text="ResourcePool2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.18 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="69.0" text="Philosopher"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="46.0" text="Barrier1"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.9 //@containedEdges.11 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="185.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="185.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="89.0" text="ResourcePool1"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="89.0" text="ResourcePool2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="46.0" text="Barrier2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.14 //@containedEdges.17 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="118.0" text="PreviousPhilosopher"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="53.0" text="NextPool"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="118.0" text="PreviousPhilosopher"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.24 //@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.23 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="53.0" text="NextPool"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="69.0" text="Philosopher"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="46.0" text="Barrier1"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.25 //@containedEdges.27 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="185.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="185.0" y="8.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="89.0" text="ResourcePool1"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="89.0" text="ResourcePool2"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="46.0" text="Barrier2"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.30 //@containedEdges.33 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.22/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.24/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.24/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.27/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.28/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.28/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.29/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.29/@ports.0" targets="//@children.22/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gt_mapreduce_MapReduce.elkg
+++ b/realworld/ptolemy/flattened/gt_mapreduce_MapReduce.elkg
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="37.0" text="merge"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="51.0" y="8.333333015441895" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="51.0" y="24.66666603088379" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="60.0" text="Distributor"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="39.0" text="worker"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="44.0" text="storage"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="39.0" text="worker"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="53.0" text="converter"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="merge"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="47.0" text="sampler"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="29.0" text="and2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="25.0" text="filter"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="31.0" text="delay"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.6/@ports.4"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.3" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.5" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.5" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gt_modelgeneration_ModelGeneration.elkg
+++ b/realworld/ptolemy/flattened/gt_modelgeneration_ModelGeneration.elkg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="64.0" text="ModelView"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/gt_modelgeneration_ModelGenerationDDF.elkg
+++ b/realworld/ptolemy/flattened/gt_modelgeneration_ModelGenerationDDF.elkg
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="64.0" text="ModelView"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="19.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.3" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.15/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/hdf_adaptivecoding_AdaptiveCoding.elkg
+++ b/realworld/ptolemy/flattened/hdf_adaptivecoding_AdaptiveCoding.elkg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="106.0" text="Uncoded Symbols"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Coder"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="ModalModel2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="98.0" text="Number of Errors"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="60.0" text="Error Rate"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/hlacerti_multidatatypes_producer.elkg
+++ b/realworld/ptolemy/flattened/hlacerti_multidatatypes_producer.elkg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="val"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="76.0" text="SingleEvent5"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="23.0" text="val1"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="23.0" text="val2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="23.0" text="val3"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/hoc_applyfft_ApplyFFT.elkg
+++ b/realworld/ptolemy/flattened/hoc_applyfft_ApplyFFT.elkg
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="79.0" text="Noise Source"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="24.0" text="FFT"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="84.0" text="ApplyFunction"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="70.0" text="ArrayPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="168.0" text="ApplyFunctionOverSequence"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="104.0" text="SequencePlotter2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/hoc_dftsubset_DFTSubSet.elkg
+++ b/realworld/ptolemy/flattened/hoc_dftsubset_DFTSubSet.elkg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="Commutator"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="96.0" text="SequenceScope"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="107.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="107.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="180.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="94.0" text="InputBlockDelay"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.9/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/hoc_iterateoverarray_IterateOverArray.elkg
+++ b/realworld/ptolemy/flattened/hoc_iterateoverarray_IterateOverArray.elkg
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="281.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="102.0" text="HammingWindow"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="113.0" text="SumArrayElements"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="59.0" text="Normalize"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="69.0" text="CreateArray"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="202.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="274.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="107.0" text="PlaneWavePhasor"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="274.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="323.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="31.0" text="expjx"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="323.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="430.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="430.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/jai_adaptivemedian_AdaptiveMedian.elkg
+++ b/realworld/ptolemy/flattened/jai_adaptivemedian_AdaptiveMedian.elkg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="95.0" text="JAIImageReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="107.0" text="JAIToDoubleMatrix"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="88.0" text="SaltAndPepper"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="94.0" text="Salt and Pepper"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="108.0" text="DoubleMatrixToJAI"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="92.0" text="AdaptiveMedian"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="115.0" text="DoubleMatrixToJAI2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="52.0" text="Repaired"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="Original Image"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="100.0" text="JAIBandCombine"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="85.0" text="JAIBandSelect"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="60.0" text="Greyscale"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/jai_imagereconstruction_ImageReconstruction.elkg
+++ b/realworld/ptolemy/flattened/jai_imagereconstruction_ImageReconstruction.elkg
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="95.0" text="JAIImageReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="102.0" text="JAIImageReader2"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="JAIBorder"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="64.0" text="JAIBorder2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="JAIDFT"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="JAIDFT2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="79.0" text="JAIMagnitude"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="56.0" text="JAIPhase"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="112.0" text="JAIPolarToComplex"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="46.0" text="JAIIDFT"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="88.0" text="JAIDataConvert"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="46.0" text="JAICrop"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="Recovered Helen"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="82.0" text="Original Helen"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="96.0" text="Original Ptolemy"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="104.0" text="Combined Images"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="107.0" text="JAIBandCombine2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="93.0" text="JAIBandSelect2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="100.0" text="JAIBandCombine"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="85.0" text="JAIBandSelect"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.17/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.1" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/js_googleoauth_GoogleOAuth.elkg
+++ b/realworld/ptolemy/flattened/js_googleoauth_GoogleOAuth.elkg
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="4.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="268.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="268.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="125.0" text="RequestAuthorization"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="59.0" text="JavaScript"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/lib_decg_DECGPi.elkg
+++ b/realworld/ptolemy/flattened/lib_decg_DECGPi.elkg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.2" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.2" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.11/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.14/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.15/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.16/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/lib_life_Life.elkg
+++ b/realworld/ptolemy/flattened/lib_life_Life.elkg
@@ -1,0 +1,692 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="160.0" width="133.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="76.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="133.0" y="76.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="49.0" text="Repeat2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25 //@containedEdges.28 //@containedEdges.31 //@containedEdges.34 //@containedEdges.37 //@containedEdges.40 //@containedEdges.43 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="44.0" text="Pulse x"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="44.0" text="Pulse y"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="70.0" width="185.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="185.0" y="31.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="44.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27 //@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.33 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.42 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.48 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="231.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@containedEdges.49 //@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="231.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="231.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@containedEdges.55 //@containedEdges.56 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="231.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@containedEdges.58 //@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.3/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.3/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.3/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.3/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.5/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.7/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.7/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.7/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.7/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.7/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.8/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.9/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.10/@ports.2" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.11/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.12/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.13/@ports.2" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E31" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.15/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.16/@ports.2" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.18/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.19/@ports.2" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.21/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.22/@ports.2" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.23/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.24/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.25/@ports.2" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E43" sources="//@children.26/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.27/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.28/@ports.2" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E46" sources="//@children.29/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.30/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.31/@ports.2" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.32/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.33/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.33/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.33/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.34/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.34/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.34/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.35/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.35/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.35/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.36/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.36/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.36/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.37/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E63" sources="//@children.38/@ports.2" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E64" sources="//@children.39/@ports.1" targets="//@children.38/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/lib_life_LifeCGAVR.elkg
+++ b/realworld/ptolemy/flattened/lib_life_LifeCGAVR.elkg
@@ -1,0 +1,550 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="160.0" width="111.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="76.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="111.0" y="76.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="49.0" text="Repeat2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29 //@containedEdges.30 //@containedEdges.31 //@containedEdges.32 //@containedEdges.33 //@containedEdges.34 //@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="44.0" text="Pulse x"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="44.0" text="Pulse y"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="70.0" width="185.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="185.0" y="31.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="44.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="146.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="225.0" width="206.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="61.0" text="LEDMatrix"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="50.25" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="108.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="166.75" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="131.0" text="ArrayElementAsMatrix"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="139.0" text="ArrayElementAsMatrix2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="139.0" text="ArrayElementAsMatrix3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="139.0" text="ArrayElementAsMatrix4"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="139.0" text="ArrayElementAsMatrix5"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="139.0" text="ArrayElementAsMatrix6"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="139.0" text="ArrayElementAsMatrix7"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="139.0" text="ArrayElementAsMatrix8"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="139.0" text="ArrayElementAsMatrix9"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="218.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="218.0" y="8.5" outgoingEdges="//@containedEdges.38 //@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="218.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="218.0" y="8.5" outgoingEdges="//@containedEdges.41 //@containedEdges.42 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="196.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="196.0" y="8.5" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="196.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="196.0" y="8.5" outgoingEdges="//@containedEdges.47 //@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.15/@ports.5"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.17/@ports.5"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.19/@ports.5"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.2/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.4/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.5/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.5/@ports.0" targets="//@children.12/@ports.4"/>
+  <containedEdges identifier="E21" sources="//@children.5/@ports.0" targets="//@children.16/@ports.4"/>
+  <containedEdges identifier="E22" sources="//@children.5/@ports.0" targets="//@children.19/@ports.4"/>
+  <containedEdges identifier="E23" sources="//@children.5/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.5/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.6/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.7/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.9/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E30" sources="//@children.11/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.12/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.13/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.14/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.15/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.16/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.17/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.18/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.19/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.20/@ports.0" targets="//@children.11/@ports.4"/>
+  <containedEdges identifier="E40" sources="//@children.20/@ports.0" targets="//@children.14/@ports.4"/>
+  <containedEdges identifier="E41" sources="//@children.20/@ports.0" targets="//@children.15/@ports.4"/>
+  <containedEdges identifier="E42" sources="//@children.21/@ports.0" targets="//@children.13/@ports.4"/>
+  <containedEdges identifier="E43" sources="//@children.21/@ports.0" targets="//@children.17/@ports.4"/>
+  <containedEdges identifier="E44" sources="//@children.21/@ports.0" targets="//@children.18/@ports.4"/>
+  <containedEdges identifier="E45" sources="//@children.22/@ports.0" targets="//@children.11/@ports.5"/>
+  <containedEdges identifier="E46" sources="//@children.22/@ports.0" targets="//@children.12/@ports.5"/>
+  <containedEdges identifier="E47" sources="//@children.22/@ports.0" targets="//@children.13/@ports.5"/>
+  <containedEdges identifier="E48" sources="//@children.23/@ports.0" targets="//@children.14/@ports.5"/>
+  <containedEdges identifier="E49" sources="//@children.23/@ports.0" targets="//@children.16/@ports.5"/>
+  <containedEdges identifier="E50" sources="//@children.23/@ports.0" targets="//@children.18/@ports.5"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/lib_life_LifeNoCG.elkg
+++ b/realworld/ptolemy/flattened/lib_life_LifeNoCG.elkg
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="160.0" width="133.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="76.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="133.0" y="76.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="225.0" width="206.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="LEDArray"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="50.25" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="108.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="166.75" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="44.0" text="Pulse y"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="44.0" text="Pulse x"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="56.0" text="Borders y"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="Borders x"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="55.0" width="312.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="165.0" text="Expression Count Neighbors"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="312.0" y="23.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="-0.125" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="7.75" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="15.625" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="31.375" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="39.25" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="47.125" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="146.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="107.0" text="SequenceToMatrix"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="49.0" text="Repeat2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="65.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="65.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="70.0" width="185.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="185.0" y="31.0" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="44.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.1" targets="//@children.7/@ports.6"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.2" targets="//@children.7/@ports.7"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.2" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.1" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.10/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.11/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.12/@ports.0" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/modal_abp_ABP.elkg
+++ b/realworld/ptolemy/flattened/modal_abp_ABP.elkg
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="23.0" text="Plot"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="-1.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="6.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="13.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="20.0">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="27.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="34.0">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="95.0" text="ResettableTimer"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="113.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="113.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="uniform"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="uniform"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="79.0" text="VariableDelay"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="91.0" text="ColtExponential"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.7" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.4" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.5" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.5" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.3" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.15/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.16/@ports.0" targets="//@children.15/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/modal_blending_Blending.elkg
+++ b/realworld/ptolemy/flattened/modal_blending_Blending.elkg
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="145.0" text="Control_SequencePlotter"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="132.0" text="Input_SequencePlotter"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="93.0" text="mode_controller"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="-1.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.12 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="74.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="Blend_Step"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="74.0" y="8.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="284.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="106.0" text="Blend_Expression"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="284.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="74.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="68.0" text="Blend_Step"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="74.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="283.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="106.0" text="Blend_Expression"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="283.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.6" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.4/@ports.5"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.0" targets="//@children.4/@ports.5"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.4/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/net_datagram_Datagram.elkg
+++ b/realworld/ptolemy/flattened/net_datagram_Datagram.elkg
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="358.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="358.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="78.0" text="EventButton2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="78.0" text="ArrayLength4"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="DatagramReader"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="92.0" text="DatagramWriter"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="191.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression1"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="191.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="78.0" text="ArrayLength2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="239.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="239.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="36.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="28.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.7 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="78.0" text="EventButton3"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="116.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="116.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="64.0" text="Datagram2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="64.0" text="Datagram1"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="159.0" text="StringToUnsignedByteArray"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="93.0" text="IntArrayToString"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/petrinet_petrinetdiningphilosophers_PetriNetDiningPhilosophers.elkg
+++ b/realworld/ptolemy/flattened/petrinet_petrinetdiningphilosophers_PetriNetDiningPhilosophers.elkg
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="15.0" text="p5"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="p8"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="15.0" text="p7"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="15.0" text="p6"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="15.0" text="p3"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="p2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="12.0" text="t0"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.26 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="12.0" text="t4"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.24 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="15.0" text="p9"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="12.0" text="t3"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.5 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="12.0" text="t2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="12.0" text="t1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.6 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="12.0" text="t5"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="12.0" text="t9"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="12.0" text="t7"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="12.0" text="t8"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="53.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="12.0" text="t6"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="22.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="22.0" y="22.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="15.0" text="p4"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="15.0" text="p0"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="15.0" text="p1"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.17/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.18/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.19/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.19/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_blindcommunication_BlindCommunication.elkg
+++ b/realworld/ptolemy/flattened/pn_blindcommunication_BlindCommunication.elkg
@@ -1,0 +1,720 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="75.0" text="AudioReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="119.0" text="CartesianToComplex"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="118.0" text="Baud Rate Estimate"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="95.0" text="Carrier Estimate"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="82.0" text="Sample Count"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="Phase states"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="264.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="136.0" text="ConvertBinToFrequency"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="264.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="250.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="58.0" text="Mix Down"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="250.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="145.0" text="PlotSpectrumWithCarrier"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="88.0" text="ArrayMaximum"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="597.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="105.0" text="RegenerateCarrier"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="597.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="163.0" text="PlotSpectrumWithoutCarrier"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="Periodogram"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="132.0" text="SmoothedPeriodogram"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="31.0" text="Chop"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="24.0" text="FFT"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="81.0" text="PhaseUnwrap"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="91.0" text="AbsoluteValue2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="298.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="193.0" text="ConvertBinAndOffsetToFrequency"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="298.0" y="8.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="88.0" text="ArrayMaximum"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="95.0" text="ComplexToPolar"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="60.0" text="Differential"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="66.0" text="CountTrues"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="242.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="95.0" text="IncrementPhase"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="242.0" y="8.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="90.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="122.0" text="IdentifyBaudSamples"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="95.0" text="ComplexToPolar"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="111.0" text="ComputeHistogram"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="103.0" text="ArrayPeakSearch"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="60.0" text="Differential"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="570.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="32.0" text="Wrap"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="570.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="95.0" text="ComplexToPolar"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="21.0" text="FIR"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.22/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.23/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.24/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.25/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.26/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.27/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.1" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.29/@ports.1" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.30/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.30/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.31/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.31/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.32/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.33/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.34/@ports.3" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.35/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.36/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.37/@ports.1" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E44" sources="//@children.38/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.39/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.40/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.41/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.41/@ports.3" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.42/@ports.2" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.42/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.44/@ports.1" targets="//@children.41/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_brockackerman_BrockAckerman.elkg
+++ b/realworld/ptolemy/flattened/pn_brockackerman_BrockAckerman.elkg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Starver"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="48.0" text="Starver2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="89.0" text="BlockedIdentity"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="49.0" text="Repeat2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Sleep"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="141.0" text="NondeterministicMerge2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="89.0" text="BlockedIdentity"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="49.0" text="Repeat2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="141.0" text="NondeterministicMerge2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_countermachine_CounterMachine.elkg
+++ b/realworld/ptolemy/flattened/pn_countermachine_CounterMachine.elkg
@@ -1,0 +1,2029 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="85.0" text="SampleDelay3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21 //@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.22 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.37" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.36" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.49 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.52 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.57 //@containedEdges.58 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.66 //@containedEdges.67 //@containedEdges.68 //@containedEdges.69 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.71 //@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.76 //@containedEdges.77 //@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.81 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.85 //@containedEdges.86 //@containedEdges.87 //@containedEdges.89 //@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="111.0" text="RecordAssembler3"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.91 //@containedEdges.92 //@containedEdges.93 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="111.0" text="RecordAssembler4"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.89 //@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.101 //@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.90 //@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.103 //@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.107 //@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.117 //@containedEdges.118 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.121" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.120" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P206" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.119 //@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.128 //@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.133 //@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P234" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.136 //@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.141 //@containedEdges.142 //@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P246" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.145 //@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.150 //@containedEdges.151 //@containedEdges.152 //@containedEdges.153 //@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P261" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.155 //@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P275" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.160 //@containedEdges.161 //@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P276" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.163 //@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.166" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.165" incomingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P286" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P289" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.171 //@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.174" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P297" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.173" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P302" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P305" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P307" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P308" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.107/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.108/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.1" targets="//@children.110/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.1" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.1" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.2/@ports.1" targets="//@children.114/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.1" targets="//@children.116/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.3/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.1" targets="//@children.58/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.7/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.7/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.8/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.9/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.10/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.11/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E25" sources="//@children.11/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E26" sources="//@children.12/@ports.3" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.13/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.14/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.15/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.16/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.17/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.19/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.20/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.20/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E36" sources="//@children.20/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.21/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.21/@ports.1" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.22/@ports.3" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.23/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.24/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.25/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.26/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.26/@ports.3" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.28/@ports.3" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.28/@ports.3" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.29/@ports.1" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.30/@ports.3" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.30/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.31/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.31/@ports.2" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.31/@ports.3" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.33/@ports.3" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.33/@ports.3" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.34/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E56" sources="//@children.35/@ports.3" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.35/@ports.2" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.36/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.36/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.36/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.36/@ports.3" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.38/@ports.3" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.38/@ports.3" targets="//@children.41/@ports.2"/>
+  <containedEdges identifier="E64" sources="//@children.39/@ports.1" targets="//@children.38/@ports.2"/>
+  <containedEdges identifier="E65" sources="//@children.40/@ports.3" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.40/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.41/@ports.3" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.41/@ports.3" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.41/@ports.3" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.41/@ports.3" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.41/@ports.3" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.43/@ports.3" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.43/@ports.3" targets="//@children.46/@ports.2"/>
+  <containedEdges identifier="E74" sources="//@children.44/@ports.1" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E75" sources="//@children.45/@ports.3" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.45/@ports.2" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.46/@ports.3" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.46/@ports.3" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E79" sources="//@children.46/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.48/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.49/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E82" sources="//@children.50/@ports.2" targets="//@children.54/@ports.2"/>
+  <containedEdges identifier="E83" sources="//@children.50/@ports.2" targets="//@children.55/@ports.2"/>
+  <containedEdges identifier="E84" sources="//@children.51/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E85" sources="//@children.52/@ports.0" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.53/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.53/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.53/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.53/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.53/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.53/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.54/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.55/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.56/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.57/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.58/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.59/@ports.0" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E98" sources="//@children.60/@ports.3" targets="//@children.56/@ports.2"/>
+  <containedEdges identifier="E99" sources="//@children.61/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.62/@ports.0" targets="//@children.61/@ports.2"/>
+  <containedEdges identifier="E101" sources="//@children.63/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E102" sources="//@children.65/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.65/@ports.1" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.66/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.66/@ports.1" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.67/@ports.0" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.68/@ports.0" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.69/@ports.1" targets="//@children.70/@ports.2"/>
+  <containedEdges identifier="E109" sources="//@children.69/@ports.1" targets="//@children.72/@ports.2"/>
+  <containedEdges identifier="E110" sources="//@children.70/@ports.3" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.71/@ports.0" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E112" sources="//@children.72/@ports.3" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.73/@ports.0" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E114" sources="//@children.74/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.75/@ports.0" targets="//@children.77/@ports.2"/>
+  <containedEdges identifier="E116" sources="//@children.76/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.77/@ports.3" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.78/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.78/@ports.1" targets="//@children.80/@ports.2"/>
+  <containedEdges identifier="E120" sources="//@children.78/@ports.1" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.79/@ports.2" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.79/@ports.1" targets="//@children.79/@ports.2"/>
+  <containedEdges identifier="E123" sources="//@children.80/@ports.3" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.81/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.82/@ports.1" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.83/@ports.1" targets="//@children.84/@ports.1"/>
+  <containedEdges identifier="E127" sources="//@children.84/@ports.2" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.84/@ports.3" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.86/@ports.3" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.86/@ports.3" targets="//@children.89/@ports.1"/>
+  <containedEdges identifier="E131" sources="//@children.87/@ports.1" targets="//@children.86/@ports.2"/>
+  <containedEdges identifier="E132" sources="//@children.88/@ports.3" targets="//@children.86/@ports.1"/>
+  <containedEdges identifier="E133" sources="//@children.88/@ports.2" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.89/@ports.2" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E135" sources="//@children.89/@ports.2" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E136" sources="//@children.89/@ports.3" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E137" sources="//@children.91/@ports.3" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.91/@ports.3" targets="//@children.94/@ports.1"/>
+  <containedEdges identifier="E139" sources="//@children.92/@ports.1" targets="//@children.91/@ports.2"/>
+  <containedEdges identifier="E140" sources="//@children.93/@ports.3" targets="//@children.91/@ports.1"/>
+  <containedEdges identifier="E141" sources="//@children.93/@ports.2" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.94/@ports.2" targets="//@children.79/@ports.1"/>
+  <containedEdges identifier="E143" sources="//@children.94/@ports.2" targets="//@children.80/@ports.1"/>
+  <containedEdges identifier="E144" sources="//@children.94/@ports.2" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E145" sources="//@children.94/@ports.3" targets="//@children.104/@ports.1"/>
+  <containedEdges identifier="E146" sources="//@children.96/@ports.3" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.96/@ports.3" targets="//@children.99/@ports.2"/>
+  <containedEdges identifier="E148" sources="//@children.97/@ports.1" targets="//@children.96/@ports.2"/>
+  <containedEdges identifier="E149" sources="//@children.98/@ports.3" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E150" sources="//@children.98/@ports.2" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.99/@ports.3" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.99/@ports.3" targets="//@children.98/@ports.1"/>
+  <containedEdges identifier="E153" sources="//@children.99/@ports.3" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.99/@ports.3" targets="//@children.93/@ports.1"/>
+  <containedEdges identifier="E155" sources="//@children.99/@ports.3" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.101/@ports.3" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.101/@ports.3" targets="//@children.104/@ports.2"/>
+  <containedEdges identifier="E158" sources="//@children.102/@ports.1" targets="//@children.101/@ports.2"/>
+  <containedEdges identifier="E159" sources="//@children.103/@ports.3" targets="//@children.101/@ports.1"/>
+  <containedEdges identifier="E160" sources="//@children.103/@ports.2" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E161" sources="//@children.104/@ports.3" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.104/@ports.3" targets="//@children.103/@ports.1"/>
+  <containedEdges identifier="E163" sources="//@children.104/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E164" sources="//@children.106/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E165" sources="//@children.106/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E166" sources="//@children.107/@ports.2" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E167" sources="//@children.107/@ports.1" targets="//@children.107/@ports.2"/>
+  <containedEdges identifier="E168" sources="//@children.108/@ports.3" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E169" sources="//@children.109/@ports.0" targets="//@children.108/@ports.1"/>
+  <containedEdges identifier="E170" sources="//@children.110/@ports.3" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E171" sources="//@children.110/@ports.2" targets="//@children.60/@ports.2"/>
+  <containedEdges identifier="E172" sources="//@children.112/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.112/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E174" sources="//@children.113/@ports.2" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E175" sources="//@children.113/@ports.1" targets="//@children.113/@ports.2"/>
+  <containedEdges identifier="E176" sources="//@children.114/@ports.3" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E177" sources="//@children.115/@ports.0" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E178" sources="//@children.116/@ports.3" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E179" sources="//@children.116/@ports.2" targets="//@children.64/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_countermachine_CounterMachinePrelim.elkg
+++ b/realworld/ptolemy/flattened/pn_countermachine_CounterMachinePrelim.elkg
@@ -1,0 +1,870 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Sequence2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Sequence3"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Sequence4"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Sequence5"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="51.0" text="Display5"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="51.0" text="Display6"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Sequence6"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="66.0" text="Sequence7"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="66.0" text="Sequence8"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.29" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.39" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.38" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.49 //@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.52 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="10.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="41.0" y="19.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.3" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.0" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.22/@ports.3" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.23/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.24/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.24/@ports.1" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E31" sources="//@children.25/@ports.3" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.26/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.27/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.28/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.29/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.29/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.31/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.31/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.32/@ports.2" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.32/@ports.1" targets="//@children.32/@ports.2"/>
+  <containedEdges identifier="E41" sources="//@children.33/@ports.3" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.34/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.35/@ports.3" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.35/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.37/@ports.3" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.37/@ports.3" targets="//@children.40/@ports.2"/>
+  <containedEdges identifier="E47" sources="//@children.38/@ports.1" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.39/@ports.3" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.39/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.40/@ports.3" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.40/@ports.3" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.40/@ports.3" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.42/@ports.3" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.42/@ports.3" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.43/@ports.1" targets="//@children.42/@ports.2"/>
+  <containedEdges identifier="E56" sources="//@children.44/@ports.3" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.44/@ports.2" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.45/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.45/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.47/@ports.1" targets="//@children.48/@ports.2"/>
+  <containedEdges identifier="E61" sources="//@children.47/@ports.1" targets="//@children.50/@ports.2"/>
+  <containedEdges identifier="E62" sources="//@children.49/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.50/@ports.3" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.51/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.52/@ports.1" targets="//@children.50/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_countermachine_CounterMachineWithException.elkg
+++ b/realworld/ptolemy/flattened/pn_countermachine_CounterMachineWithException.elkg
@@ -1,0 +1,2306 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="85.0" text="SampleDelay3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.26 //@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.37 //@containedEdges.38 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.41" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.39 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.56 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.61 //@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.65 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.70 //@containedEdges.71 //@containedEdges.72 //@containedEdges.73 //@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.75 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.80 //@containedEdges.81 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.114 //@containedEdges.115 //@containedEdges.116 //@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.90 //@containedEdges.91 //@containedEdges.92 //@containedEdges.93 //@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17 //@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.95 //@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.18 //@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.98 //@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="48.0" text="Equals3"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19 //@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.101 //@containedEdges.102 //@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="48.0" text="Equals4"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20 //@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.105 //@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.83 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.110 //@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="49.0" text="Const13"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P177" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="49.0" text="Const14"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="92.0" text="BooleanSelect3"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="92.0" text="BooleanSelect4"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="10.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="52.0" text="Discard2"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="52.0" text="Discard3"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="94.0" text="BooleanSwitch5"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="52.0" text="Discard4"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.93 //@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.126 //@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.94 //@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.128 //@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P214" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.132 //@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P228" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.142 //@containedEdges.143 //@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.146" incomingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.145" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P249" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.144 //@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.153 //@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.158 //@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P274" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.161 //@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P287" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.166 //@containedEdges.167 //@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P292" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.170 //@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P295" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P297" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.175 //@containedEdges.176 //@containedEdges.177 //@containedEdges.178 //@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P304" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P307" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.180 //@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P310" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P312" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P314" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.185 //@containedEdges.186 //@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P319" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.188 //@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.191" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.190" incomingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P327" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P332" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P335" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.196 //@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="100.0" text="TransitionFunctio"/>
+    <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.199" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.198" incomingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P343" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P345" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P348" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P349" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P350" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P351" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.123/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.124/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.1" targets="//@children.126/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.1" targets="//@children.104/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.1" targets="//@children.129/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.2/@ports.1" targets="//@children.130/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.1" targets="//@children.132/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.3/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.1" targets="//@children.55/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.3/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.3/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.3/@ports.1" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.7/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.7/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.8/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.8/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.9/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.10/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.11/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.11/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E30" sources="//@children.12/@ports.3" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.13/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.14/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.15/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.16/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.17/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E36" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.19/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.20/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.20/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.20/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.21/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.21/@ports.1" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E43" sources="//@children.22/@ports.3" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.23/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.24/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.25/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.26/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.26/@ports.3" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.28/@ports.3" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.28/@ports.3" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.29/@ports.1" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.30/@ports.3" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.30/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.31/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.31/@ports.2" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.31/@ports.3" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.33/@ports.3" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.33/@ports.3" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.34/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E60" sources="//@children.35/@ports.3" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.35/@ports.2" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.36/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.36/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.36/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.36/@ports.3" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.38/@ports.3" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.38/@ports.3" targets="//@children.41/@ports.2"/>
+  <containedEdges identifier="E68" sources="//@children.39/@ports.1" targets="//@children.38/@ports.2"/>
+  <containedEdges identifier="E69" sources="//@children.40/@ports.3" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.40/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.41/@ports.3" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.41/@ports.3" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.41/@ports.3" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.41/@ports.3" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.41/@ports.3" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.43/@ports.3" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.43/@ports.3" targets="//@children.46/@ports.2"/>
+  <containedEdges identifier="E78" sources="//@children.44/@ports.1" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E79" sources="//@children.45/@ports.3" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.45/@ports.2" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.46/@ports.3" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.46/@ports.3" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E83" sources="//@children.46/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.48/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.49/@ports.0" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.50/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E87" sources="//@children.51/@ports.3" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.53/@ports.3" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.54/@ports.3" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.54/@ports.2" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.55/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.55/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.55/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.55/@ports.1" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.55/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.56/@ports.1" targets="//@children.53/@ports.2"/>
+  <containedEdges identifier="E97" sources="//@children.56/@ports.1" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E98" sources="//@children.57/@ports.0" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.58/@ports.1" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.58/@ports.1" targets="//@children.66/@ports.2"/>
+  <containedEdges identifier="E101" sources="//@children.59/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.60/@ports.1" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E103" sources="//@children.60/@ports.1" targets="//@children.73/@ports.2"/>
+  <containedEdges identifier="E104" sources="//@children.60/@ports.1" targets="//@children.79/@ports.1"/>
+  <containedEdges identifier="E105" sources="//@children.61/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.62/@ports.1" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E107" sources="//@children.62/@ports.1" targets="//@children.75/@ports.2"/>
+  <containedEdges identifier="E108" sources="//@children.63/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.64/@ports.2" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.65/@ports.3" targets="//@children.66/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.65/@ports.2" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.66/@ports.3" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.67/@ports.2" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.68/@ports.0" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.69/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.70/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.71/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.72/@ports.3" targets="//@children.73/@ports.1"/>
+  <containedEdges identifier="E119" sources="//@children.72/@ports.2" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.73/@ports.3" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.74/@ports.3" targets="//@children.75/@ports.1"/>
+  <containedEdges identifier="E122" sources="//@children.74/@ports.2" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.75/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.78/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.79/@ports.2" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.79/@ports.3" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.81/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.81/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.82/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.82/@ports.1" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.83/@ports.0" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.84/@ports.0" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.85/@ports.1" targets="//@children.86/@ports.2"/>
+  <containedEdges identifier="E134" sources="//@children.85/@ports.1" targets="//@children.88/@ports.2"/>
+  <containedEdges identifier="E135" sources="//@children.86/@ports.3" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.87/@ports.0" targets="//@children.86/@ports.1"/>
+  <containedEdges identifier="E137" sources="//@children.88/@ports.3" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.89/@ports.0" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E139" sources="//@children.90/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.91/@ports.0" targets="//@children.93/@ports.2"/>
+  <containedEdges identifier="E141" sources="//@children.92/@ports.0" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.93/@ports.3" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.94/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.94/@ports.1" targets="//@children.96/@ports.2"/>
+  <containedEdges identifier="E145" sources="//@children.94/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.95/@ports.2" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.95/@ports.1" targets="//@children.95/@ports.2"/>
+  <containedEdges identifier="E148" sources="//@children.96/@ports.3" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E149" sources="//@children.97/@ports.0" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.98/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.99/@ports.1" targets="//@children.100/@ports.1"/>
+  <containedEdges identifier="E152" sources="//@children.100/@ports.2" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.100/@ports.3" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.102/@ports.3" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E155" sources="//@children.102/@ports.3" targets="//@children.105/@ports.1"/>
+  <containedEdges identifier="E156" sources="//@children.103/@ports.1" targets="//@children.102/@ports.2"/>
+  <containedEdges identifier="E157" sources="//@children.104/@ports.3" targets="//@children.102/@ports.1"/>
+  <containedEdges identifier="E158" sources="//@children.104/@ports.2" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.105/@ports.2" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E160" sources="//@children.105/@ports.2" targets="//@children.93/@ports.1"/>
+  <containedEdges identifier="E161" sources="//@children.105/@ports.3" targets="//@children.115/@ports.1"/>
+  <containedEdges identifier="E162" sources="//@children.107/@ports.3" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.107/@ports.3" targets="//@children.110/@ports.1"/>
+  <containedEdges identifier="E164" sources="//@children.108/@ports.1" targets="//@children.107/@ports.2"/>
+  <containedEdges identifier="E165" sources="//@children.109/@ports.3" targets="//@children.107/@ports.1"/>
+  <containedEdges identifier="E166" sources="//@children.109/@ports.2" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E167" sources="//@children.110/@ports.2" targets="//@children.95/@ports.1"/>
+  <containedEdges identifier="E168" sources="//@children.110/@ports.2" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E169" sources="//@children.110/@ports.2" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E170" sources="//@children.110/@ports.3" targets="//@children.120/@ports.1"/>
+  <containedEdges identifier="E171" sources="//@children.112/@ports.3" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E172" sources="//@children.112/@ports.3" targets="//@children.115/@ports.2"/>
+  <containedEdges identifier="E173" sources="//@children.113/@ports.1" targets="//@children.112/@ports.2"/>
+  <containedEdges identifier="E174" sources="//@children.114/@ports.3" targets="//@children.112/@ports.1"/>
+  <containedEdges identifier="E175" sources="//@children.114/@ports.2" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E176" sources="//@children.115/@ports.3" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E177" sources="//@children.115/@ports.3" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E178" sources="//@children.115/@ports.3" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E179" sources="//@children.115/@ports.3" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E180" sources="//@children.115/@ports.3" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E181" sources="//@children.117/@ports.3" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E182" sources="//@children.117/@ports.3" targets="//@children.120/@ports.2"/>
+  <containedEdges identifier="E183" sources="//@children.118/@ports.1" targets="//@children.117/@ports.2"/>
+  <containedEdges identifier="E184" sources="//@children.119/@ports.3" targets="//@children.117/@ports.1"/>
+  <containedEdges identifier="E185" sources="//@children.119/@ports.2" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E186" sources="//@children.120/@ports.3" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E187" sources="//@children.120/@ports.3" targets="//@children.119/@ports.1"/>
+  <containedEdges identifier="E188" sources="//@children.120/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E189" sources="//@children.122/@ports.1" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E190" sources="//@children.122/@ports.1" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E191" sources="//@children.123/@ports.2" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.123/@ports.1" targets="//@children.123/@ports.2"/>
+  <containedEdges identifier="E193" sources="//@children.124/@ports.3" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E194" sources="//@children.125/@ports.0" targets="//@children.124/@ports.1"/>
+  <containedEdges identifier="E195" sources="//@children.126/@ports.3" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E196" sources="//@children.126/@ports.2" targets="//@children.51/@ports.2"/>
+  <containedEdges identifier="E197" sources="//@children.128/@ports.1" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E198" sources="//@children.128/@ports.1" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E199" sources="//@children.129/@ports.2" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E200" sources="//@children.129/@ports.1" targets="//@children.129/@ports.2"/>
+  <containedEdges identifier="E201" sources="//@children.130/@ports.3" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E202" sources="//@children.131/@ports.0" targets="//@children.130/@ports.1"/>
+  <containedEdges identifier="E203" sources="//@children.132/@ports.3" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E204" sources="//@children.132/@ports.2" targets="//@children.52/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_orderedmerge_OrderedMerge.elkg
+++ b/realworld/ptolemy/flattened/pn_orderedmerge_OrderedMerge.elkg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="OrderedMerge"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="90.0" text="OrderedMerge2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="117.0" text="Limit on powers of 5"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_removeniltokens_RemoveNilTokens.elkg
+++ b/realworld/ptolemy/flattened/pn_removeniltokens_RemoveNilTokens.elkg
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="23.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="23.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="132.0" text="Data without nil tokens"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="28.0" text="Limit"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="102.0" text="RemoveNilTokens"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="114.0" text="Data with nil tokens"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.3" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pn_stack_Stack.elkg
+++ b/realworld/ptolemy/flattened/pn_stack_Stack.elkg
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="30.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="92.0" text="BooleanSelect3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.3" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.1" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.11/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.3" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.12/@ports.3" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.12/@ports.3" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.12/@ports.3" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E25" sources="//@children.13/@ports.3" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.14/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.14/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.15/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.16/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.16/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.17/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.17/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.18/@ports.2" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.18/@ports.3" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.19/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.21/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.21/@ports.3" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.22/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.24/@ports.2" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.24/@ports.3" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.25/@ports.0" targets="//@children.13/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/psdf_blindcommunication_BlindCommunication.elkg
+++ b/realworld/ptolemy/flattened/psdf_blindcommunication_BlindCommunication.elkg
@@ -1,0 +1,720 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="75.0" text="AudioReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="119.0" text="CartesianToComplex"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="118.0" text="Baud Rate Estimate"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="95.0" text="Carrier Estimate"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="82.0" text="Sample Count"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="Phase states"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="264.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="136.0" text="ConvertBinToFrequency"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="264.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="250.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="58.0" text="Mix Down"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="250.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="145.0" text="PlotSpectrumWithCarrier"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="88.0" text="ArrayMaximum"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="597.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="105.0" text="RegenerateCarrier"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="597.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="163.0" text="PlotSpectrumWithoutCarrier"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="Periodogram"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="132.0" text="SmoothedPeriodogram"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="31.0" text="Chop"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="24.0" text="FFT"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="81.0" text="PhaseUnwrap"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="91.0" text="AbsoluteValue2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="298.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="193.0" text="ConvertBinAndOffsetToFrequency"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="298.0" y="8.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="88.0" text="ArrayMaximum"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="95.0" text="ComplexToPolar"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="60.0" text="Differential"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="66.0" text="CountTrues"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="242.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="95.0" text="IncrementPhase"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="242.0" y="8.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="90.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="122.0" text="IdentifyBaudSamples"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="95.0" text="ComplexToPolar"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="111.0" text="ComputeHistogram"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="103.0" text="ArrayPeakSearch"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="60.0" text="Differential"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="570.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="32.0" text="Wrap"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="570.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="95.0" text="ComplexToPolar"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="21.0" text="FIR"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.22/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.23/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.24/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.25/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.26/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.27/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.1" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.29/@ports.1" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.30/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.30/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.31/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.31/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.32/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.33/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.34/@ports.3" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.35/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.36/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.37/@ports.1" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E44" sources="//@children.38/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.39/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.40/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.41/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.41/@ports.3" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.42/@ports.2" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.42/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.44/@ports.1" targets="//@children.41/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptalon_smallworld_ParameterSweepSmallWorldSDF.elkg
+++ b/realworld/ptolemy/flattened/ptalon_smallworld_ParameterSweepSmallWorldSDF.elkg
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="64.0" text="startRange"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="130.0" text="VisualModelReference"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="26.0" text="Zero"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="182.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="182.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="93.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="93.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.2" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptalon_smallworld_SmallWorldMultiInstanceComposite.elkg
+++ b/realworld/ptolemy/flattened/ptalon_smallworld_SmallWorldMultiInstanceComposite.elkg
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="99.0" text="WirelessToWired"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="134.0" text="AverageNumberOfHops"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="89.0" text="NumberOfLinks"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="101.0" text="ExpressionWriter"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="49.0" text="Previous"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="113.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="113.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.14/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.16/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.17/@ports.0" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_chat_ChatClient.elkg
+++ b/realworld/ptolemy/flattened/ptango_chat_ChatClient.elkg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="87.0" text="InteractiveShell"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="HttpPost"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="143.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="143.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="45.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="45.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="45.0" text="HttpGet"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="87.0" text="StringCompare"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.3" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_chat_ChatClient2.elkg
+++ b/realworld/ptolemy/flattened/ptango_chat_ChatClient2.elkg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="87.0" text="InteractiveShell"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="HttpPost"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="143.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="143.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="45.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="45.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="45.0" text="HttpGet"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="87.0" text="StringCompare"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="18.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.3" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_chat_ChatServer.elkg
+++ b/realworld/ptolemy/flattened/ptango_chat_ChatServer.elkg
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="63.0" text="HttpActor2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="63.0" text="HttpActor3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="36.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="28.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="95.0" text="ResettableTimer"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="154.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="154.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="114.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="114.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="36.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="28.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="95.0" text="ResettableTimer"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="154.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="154.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="114.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="114.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.19/@ports.1" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_cookies_Cookies.elkg
+++ b/realworld/ptolemy/flattened/ptango_cookies_Cookies.elkg
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.11 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="127.0" text="HTMLPageAssembler"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="134.0" text="HTMLPageAssembler2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="HttpActor2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="24.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="32.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="279.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="279.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="69.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="69.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="345.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="345.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="55.0" width="249.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="249.0" y="23.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="98.0" text="MicrostepDelay4"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="MicrostepDelay5"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.5" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.3/@ports.4"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.3/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_eplus70actuator_EPlus70Actuator.elkg
+++ b/realworld/ptolemy/flattened/ptango_eplus70actuator_EPlus70Actuator.elkg
@@ -1,0 +1,1121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.43 //@containedEdges.59 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="107.0" text="ElementsToArray2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.51 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="109.0" text="DygraphsJSPlotter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="89.0" text="TokenToJSON2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="52.0" text="RunTime"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="90.0" text="SimulationTime"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="78.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="110.0" text="PlotterTemperature"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="56.0" text="Simulator"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="125.0" text="PlotterSolarIrradiation"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="101.0" text="shadingController"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="79.0" text="PlotterControl"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="150.0" text="PlotterFractionShadingOn"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="111.0" text="RecordAssembler3"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="111.0" text="RecordAssembler4"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="353.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="353.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="111.0" text="RecordAssembler5"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="178.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="178.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="165.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="165.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.8/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.8/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.8/@ports.1" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.1" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.8/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.12/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.12/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.12/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.13/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.15/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.17/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.17/@ports.2" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.20/@ports.1" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.20/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.21/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.22/@ports.0" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.23/@ports.0" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.24/@ports.0" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.25/@ports.0" targets="//@children.24/@ports.3"/>
+  <containedEdges identifier="E38" sources="//@children.26/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.27/@ports.0" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.28/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.29/@ports.0" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E42" sources="//@children.30/@ports.0" targets="//@children.21/@ports.3"/>
+  <containedEdges identifier="E43" sources="//@children.31/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.32/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.33/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.34/@ports.1" targets="//@children.32/@ports.2"/>
+  <containedEdges identifier="E47" sources="//@children.35/@ports.0" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.36/@ports.0" targets="//@children.35/@ports.3"/>
+  <containedEdges identifier="E49" sources="//@children.37/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.38/@ports.0" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.39/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.40/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.41/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.42/@ports.1" targets="//@children.40/@ports.2"/>
+  <containedEdges identifier="E55" sources="//@children.43/@ports.0" targets="//@children.42/@ports.2"/>
+  <containedEdges identifier="E56" sources="//@children.44/@ports.0" targets="//@children.43/@ports.3"/>
+  <containedEdges identifier="E57" sources="//@children.45/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.46/@ports.0" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E59" sources="//@children.47/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.48/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.49/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.50/@ports.1" targets="//@children.48/@ports.2"/>
+  <containedEdges identifier="E63" sources="//@children.51/@ports.0" targets="//@children.50/@ports.2"/>
+  <containedEdges identifier="E64" sources="//@children.52/@ports.0" targets="//@children.51/@ports.3"/>
+  <containedEdges identifier="E65" sources="//@children.53/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.54/@ports.0" targets="//@children.51/@ports.2"/>
+  <containedEdges identifier="E67" sources="//@children.55/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.56/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.57/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.58/@ports.1" targets="//@children.56/@ports.2"/>
+  <containedEdges identifier="E71" sources="//@children.59/@ports.0" targets="//@children.58/@ports.2"/>
+  <containedEdges identifier="E72" sources="//@children.60/@ports.0" targets="//@children.59/@ports.3"/>
+  <containedEdges identifier="E73" sources="//@children.61/@ports.0" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.62/@ports.0" targets="//@children.59/@ports.2"/>
+  <containedEdges identifier="E75" sources="//@children.63/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.64/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.65/@ports.0" targets="//@children.64/@ports.1"/>
+  <containedEdges identifier="E78" sources="//@children.66/@ports.1" targets="//@children.64/@ports.2"/>
+  <containedEdges identifier="E79" sources="//@children.67/@ports.0" targets="//@children.66/@ports.2"/>
+  <containedEdges identifier="E80" sources="//@children.68/@ports.0" targets="//@children.67/@ports.3"/>
+  <containedEdges identifier="E81" sources="//@children.69/@ports.0" targets="//@children.67/@ports.1"/>
+  <containedEdges identifier="E82" sources="//@children.70/@ports.0" targets="//@children.67/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_guidance_Guidance.elkg
+++ b/realworld/ptolemy/flattened/ptango_guidance_Guidance.elkg
@@ -1,0 +1,1118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.57 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24 //@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.28 //@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="32.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="119.0" text="HTMLModelExporter"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="-4.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="12.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="36.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="126.0" text="HTMLModelExporter2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="-4.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="12.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="36.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="49.0" text="Const13"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="49.0" text="Const14"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="49.0" text="Const15"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="49.0" text="Const16"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="49.0" text="Const17"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="49.0" text="Const18"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="49.0" text="Const19"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="49.0" text="Const20"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="49.0" text="Const32"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="128.0" text="RecordDisassembler3"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="120.0" text="ExpressionToToken2"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="30.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="30.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="30.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="30.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="30.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.64 //@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="84.0" text="StringMatches"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.68 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.70 //@containedEdges.71 //@containedEdges.72 //@containedEdges.73 //@containedEdges.74 //@containedEdges.75 //@containedEdges.76 //@containedEdges.77 //@containedEdges.78 //@containedEdges.79 //@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="92.0" text="StringMatches2"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.81 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="92.0" text="StringMatches3"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.83 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="92.0" text="StringMatches4"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.85 //@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="92.0" text="StringMatches5"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.87 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.89 //@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="92.0" text="BooleanSelect3"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.93 //@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.96 //@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="92.0" text="BooleanSelect4"/>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="74.0" text="SetVariable7"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="74.0" text="SetVariable8"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="94.0" text="BooleanSwitch5"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.100 //@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="92.0" text="BooleanSelect5"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="74.0" text="SetVariable9"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="81.0" text="SetVariable10"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.2" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.2" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.2" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.0/@ports.2" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.0/@ports.3" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.0/@ports.3" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.0/@ports.3" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.0/@ports.3" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.0/@ports.3" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.0/@ports.3" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.0/@ports.3" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.0/@ports.3" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.0/@ports.3" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.0/@ports.3" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.1/@ports.5" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.1/@ports.3" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.1/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.1/@ports.3" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.1/@ports.3" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.1/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.1/@ports.3" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.1/@ports.3" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.1/@ports.3" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.1/@ports.3" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.1/@ports.3" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.1/@ports.4" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.2/@ports.11" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.5/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.6/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E38" sources="//@children.7/@ports.0" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E39" sources="//@children.8/@ports.0" targets="//@children.2/@ports.5"/>
+  <containedEdges identifier="E40" sources="//@children.9/@ports.0" targets="//@children.2/@ports.6"/>
+  <containedEdges identifier="E41" sources="//@children.10/@ports.0" targets="//@children.2/@ports.7"/>
+  <containedEdges identifier="E42" sources="//@children.11/@ports.0" targets="//@children.2/@ports.8"/>
+  <containedEdges identifier="E43" sources="//@children.12/@ports.0" targets="//@children.2/@ports.9"/>
+  <containedEdges identifier="E44" sources="//@children.13/@ports.11" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.14/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.15/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.16/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.17/@ports.0" targets="//@children.13/@ports.3"/>
+  <containedEdges identifier="E49" sources="//@children.18/@ports.0" targets="//@children.13/@ports.4"/>
+  <containedEdges identifier="E50" sources="//@children.19/@ports.0" targets="//@children.13/@ports.5"/>
+  <containedEdges identifier="E51" sources="//@children.20/@ports.0" targets="//@children.13/@ports.6"/>
+  <containedEdges identifier="E52" sources="//@children.21/@ports.0" targets="//@children.13/@ports.7"/>
+  <containedEdges identifier="E53" sources="//@children.22/@ports.0" targets="//@children.13/@ports.8"/>
+  <containedEdges identifier="E54" sources="//@children.23/@ports.0" targets="//@children.13/@ports.9"/>
+  <containedEdges identifier="E55" sources="//@children.24/@ports.0" targets="//@children.13/@ports.10"/>
+  <containedEdges identifier="E56" sources="//@children.25/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.26/@ports.1" targets="//@children.2/@ports.10"/>
+  <containedEdges identifier="E58" sources="//@children.27/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.28/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.29/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.30/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.31/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.32/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.33/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.34/@ports.2" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.34/@ports.2" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.35/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.37/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.39/@ports.2" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.39/@ports.2" targets="//@children.40/@ports.2"/>
+  <containedEdges identifier="E71" sources="//@children.40/@ports.3" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E72" sources="//@children.40/@ports.3" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.40/@ports.3" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.40/@ports.3" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.40/@ports.3" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.40/@ports.3" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E77" sources="//@children.40/@ports.3" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E78" sources="//@children.40/@ports.3" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E79" sources="//@children.40/@ports.3" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.40/@ports.3" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.40/@ports.3" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E82" sources="//@children.41/@ports.2" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E83" sources="//@children.41/@ports.2" targets="//@children.46/@ports.2"/>
+  <containedEdges identifier="E84" sources="//@children.42/@ports.2" targets="//@children.47/@ports.2"/>
+  <containedEdges identifier="E85" sources="//@children.42/@ports.2" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.43/@ports.2" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E87" sources="//@children.43/@ports.2" targets="//@children.52/@ports.2"/>
+  <containedEdges identifier="E88" sources="//@children.44/@ports.2" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E89" sources="//@children.44/@ports.2" targets="//@children.56/@ports.2"/>
+  <containedEdges identifier="E90" sources="//@children.45/@ports.2" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.45/@ports.2" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.46/@ports.3" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E93" sources="//@children.47/@ports.3" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E94" sources="//@children.48/@ports.2" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.48/@ports.2" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.49/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.51/@ports.2" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.51/@ports.2" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.52/@ports.3" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.53/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.55/@ports.2" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.55/@ports.2" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.55/@ports.3" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E104" sources="//@children.56/@ports.3" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E105" sources="//@children.57/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.59/@ports.0" targets="//@children.56/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_optimizationadvisor_OptimizationAdvisor.elkg
+++ b/realworld/ptolemy/flattened/ptango_optimizationadvisor_OptimizationAdvisor.elkg
@@ -1,0 +1,1504 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="49.0" text="Previous"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="Previous2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="57.0" text="Previous3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="57.0" text="Previous4"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="TOut"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="68.0" text="controlError"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="76.0" text="HeaterStates"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="95.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="95.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="86.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="86.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="274.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="274.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31 //@containedEdges.32 //@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="17.0" text="Kp"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.38 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="72.0" text="pastMorning"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="49.0" text="dayStart"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="48.0" text="pastDay"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="58.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="56.0" text="nightStart"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="58.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.40 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="125.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="46.0" text="TSetPoi"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="125.0" y="8.5" outgoingEdges="//@containedEdges.45 //@containedEdges.46 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="61.0" text="timeOfDay"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="111.0" text="RecordAssembler5"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="147.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="147.0" y="8.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="147.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="147.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="72.0" text="pastMorning"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="78.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="49.0" text="dayStart"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="48.0" text="pastDay"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="119.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="56.0" text="nightStart"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="119.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.55 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="25.0" width="116.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="46.0" text="TSetPoi"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="116.0" y="8.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="61.0" text="timeOfDay"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.68 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="107.0" text="ElementsToArray2"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="89.0" text="TokenToJSON2"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="59.0" text="TOutArray"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="25.0" width="80.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="63.0" text="EmptyItem"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="10.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="10.0" y="11.600000381469727" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="10.0" y="21.399999618530273" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="10.0" y="31.200000762939453" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="31.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="120.0" text="ExpressionToToken2"/>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="31.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="120.0" text="ExpressionToToken3"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="31.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="120.0" text="ExpressionToToken4"/>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="31.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="25.0" width="141.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P188" height="8.0" width="8.0" x="141.0" y="8.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="25.0" width="148.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="148.0" y="8.5" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="25.0" width="146.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="25.0" width="149.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="149.0" y="8.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="127.0" text="HTMLPageAssembler"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="-2.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="22.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P209" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="60.0" text="StringSplit"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="25.0" width="260.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P214" height="8.0" width="8.0" x="260.0" y="8.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="100.0" width="591.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="73.0" text="Expression5"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="591.0" y="46.0" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="13.600000381469727" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="35.20000076293945" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="56.79999923706055">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="78.4000015258789" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="25.0" width="272.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="73.0" text="Expression6"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="272.0" y="8.5" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="25.0" width="266.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="266.0" y="8.5" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="25.0" width="278.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P225" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="71.0" width="329.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="329.0" y="31.5" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="31.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.4" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.3" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.3" targets="//@children.79/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.3" targets="//@children.80/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.85/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.87/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.1" targets="//@children.86/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.1" targets="//@children.90/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.1" targets="//@children.86/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.1" targets="//@children.86/@ports.4"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.1" targets="//@children.35/@ports.3"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.36/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.15/@ports.1" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.15/@ports.1" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.15/@ports.1" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.20/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.20/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.20/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.20/@ports.1" targets="//@children.32/@ports.2"/>
+  <containedEdges identifier="E35" sources="//@children.20/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.21/@ports.1" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.22/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.23/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.24/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.24/@ports.1" targets="//@children.19/@ports.3"/>
+  <containedEdges identifier="E41" sources="//@children.25/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.26/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.27/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.28/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.29/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.30/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.30/@ports.0" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.30/@ports.0" targets="//@children.42/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.31/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.31/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.32/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.33/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.34/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.35/@ports.0" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.36/@ports.0" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E56" sources="//@children.37/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.38/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.39/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.40/@ports.0" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.41/@ports.1" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.42/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.43/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.43/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.44/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.45/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.46/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.47/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.48/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.49/@ports.0" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.50/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.51/@ports.1" targets="//@children.49/@ports.2"/>
+  <containedEdges identifier="E72" sources="//@children.52/@ports.0" targets="//@children.51/@ports.2"/>
+  <containedEdges identifier="E73" sources="//@children.53/@ports.0" targets="//@children.52/@ports.3"/>
+  <containedEdges identifier="E74" sources="//@children.54/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.55/@ports.0" targets="//@children.52/@ports.2"/>
+  <containedEdges identifier="E76" sources="//@children.56/@ports.1" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.57/@ports.0" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.58/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E79" sources="//@children.59/@ports.1" targets="//@children.57/@ports.2"/>
+  <containedEdges identifier="E80" sources="//@children.60/@ports.0" targets="//@children.59/@ports.2"/>
+  <containedEdges identifier="E81" sources="//@children.61/@ports.0" targets="//@children.60/@ports.3"/>
+  <containedEdges identifier="E82" sources="//@children.62/@ports.0" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E83" sources="//@children.63/@ports.0" targets="//@children.60/@ports.2"/>
+  <containedEdges identifier="E84" sources="//@children.64/@ports.1" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.65/@ports.0" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.66/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E87" sources="//@children.67/@ports.1" targets="//@children.65/@ports.2"/>
+  <containedEdges identifier="E88" sources="//@children.68/@ports.0" targets="//@children.67/@ports.2"/>
+  <containedEdges identifier="E89" sources="//@children.69/@ports.0" targets="//@children.68/@ports.3"/>
+  <containedEdges identifier="E90" sources="//@children.70/@ports.0" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E91" sources="//@children.71/@ports.0" targets="//@children.68/@ports.2"/>
+  <containedEdges identifier="E92" sources="//@children.72/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.72/@ports.2" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.72/@ports.3" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.72/@ports.4" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.77/@ports.0" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E97" sources="//@children.78/@ports.0" targets="//@children.81/@ports.2"/>
+  <containedEdges identifier="E98" sources="//@children.79/@ports.0" targets="//@children.81/@ports.3"/>
+  <containedEdges identifier="E99" sources="//@children.80/@ports.0" targets="//@children.81/@ports.4"/>
+  <containedEdges identifier="E100" sources="//@children.81/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.82/@ports.7" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.83/@ports.0" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.84/@ports.1" targets="//@children.82/@ports.4"/>
+  <containedEdges identifier="E104" sources="//@children.85/@ports.0" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.86/@ports.0" targets="//@children.82/@ports.5"/>
+  <containedEdges identifier="E106" sources="//@children.87/@ports.0" targets="//@children.82/@ports.1"/>
+  <containedEdges identifier="E107" sources="//@children.88/@ports.0" targets="//@children.82/@ports.2"/>
+  <containedEdges identifier="E108" sources="//@children.89/@ports.0" targets="//@children.82/@ports.3"/>
+  <containedEdges identifier="E109" sources="//@children.90/@ports.0" targets="//@children.82/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_smartroom_SmartRoom.elkg
+++ b/realworld/ptolemy/flattened/ptango_smartroom_SmartRoom.elkg
@@ -1,0 +1,554 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="HttpActor3"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="63.0" text="HttpActor2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="4.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="56.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="56.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="130.0" text="VisualModelReference"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="89.0" text="TokenToJSON2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="56.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="56.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="98.0" text="MicrostepDelay4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="89.0" text="JSONToToken2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="89.0" text="TokenToJSON3"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="120.0" text="ExpressionToToken2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="120.0" text="ExpressionToToken2"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="10.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="10.0" y="11.600000381469727" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="21.399999618530273" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="31.200000762939453" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="120.0" text="ExpressionToToken3"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.3" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.1" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.26/@ports.3" targets="//@children.25/@ports.3"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.28/@ports.1" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.30/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.30/@ports.2" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.30/@ports.3" targets="//@children.29/@ports.3"/>
+  <containedEdges identifier="E37" sources="//@children.30/@ports.4" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.31/@ports.1" targets="//@children.29/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_temperaturesimulation_EPlusSimulation.elkg
+++ b/realworld/ptolemy/flattened/ptango_temperaturesimulation_EPlusSimulation.elkg
@@ -1,0 +1,5824 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="52.0" text="RunTime"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="90.0" text="SimulationTime"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="78.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="EnergyPlus"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="63.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="42.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="38.0" text="Round"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="46.0" text="TReturn"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="28.0" text="TOut"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="41.0" text="TRoom"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="32.83333206176758">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="50.0" text="TRooExt"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31 //@containedEdges.32 //@containedEdges.33 //@containedEdges.34 //@containedEdges.35 //@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="129.0" text="DayTimeTemperatures"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30 //@containedEdges.31 //@containedEdges.32 //@containedEdges.33 //@containedEdges.34 //@containedEdges.35 //@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="149.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="70.0" text="TSetPoiCoo"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="149.0" y="8.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="458.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="TSetCooOn"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="458.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="52.0" text="TOutLow"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="50.0" text="TRooHig"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="44.0" text="TOutDif"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="53.0" text="Minimum"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.43 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="57.0" text="Maximum"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.47 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="57.0" text="TRooHig2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="172.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="70.0" text="TSetPoiHea"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="172.0" y="8.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.53 //@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63 //@containedEdges.64 //@containedEdges.65 //@containedEdges.66 //@containedEdges.67 //@containedEdges.68 //@containedEdges.69 //@containedEdges.70 //@containedEdges.71 //@containedEdges.72 //@containedEdges.73 //@containedEdges.74 //@containedEdges.75 //@containedEdges.76 //@containedEdges.77 //@containedEdges.78 //@containedEdges.79 //@containedEdges.80 //@containedEdges.81 //@containedEdges.82 //@containedEdges.83 //@containedEdges.84 //@containedEdges.85 //@containedEdges.86 //@containedEdges.87 //@containedEdges.88 //@containedEdges.89 //@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="72.0" text="pastMorning"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="49.0" text="dayStart"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="48.0" text="pastDay"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.93 //@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="56.0" text="nightStart"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="66.0" y="8.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.91 //@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.96 //@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="91.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="61.0" text="timeOfDay"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="91.0" y="8.5" outgoingEdges="//@containedEdges.98 //@containedEdges.99 //@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="108.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="91.0" text="occupancyStart"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="119.0" text="pastOccupancyStart"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.94 //@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="31.0" text="TRoo"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.104 //@containedEdges.105 //@containedEdges.106 //@containedEdges.107 //@containedEdges.108 //@containedEdges.109 //@containedEdges.110 //@containedEdges.111 //@containedEdges.112 //@containedEdges.113 //@containedEdges.114 //@containedEdges.115 //@containedEdges.116 //@containedEdges.117 //@containedEdges.118 //@containedEdges.119 //@containedEdges.120 //@containedEdges.121 //@containedEdges.122 //@containedEdges.123 //@containedEdges.124 //@containedEdges.125 //@containedEdges.126 //@containedEdges.127 //@containedEdges.128 //@containedEdges.129 //@containedEdges.130 //@containedEdges.131 //@containedEdges.132 //@containedEdges.133 //@containedEdges.134 //@containedEdges.135 //@containedEdges.136 //@containedEdges.137 //@containedEdges.138 //@containedEdges.139 //@containedEdges.140 //@containedEdges.141 //@containedEdges.142 //@containedEdges.143 //@containedEdges.144 //@containedEdges.145 //@containedEdges.146 //@containedEdges.147 //@containedEdges.148 //@containedEdges.149 //@containedEdges.150 //@containedEdges.151 //@containedEdges.152 //@containedEdges.153 //@containedEdges.154 //@containedEdges.155 //@containedEdges.156 //@containedEdges.157 //@containedEdges.158 //@containedEdges.159 //@containedEdges.160 //@containedEdges.161 //@containedEdges.162 //@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.207 //@containedEdges.232 //@containedEdges.257 //@containedEdges.282 //@containedEdges.307">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.164 //@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="62.0" text="CSup_flow"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.166 //@containedEdges.167 //@containedEdges.168 //@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="52.0" text="mRooms"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.208 //@containedEdges.233 //@containedEdges.258 //@containedEdges.283 //@containedEdges.308 //@containedEdges.332 //@containedEdges.356 //@containedEdges.380 //@containedEdges.404 //@containedEdges.428 //@containedEdges.452 //@containedEdges.476">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.170 //@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="77.0" text="mNormalized"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="51.0" text="QRooms"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.212 //@containedEdges.237 //@containedEdges.262 //@containedEdges.287 //@containedEdges.312 //@containedEdges.336 //@containedEdges.360 //@containedEdges.384 //@containedEdges.408 //@containedEdges.432 //@containedEdges.456 //@containedEdges.480">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="78.0" text="Temperatures"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19 //@containedEdges.174 //@containedEdges.176 //@containedEdges.178 //@containedEdges.180 //@containedEdges.182 //@containedEdges.184 //@containedEdges.186 //@containedEdges.188 //@containedEdges.190 //@containedEdges.192 //@containedEdges.194 //@containedEdges.196 //@containedEdges.198 //@containedEdges.199 //@containedEdges.525">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="38.0" text="TRoo2"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.174 //@containedEdges.175 //@containedEdges.176 //@containedEdges.177 //@containedEdges.178 //@containedEdges.179 //@containedEdges.180 //@containedEdges.181 //@containedEdges.182 //@containedEdges.183 //@containedEdges.184 //@containedEdges.185 //@containedEdges.186 //@containedEdges.187 //@containedEdges.188 //@containedEdges.189 //@containedEdges.190 //@containedEdges.191 //@containedEdges.192 //@containedEdges.193 //@containedEdges.194 //@containedEdges.195 //@containedEdges.196 //@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="48.0" text="TRooSP"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.198 //@containedEdges.199 //@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="93.0" text="massFlowRates"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="56.0" text="TRooSP2"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="63.0" text="CSVWriter"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="-4.5" incomingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="-1.0" incomingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="2.5" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="9.5" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="30.5" incomingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="37.5" incomingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="-13"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.204 //@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.204 //@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.206 //@containedEdges.207 //@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.526">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.210 //@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.213 //@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.219 //@containedEdges.223 //@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.217 //@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.219">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.216 //@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.527">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.220 //@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.226 //@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.229 //@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.229 //@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.231 //@containedEdges.232 //@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.528">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.235 //@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.238 //@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.244 //@containedEdges.248 //@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.242 //@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.241 //@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.529">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.245 //@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.251 //@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.254 //@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.254 //@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.256 //@containedEdges.257 //@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P242" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.530">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.260 //@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.262">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.263 //@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.269 //@containedEdges.273 //@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.267 //@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P261" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P272" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.266 //@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.273">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.531">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.270 //@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.276 //@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P289" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.279 //@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.279 //@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.281 //@containedEdges.282 //@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.532">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.285 //@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.287">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.288 //@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.294 //@containedEdges.298 //@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P309" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P311" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.292 //@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P314" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P319" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.295">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P325" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.291 //@containedEdges.301">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P331" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P332" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.533">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.295 //@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.301 //@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.304 //@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.304 //@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P347" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.306 //@containedEdges.307 //@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P348" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.534">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P352" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P354" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.310 //@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P356" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P357" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P359" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.313 //@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.319 //@containedEdges.323 //@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P361" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P362" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P364" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P366" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.317 //@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P367" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P368" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P370" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P372" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.320">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P374" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P377" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P378" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P380" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.316 //@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P384" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P385" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.535">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P388" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.320 //@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P390" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P392" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.326 //@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P395" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P396" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P397" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.329 //@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.329 //@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P400" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.331 //@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P401" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.536">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P404" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P405" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P406" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P407" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P408" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.334 //@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P410" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P411" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P412" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.337 //@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P413" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.343 //@containedEdges.347 //@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P414" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P415" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P416" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P417" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P418" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P419" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.341 //@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P420" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P423" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P424" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P425" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P426" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P427" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P430" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P431" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P433" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.340 //@containedEdges.350">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P436" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P437" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P438" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P439" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P440" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.537">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N176" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L176" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.344 //@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P442" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P443" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N177" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P444" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P445" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.350 //@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P447" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P448" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P450" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.353 //@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P451" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.353 //@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P453" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.355 //@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N181" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L181" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P454" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N182" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L182" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.538">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P458" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.358">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N183" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L183" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P459" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P460" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N184" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L184" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P461" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.358 //@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P462" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P463" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N185" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L185" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P465" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.361 //@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N186" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L186" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.367 //@containedEdges.371 //@containedEdges.373">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P467" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P468" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N187" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L187" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P469" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P470" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N188" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L188" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P471" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P472" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.365 //@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N189" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L189" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P473" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N190" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L190" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P475" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P476" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N191" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L191" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P478" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N192" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L192" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P479" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P480" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N193" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L193" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P482" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P483" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N194" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L194" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P484" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P486" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P487" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N195" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.364 //@containedEdges.374">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P489" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P490" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.371">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N196" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L196" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P491" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P493" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.539">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N197" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L197" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P494" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.368 //@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P496" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.373">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N198" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L198" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P497" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P498" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.374 //@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N199" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L199" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.385">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P501" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N200" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L200" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P502" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.387">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P503" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.377 //@containedEdges.378">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N201" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L201" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P504" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.377 //@containedEdges.381">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P505" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P506" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.379 //@containedEdges.380">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N202" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L202" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P507" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.381">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P508" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N203" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L203" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.540">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P511" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.382">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N204" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L204" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P512" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.379">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P513" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.383">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N205" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L205" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P514" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.382 //@containedEdges.383">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P516" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.384">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N206" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L206" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P517" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P518" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.385 //@containedEdges.386">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N207" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L207" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.391 //@containedEdges.395 //@containedEdges.397">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P520" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.387">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P521" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.394">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N208" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L208" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P523" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.388">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N209" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L209" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P524" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P525" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.389 //@containedEdges.390">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N210" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L210" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P526" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.391">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N211" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L211" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P528" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.378">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P529" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N212" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L212" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.393">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P531" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.392">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N213" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L213" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P532" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P533" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N214" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L214" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P534" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.386">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P536" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.393">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N215" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L215" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P537" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.394">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P538" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.389">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P540" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.390">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N216" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L216" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P541" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.388 //@containedEdges.398">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P542" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P543" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.395">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N217" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L217" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P544" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.396">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.541">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N218" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L218" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P547" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.392 //@containedEdges.399">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P548" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P549" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.397">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N219" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L219" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.396">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P551" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.398 //@containedEdges.399">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N220" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L220" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.409">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P553" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P554" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.400">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N221" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L221" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P555" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.411">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P556" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.401 //@containedEdges.402">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N222" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L222" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.401 //@containedEdges.405">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P558" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P559" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.403 //@containedEdges.404">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N223" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L223" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P560" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.405">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N224" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L224" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P562" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.542">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P563" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P564" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.406">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N225" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L225" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P565" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.403">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P566" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.407">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N226" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L226" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P567" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.406 //@containedEdges.407">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P568" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P569" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.408">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N227" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L227" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P570" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P571" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.409 //@containedEdges.410">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N228" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L228" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.415 //@containedEdges.419 //@containedEdges.421">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P573" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.411">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P574" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.418">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N229" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L229" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.400">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P576" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.412">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N230" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L230" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P578" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.413 //@containedEdges.414">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N231" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L231" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P579" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.415">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N232" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L232" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P581" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.402">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P582" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N233" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L233" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P583" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.417">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P584" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.416">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N234" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L234" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P585" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P586" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N235" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L235" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P587" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.410">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P588" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P589" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.417">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N236" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L236" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P590" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.418">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P592" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.413">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.414">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N237" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L237" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P594" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.412 //@containedEdges.422">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P595" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P596" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.419">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N238" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L238" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P597" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.420">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P598" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.543">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N239" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L239" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P600" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.416 //@containedEdges.423">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P602" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.421">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N240" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L240" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.420">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P604" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.422 //@containedEdges.423">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N241" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L241" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P605" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.433">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P606" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P607" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.424">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N242" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L242" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.435">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P609" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.425 //@containedEdges.426">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N243" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L243" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P610" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.425 //@containedEdges.429">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P612" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.427 //@containedEdges.428">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N244" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L244" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P613" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.429">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P614" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N245" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L245" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.544">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P616" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P617" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.430">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N246" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L246" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P618" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.427">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P619" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.431">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N247" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L247" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P620" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.430 //@containedEdges.431">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P622" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.432">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N248" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L248" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P623" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P624" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.433 //@containedEdges.434">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N249" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L249" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P625" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.439 //@containedEdges.443 //@containedEdges.445">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P626" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.435">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P627" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.442">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N250" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L250" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P628" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.424">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P629" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.436">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N251" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L251" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P630" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P631" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.437 //@containedEdges.438">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N252" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L252" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P632" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.439">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P633" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N253" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L253" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P634" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.426">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P635" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N254" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L254" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P636" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.441">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P637" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.440">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N255" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L255" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P638" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P639" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N256" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L256" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.434">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P641" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P642" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.441">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N257" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L257" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P643" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.442">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P645" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.437">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P646" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.438">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N258" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L258" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P647" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.436 //@containedEdges.446">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P648" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P649" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.443">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N259" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L259" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P650" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.444">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P651" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.545">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N260" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L260" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P653" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.440 //@containedEdges.447">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P654" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P655" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.445">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N261" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L261" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P656" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.444">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P657" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.446 //@containedEdges.447">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N262" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L262" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P658" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.457">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P659" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P660" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.448">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N263" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L263" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P661" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.459">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P662" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.449 //@containedEdges.450">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N264" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L264" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P663" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.449 //@containedEdges.453">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P664" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P665" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.451 //@containedEdges.452">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N265" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L265" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P666" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.453">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P667" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N266" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L266" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.546">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P670" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.454">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N267" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L267" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P671" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.451">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P672" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.455">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N268" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L268" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P673" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.454 //@containedEdges.455">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P674" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P675" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.456">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N269" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L269" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P676" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P677" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.457 //@containedEdges.458">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N270" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L270" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P678" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.463 //@containedEdges.467 //@containedEdges.469">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P679" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.459">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P680" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.466">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N271" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L271" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P681" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.448">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P682" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.460">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N272" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L272" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P683" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P684" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.461 //@containedEdges.462">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N273" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L273" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P685" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.463">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P686" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N274" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L274" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P687" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.450">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P688" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N275" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L275" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P689" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.465">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P690" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.464">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N276" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L276" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P691" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P692" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N277" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L277" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P693" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.458">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P695" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.465">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N278" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L278" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P696" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.466">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P698" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.461">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P699" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.462">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N279" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L279" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.460 //@containedEdges.470">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P701" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P702" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.467">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N280" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L280" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P703" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.468">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P704" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P705" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N281" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L281" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P706" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.464 //@containedEdges.471">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P707" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P708" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.469">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N282" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L282" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P709" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.468">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P710" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.470 //@containedEdges.471">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N283" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L283" height="15.0" width="59.0" text="ErrorTRoo"/>
+    <ports identifier="P711" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.481">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P712" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P713" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.472">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N284" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L284" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P714" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.483">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P715" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.473 //@containedEdges.474">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N285" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L285" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.473 //@containedEdges.477">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P717" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P718" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.475 //@containedEdges.476">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N286" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L286" height="15.0" width="72.0" text="m_flow_max"/>
+    <ports identifier="P719" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.477">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P720" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N287" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L287" height="15.0" width="38.0" text="dTSup"/>
+    <ports identifier="P721" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.548">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P722" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P723" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.478">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N288" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L288" height="15.0" width="39.0" text="C_flow"/>
+    <ports identifier="P724" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.475">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P725" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.479">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N289" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L289" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P726" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.478 //@containedEdges.479">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P727" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P728" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.480">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N290" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L290" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P729" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P730" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.481 //@containedEdges.482">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N291" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L291" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P731" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.487 //@containedEdges.491 //@containedEdges.493">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P732" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.483">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P733" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.490">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N292" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L292" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P734" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.472">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P735" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.484">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N293" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L293" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P736" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P737" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.485 //@containedEdges.486">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N294" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L294" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P738" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.487">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P739" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N295" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L295" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P740" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.474">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P741" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N296" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L296" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P742" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.489">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P743" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.488">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N297" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L297" height="15.0" width="124.0" text="VectorDisassembler3"/>
+    <ports identifier="P744" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P745" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N298" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L298" height="15.0" width="66.0" text="ErrorTRoo2"/>
+    <ports identifier="P746" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.482">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P747" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P748" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.489">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N299" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L299" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P749" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.490">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P750" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P751" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.485">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P752" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.486">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N300" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L300" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P753" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.484 //@containedEdges.494">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P754" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P755" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.491">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N301" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L301" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P756" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.492">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P758" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.549">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N302" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L302" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P759" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.488 //@containedEdges.495">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P760" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P761" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.493">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N303" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L303" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P762" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.492">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P763" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.494 //@containedEdges.495">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N304" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L304" height="15.0" width="89.0" text="OperatingMode"/>
+    <ports identifier="P764" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.496 //@containedEdges.497 //@containedEdges.498">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P765" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.499">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P766" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.500">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P767" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P768" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N305" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L305" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P769" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P770" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.499 //@containedEdges.500 //@containedEdges.501 //@containedEdges.502">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N306" height="25.0" width="224.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L306" height="15.0" width="97.0" text="TEconomizerOut"/>
+    <ports identifier="P771" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@containedEdges.503 //@containedEdges.504 //@containedEdges.505 //@containedEdges.506">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P772" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P773" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P774" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.507">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N307" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L307" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P775" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.22 //@containedEdges.503 //@containedEdges.510 //@containedEdges.511 //@containedEdges.515 //@containedEdges.524">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N308" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L308" height="15.0" width="115.0" text="EconomizerDamper"/>
+    <ports identifier="P776" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.507 //@containedEdges.508">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P777" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.554">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P778" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P779" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P780" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.509">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N309" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L309" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P781" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.508">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P782" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.510">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N310" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L310" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P783" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.509">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P784" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.511">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N311" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L311" height="15.0" width="56.0" text="dTCoilSet"/>
+    <ports identifier="P785" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.520">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P786" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.504">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P787" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.512">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N312" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L312" height="15.0" width="63.0" text="Q_unconst"/>
+    <ports identifier="P788" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.166 //@containedEdges.512">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P789" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P790" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.513">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N313" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L313" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P791" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.513">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P792" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.514">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N314" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L314" height="15.0" width="50.0" text="TOutCoil"/>
+    <ports identifier="P793" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.505 //@containedEdges.519">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P794" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P795" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.515 //@containedEdges.516 //@containedEdges.517 //@containedEdges.518">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N315" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L315" height="15.0" width="63.0" text="dTEffective"/>
+    <ports identifier="P796" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.514">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P797" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P798" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.519">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N316" height="25.0" width="211.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L316" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P799" height="8.0" width="8.0" x="211.0" y="8.5" outgoingEdges="//@containedEdges.520">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P800" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.555">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P801" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.506">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P802" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.496">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N317" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L317" height="15.0" width="56.0" text="dTCoilSet"/>
+    <ports identifier="P803" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.551">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P804" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.516">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P805" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.521">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N318" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L318" height="15.0" width="63.0" text="Q_unconst"/>
+    <ports identifier="P806" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.168 //@containedEdges.521">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P807" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P808" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.522">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N319" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L319" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P809" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.522">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P810" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.523">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N320" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L320" height="15.0" width="50.0" text="TOutCoil"/>
+    <ports identifier="P811" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.517 //@containedEdges.550">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P812" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P813" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.524 //@containedEdges.525 //@containedEdges.526 //@containedEdges.527 //@containedEdges.528 //@containedEdges.529 //@containedEdges.530 //@containedEdges.531 //@containedEdges.532 //@containedEdges.533 //@containedEdges.534 //@containedEdges.535 //@containedEdges.536 //@containedEdges.537 //@containedEdges.538 //@containedEdges.539 //@containedEdges.540 //@containedEdges.541 //@containedEdges.542 //@containedEdges.543 //@containedEdges.544 //@containedEdges.545 //@containedEdges.546 //@containedEdges.547 //@containedEdges.548 //@containedEdges.549">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N321" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L321" height="15.0" width="63.0" text="dTEffective"/>
+    <ports identifier="P814" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.523">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P815" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P816" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.550">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N322" height="25.0" width="211.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L322" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P817" height="8.0" width="8.0" x="211.0" y="8.5" outgoingEdges="//@containedEdges.551">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P818" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.556">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P819" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.518">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P820" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.497">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N323" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L323" height="15.0" width="71.0" text="TRooErrHea"/>
+    <ports identifier="P821" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.501">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P822" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P823" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.552">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N324" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L324" height="15.0" width="71.0" text="TRooErrCoo"/>
+    <ports identifier="P824" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.502">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P825" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P826" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.553">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N325" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L325" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P827" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.559 //@containedEdges.566 //@containedEdges.574">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P828" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.554 //@containedEdges.555 //@containedEdges.556">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P829" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.498">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N326" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L326" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P830" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.557">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P831" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N327" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L327" height="15.0" width="53.0" text="Minimum"/>
+    <ports identifier="P832" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P833" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.558">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P834" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N328" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L328" height="15.0" width="57.0" text="Maximum"/>
+    <ports identifier="P835" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.557 //@containedEdges.558">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P836" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.559">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P837" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N329" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L329" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P838" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.552">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P839" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.560">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N330" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L330" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P840" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.560">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P841" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.561">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N331" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L331" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P842" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.563">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P843" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.567">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P844" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.562">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N332" height="25.0" width="42.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L332" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P845" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@containedEdges.563">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P846" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N333" height="25.0" width="109.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L333" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P847" height="8.0" width="8.0" x="109.0" y="8.5" outgoingEdges="//@containedEdges.564">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P848" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N334" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L334" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P849" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.561 //@containedEdges.562">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P850" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P851" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.565">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N335" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L335" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P852" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.564 //@containedEdges.565">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P853" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P854" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.566">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N336" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L336" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P855" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.567">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P856" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N337" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L337" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P857" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.553">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P858" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.568">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N338" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L338" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P859" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.568">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P860" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.569">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N339" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L339" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P861" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.571">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P862" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.575">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P863" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.570">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N340" height="25.0" width="42.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L340" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P864" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@containedEdges.571">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P865" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N341" height="25.0" width="109.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L341" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P866" height="8.0" width="8.0" x="109.0" y="8.5" outgoingEdges="//@containedEdges.572">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P867" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N342" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L342" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P868" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.569 //@containedEdges.570">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P869" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P870" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.573">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N343" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L343" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P871" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.572 //@containedEdges.573">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P872" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P873" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.574">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N344" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L344" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P874" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.575">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P875" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.303/@ports.4"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.305/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.2" targets="//@children.306/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.2" targets="//@children.307/@ports.3"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.322/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.2" targets="//@children.323/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.2" targets="//@children.326/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.1" targets="//@children.303/@ports.3"/>
+  <containedEdges identifier="E22" sources="//@children.12/@ports.1" targets="//@children.305/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.12/@ports.1" targets="//@children.306/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.12/@ports.1" targets="//@children.307/@ports.2"/>
+  <containedEdges identifier="E25" sources="//@children.12/@ports.1" targets="//@children.326/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.13/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.13/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.13/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.14/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.17/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.18/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.19/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.20/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.21/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.22/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.23/@ports.1" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.24/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.25/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.26/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.27/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.28/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.28/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.28/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.28/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.28/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.28/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.28/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.28/@ports.1" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.28/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.28/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.28/@ports.1" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.28/@ports.1" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.28/@ports.1" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.28/@ports.1" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.28/@ports.1" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.28/@ports.1" targets="//@children.149/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.28/@ports.1" targets="//@children.163/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.28/@ports.1" targets="//@children.166/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.28/@ports.1" targets="//@children.170/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.28/@ports.1" targets="//@children.184/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.28/@ports.1" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.28/@ports.1" targets="//@children.191/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.28/@ports.1" targets="//@children.205/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.28/@ports.1" targets="//@children.208/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.28/@ports.1" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.28/@ports.1" targets="//@children.226/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.28/@ports.1" targets="//@children.229/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.28/@ports.1" targets="//@children.233/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.28/@ports.1" targets="//@children.247/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.28/@ports.1" targets="//@children.250/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.28/@ports.1" targets="//@children.254/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.28/@ports.1" targets="//@children.268/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.28/@ports.1" targets="//@children.271/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.28/@ports.1" targets="//@children.275/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.28/@ports.1" targets="//@children.289/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.28/@ports.1" targets="//@children.292/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.28/@ports.1" targets="//@children.296/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.28/@ports.1" targets="//@children.304/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.29/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.30/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E94" sources="//@children.31/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.31/@ports.2" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.32/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.33/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E98" sources="//@children.33/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E99" sources="//@children.34/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.34/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E101" sources="//@children.34/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.35/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E103" sources="//@children.36/@ports.2" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.37/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E105" sources="//@children.38/@ports.1" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E106" sources="//@children.38/@ports.1" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E107" sources="//@children.38/@ports.1" targets="//@children.66/@ports.1"/>
+  <containedEdges identifier="E108" sources="//@children.38/@ports.1" targets="//@children.67/@ports.1"/>
+  <containedEdges identifier="E109" sources="//@children.38/@ports.1" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E110" sources="//@children.38/@ports.1" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.38/@ports.1" targets="//@children.76/@ports.1"/>
+  <containedEdges identifier="E112" sources="//@children.38/@ports.1" targets="//@children.87/@ports.1"/>
+  <containedEdges identifier="E113" sources="//@children.38/@ports.1" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E114" sources="//@children.38/@ports.1" targets="//@children.90/@ports.1"/>
+  <containedEdges identifier="E115" sources="//@children.38/@ports.1" targets="//@children.93/@ports.1"/>
+  <containedEdges identifier="E116" sources="//@children.38/@ports.1" targets="//@children.97/@ports.1"/>
+  <containedEdges identifier="E117" sources="//@children.38/@ports.1" targets="//@children.108/@ports.1"/>
+  <containedEdges identifier="E118" sources="//@children.38/@ports.1" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E119" sources="//@children.38/@ports.1" targets="//@children.111/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.38/@ports.1" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E121" sources="//@children.38/@ports.1" targets="//@children.118/@ports.1"/>
+  <containedEdges identifier="E122" sources="//@children.38/@ports.1" targets="//@children.129/@ports.1"/>
+  <containedEdges identifier="E123" sources="//@children.38/@ports.1" targets="//@children.130/@ports.1"/>
+  <containedEdges identifier="E124" sources="//@children.38/@ports.1" targets="//@children.132/@ports.1"/>
+  <containedEdges identifier="E125" sources="//@children.38/@ports.1" targets="//@children.135/@ports.1"/>
+  <containedEdges identifier="E126" sources="//@children.38/@ports.1" targets="//@children.139/@ports.1"/>
+  <containedEdges identifier="E127" sources="//@children.38/@ports.1" targets="//@children.150/@ports.1"/>
+  <containedEdges identifier="E128" sources="//@children.38/@ports.1" targets="//@children.151/@ports.1"/>
+  <containedEdges identifier="E129" sources="//@children.38/@ports.1" targets="//@children.153/@ports.1"/>
+  <containedEdges identifier="E130" sources="//@children.38/@ports.1" targets="//@children.156/@ports.1"/>
+  <containedEdges identifier="E131" sources="//@children.38/@ports.1" targets="//@children.160/@ports.1"/>
+  <containedEdges identifier="E132" sources="//@children.38/@ports.1" targets="//@children.171/@ports.1"/>
+  <containedEdges identifier="E133" sources="//@children.38/@ports.1" targets="//@children.172/@ports.1"/>
+  <containedEdges identifier="E134" sources="//@children.38/@ports.1" targets="//@children.174/@ports.1"/>
+  <containedEdges identifier="E135" sources="//@children.38/@ports.1" targets="//@children.177/@ports.1"/>
+  <containedEdges identifier="E136" sources="//@children.38/@ports.1" targets="//@children.181/@ports.1"/>
+  <containedEdges identifier="E137" sources="//@children.38/@ports.1" targets="//@children.192/@ports.1"/>
+  <containedEdges identifier="E138" sources="//@children.38/@ports.1" targets="//@children.193/@ports.1"/>
+  <containedEdges identifier="E139" sources="//@children.38/@ports.1" targets="//@children.195/@ports.1"/>
+  <containedEdges identifier="E140" sources="//@children.38/@ports.1" targets="//@children.198/@ports.1"/>
+  <containedEdges identifier="E141" sources="//@children.38/@ports.1" targets="//@children.202/@ports.1"/>
+  <containedEdges identifier="E142" sources="//@children.38/@ports.1" targets="//@children.213/@ports.1"/>
+  <containedEdges identifier="E143" sources="//@children.38/@ports.1" targets="//@children.214/@ports.1"/>
+  <containedEdges identifier="E144" sources="//@children.38/@ports.1" targets="//@children.216/@ports.1"/>
+  <containedEdges identifier="E145" sources="//@children.38/@ports.1" targets="//@children.219/@ports.1"/>
+  <containedEdges identifier="E146" sources="//@children.38/@ports.1" targets="//@children.223/@ports.1"/>
+  <containedEdges identifier="E147" sources="//@children.38/@ports.1" targets="//@children.234/@ports.1"/>
+  <containedEdges identifier="E148" sources="//@children.38/@ports.1" targets="//@children.235/@ports.1"/>
+  <containedEdges identifier="E149" sources="//@children.38/@ports.1" targets="//@children.237/@ports.1"/>
+  <containedEdges identifier="E150" sources="//@children.38/@ports.1" targets="//@children.240/@ports.1"/>
+  <containedEdges identifier="E151" sources="//@children.38/@ports.1" targets="//@children.244/@ports.1"/>
+  <containedEdges identifier="E152" sources="//@children.38/@ports.1" targets="//@children.255/@ports.1"/>
+  <containedEdges identifier="E153" sources="//@children.38/@ports.1" targets="//@children.256/@ports.1"/>
+  <containedEdges identifier="E154" sources="//@children.38/@ports.1" targets="//@children.258/@ports.1"/>
+  <containedEdges identifier="E155" sources="//@children.38/@ports.1" targets="//@children.261/@ports.1"/>
+  <containedEdges identifier="E156" sources="//@children.38/@ports.1" targets="//@children.265/@ports.1"/>
+  <containedEdges identifier="E157" sources="//@children.38/@ports.1" targets="//@children.276/@ports.1"/>
+  <containedEdges identifier="E158" sources="//@children.38/@ports.1" targets="//@children.277/@ports.1"/>
+  <containedEdges identifier="E159" sources="//@children.38/@ports.1" targets="//@children.279/@ports.1"/>
+  <containedEdges identifier="E160" sources="//@children.38/@ports.1" targets="//@children.282/@ports.1"/>
+  <containedEdges identifier="E161" sources="//@children.38/@ports.1" targets="//@children.286/@ports.1"/>
+  <containedEdges identifier="E162" sources="//@children.38/@ports.1" targets="//@children.297/@ports.1"/>
+  <containedEdges identifier="E163" sources="//@children.38/@ports.1" targets="//@children.298/@ports.1"/>
+  <containedEdges identifier="E164" sources="//@children.38/@ports.1" targets="//@children.300/@ports.1"/>
+  <containedEdges identifier="E165" sources="//@children.39/@ports.2" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E166" sources="//@children.39/@ports.2" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E167" sources="//@children.40/@ports.1" targets="//@children.311/@ports.0"/>
+  <containedEdges identifier="E168" sources="//@children.40/@ports.1" targets="//@children.314/@ports.1"/>
+  <containedEdges identifier="E169" sources="//@children.40/@ports.1" targets="//@children.317/@ports.0"/>
+  <containedEdges identifier="E170" sources="//@children.40/@ports.1" targets="//@children.320/@ports.1"/>
+  <containedEdges identifier="E171" sources="//@children.41/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E172" sources="//@children.41/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.42/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E174" sources="//@children.43/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E175" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E176" sources="//@children.45/@ports.1" targets="//@children.50/@ports.2"/>
+  <containedEdges identifier="E177" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E178" sources="//@children.45/@ports.1" targets="//@children.50/@ports.3"/>
+  <containedEdges identifier="E179" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E180" sources="//@children.45/@ports.1" targets="//@children.50/@ports.4"/>
+  <containedEdges identifier="E181" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E182" sources="//@children.45/@ports.1" targets="//@children.50/@ports.5"/>
+  <containedEdges identifier="E183" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E184" sources="//@children.45/@ports.1" targets="//@children.50/@ports.6"/>
+  <containedEdges identifier="E185" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E186" sources="//@children.45/@ports.1" targets="//@children.50/@ports.7"/>
+  <containedEdges identifier="E187" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E188" sources="//@children.45/@ports.1" targets="//@children.50/@ports.8"/>
+  <containedEdges identifier="E189" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E190" sources="//@children.45/@ports.1" targets="//@children.50/@ports.9"/>
+  <containedEdges identifier="E191" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.45/@ports.1" targets="//@children.50/@ports.10"/>
+  <containedEdges identifier="E193" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E194" sources="//@children.45/@ports.1" targets="//@children.50/@ports.11"/>
+  <containedEdges identifier="E195" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E196" sources="//@children.45/@ports.1" targets="//@children.50/@ports.12"/>
+  <containedEdges identifier="E197" sources="//@children.45/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E198" sources="//@children.45/@ports.1" targets="//@children.50/@ports.13"/>
+  <containedEdges identifier="E199" sources="//@children.46/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E200" sources="//@children.46/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E201" sources="//@children.46/@ports.1" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E202" sources="//@children.48/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E203" sources="//@children.50/@ports.0" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E204" sources="//@children.51/@ports.2" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E205" sources="//@children.52/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E206" sources="//@children.52/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E207" sources="//@children.53/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E208" sources="//@children.53/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E209" sources="//@children.53/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E210" sources="//@children.54/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E211" sources="//@children.55/@ports.2" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E212" sources="//@children.56/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E213" sources="//@children.57/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E214" sources="//@children.58/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E215" sources="//@children.58/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E216" sources="//@children.59/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E217" sources="//@children.60/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E218" sources="//@children.61/@ports.1" targets="//@children.67/@ports.2"/>
+  <containedEdges identifier="E219" sources="//@children.61/@ports.1" targets="//@children.67/@ports.3"/>
+  <containedEdges identifier="E220" sources="//@children.62/@ports.0" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E221" sources="//@children.64/@ports.1" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E222" sources="//@children.66/@ports.2" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E223" sources="//@children.67/@ports.0" targets="//@children.59/@ports.2"/>
+  <containedEdges identifier="E224" sources="//@children.68/@ports.2" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E225" sources="//@children.69/@ports.0" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E226" sources="//@children.70/@ports.2" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E227" sources="//@children.71/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E228" sources="//@children.71/@ports.1" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E229" sources="//@children.72/@ports.2" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E230" sources="//@children.73/@ports.1" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E231" sources="//@children.73/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E232" sources="//@children.74/@ports.2" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E233" sources="//@children.74/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E234" sources="//@children.74/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E235" sources="//@children.75/@ports.0" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E236" sources="//@children.76/@ports.2" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E237" sources="//@children.77/@ports.1" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E238" sources="//@children.78/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E239" sources="//@children.79/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E240" sources="//@children.79/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E241" sources="//@children.80/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E242" sources="//@children.81/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E243" sources="//@children.82/@ports.1" targets="//@children.88/@ports.2"/>
+  <containedEdges identifier="E244" sources="//@children.82/@ports.1" targets="//@children.88/@ports.3"/>
+  <containedEdges identifier="E245" sources="//@children.83/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E246" sources="//@children.85/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E247" sources="//@children.87/@ports.2" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E248" sources="//@children.88/@ports.0" targets="//@children.80/@ports.2"/>
+  <containedEdges identifier="E249" sources="//@children.89/@ports.2" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E250" sources="//@children.90/@ports.0" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E251" sources="//@children.91/@ports.2" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E252" sources="//@children.92/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E253" sources="//@children.92/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E254" sources="//@children.93/@ports.2" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E255" sources="//@children.94/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E256" sources="//@children.94/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E257" sources="//@children.95/@ports.2" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E258" sources="//@children.95/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E259" sources="//@children.95/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E260" sources="//@children.96/@ports.0" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E261" sources="//@children.97/@ports.2" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E262" sources="//@children.98/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E263" sources="//@children.99/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E264" sources="//@children.100/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E265" sources="//@children.100/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E266" sources="//@children.101/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E267" sources="//@children.102/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E268" sources="//@children.103/@ports.1" targets="//@children.109/@ports.2"/>
+  <containedEdges identifier="E269" sources="//@children.103/@ports.1" targets="//@children.109/@ports.3"/>
+  <containedEdges identifier="E270" sources="//@children.104/@ports.0" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E271" sources="//@children.106/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E272" sources="//@children.108/@ports.2" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E273" sources="//@children.109/@ports.0" targets="//@children.101/@ports.2"/>
+  <containedEdges identifier="E274" sources="//@children.110/@ports.2" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E275" sources="//@children.111/@ports.0" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E276" sources="//@children.112/@ports.2" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E277" sources="//@children.113/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E278" sources="//@children.113/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E279" sources="//@children.114/@ports.2" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E280" sources="//@children.115/@ports.1" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E281" sources="//@children.115/@ports.1" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E282" sources="//@children.116/@ports.2" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E283" sources="//@children.116/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E284" sources="//@children.116/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E285" sources="//@children.117/@ports.0" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E286" sources="//@children.118/@ports.2" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E287" sources="//@children.119/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E288" sources="//@children.120/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E289" sources="//@children.121/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E290" sources="//@children.121/@ports.1" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E291" sources="//@children.122/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E292" sources="//@children.123/@ports.1" targets="//@children.131/@ports.0"/>
+  <containedEdges identifier="E293" sources="//@children.124/@ports.1" targets="//@children.130/@ports.2"/>
+  <containedEdges identifier="E294" sources="//@children.124/@ports.1" targets="//@children.130/@ports.3"/>
+  <containedEdges identifier="E295" sources="//@children.125/@ports.0" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E296" sources="//@children.127/@ports.1" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E297" sources="//@children.129/@ports.2" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E298" sources="//@children.130/@ports.0" targets="//@children.122/@ports.2"/>
+  <containedEdges identifier="E299" sources="//@children.131/@ports.2" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E300" sources="//@children.132/@ports.0" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E301" sources="//@children.133/@ports.2" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E302" sources="//@children.134/@ports.1" targets="//@children.131/@ports.0"/>
+  <containedEdges identifier="E303" sources="//@children.134/@ports.1" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E304" sources="//@children.135/@ports.2" targets="//@children.144/@ports.0"/>
+  <containedEdges identifier="E305" sources="//@children.136/@ports.1" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E306" sources="//@children.136/@ports.1" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E307" sources="//@children.137/@ports.2" targets="//@children.140/@ports.0"/>
+  <containedEdges identifier="E308" sources="//@children.137/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E309" sources="//@children.137/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E310" sources="//@children.138/@ports.0" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E311" sources="//@children.139/@ports.2" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E312" sources="//@children.140/@ports.1" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E313" sources="//@children.141/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E314" sources="//@children.142/@ports.1" targets="//@children.135/@ports.0"/>
+  <containedEdges identifier="E315" sources="//@children.142/@ports.1" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E316" sources="//@children.143/@ports.1" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E317" sources="//@children.144/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E318" sources="//@children.145/@ports.1" targets="//@children.151/@ports.2"/>
+  <containedEdges identifier="E319" sources="//@children.145/@ports.1" targets="//@children.151/@ports.3"/>
+  <containedEdges identifier="E320" sources="//@children.146/@ports.0" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E321" sources="//@children.148/@ports.1" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E322" sources="//@children.150/@ports.2" targets="//@children.148/@ports.0"/>
+  <containedEdges identifier="E323" sources="//@children.151/@ports.0" targets="//@children.143/@ports.2"/>
+  <containedEdges identifier="E324" sources="//@children.152/@ports.2" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E325" sources="//@children.153/@ports.0" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E326" sources="//@children.154/@ports.2" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E327" sources="//@children.155/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E328" sources="//@children.155/@ports.1" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E329" sources="//@children.156/@ports.2" targets="//@children.165/@ports.0"/>
+  <containedEdges identifier="E330" sources="//@children.157/@ports.1" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E331" sources="//@children.157/@ports.1" targets="//@children.168/@ports.0"/>
+  <containedEdges identifier="E332" sources="//@children.158/@ports.2" targets="//@children.161/@ports.0"/>
+  <containedEdges identifier="E333" sources="//@children.158/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E334" sources="//@children.159/@ports.0" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E335" sources="//@children.160/@ports.2" targets="//@children.162/@ports.0"/>
+  <containedEdges identifier="E336" sources="//@children.161/@ports.1" targets="//@children.162/@ports.0"/>
+  <containedEdges identifier="E337" sources="//@children.162/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E338" sources="//@children.163/@ports.1" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E339" sources="//@children.163/@ports.1" targets="//@children.171/@ports.0"/>
+  <containedEdges identifier="E340" sources="//@children.164/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E341" sources="//@children.165/@ports.1" targets="//@children.173/@ports.0"/>
+  <containedEdges identifier="E342" sources="//@children.166/@ports.1" targets="//@children.172/@ports.2"/>
+  <containedEdges identifier="E343" sources="//@children.166/@ports.1" targets="//@children.172/@ports.3"/>
+  <containedEdges identifier="E344" sources="//@children.167/@ports.0" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E345" sources="//@children.169/@ports.1" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E346" sources="//@children.171/@ports.2" targets="//@children.169/@ports.0"/>
+  <containedEdges identifier="E347" sources="//@children.172/@ports.0" targets="//@children.164/@ports.2"/>
+  <containedEdges identifier="E348" sources="//@children.173/@ports.2" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E349" sources="//@children.174/@ports.0" targets="//@children.176/@ports.0"/>
+  <containedEdges identifier="E350" sources="//@children.175/@ports.2" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E351" sources="//@children.176/@ports.1" targets="//@children.173/@ports.0"/>
+  <containedEdges identifier="E352" sources="//@children.176/@ports.1" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E353" sources="//@children.177/@ports.2" targets="//@children.186/@ports.0"/>
+  <containedEdges identifier="E354" sources="//@children.178/@ports.1" targets="//@children.179/@ports.0"/>
+  <containedEdges identifier="E355" sources="//@children.178/@ports.1" targets="//@children.189/@ports.0"/>
+  <containedEdges identifier="E356" sources="//@children.179/@ports.2" targets="//@children.182/@ports.0"/>
+  <containedEdges identifier="E357" sources="//@children.179/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E358" sources="//@children.180/@ports.0" targets="//@children.179/@ports.0"/>
+  <containedEdges identifier="E359" sources="//@children.181/@ports.2" targets="//@children.183/@ports.0"/>
+  <containedEdges identifier="E360" sources="//@children.182/@ports.1" targets="//@children.183/@ports.0"/>
+  <containedEdges identifier="E361" sources="//@children.183/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E362" sources="//@children.184/@ports.1" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E363" sources="//@children.184/@ports.1" targets="//@children.192/@ports.0"/>
+  <containedEdges identifier="E364" sources="//@children.185/@ports.1" targets="//@children.178/@ports.0"/>
+  <containedEdges identifier="E365" sources="//@children.186/@ports.1" targets="//@children.194/@ports.0"/>
+  <containedEdges identifier="E366" sources="//@children.187/@ports.1" targets="//@children.193/@ports.2"/>
+  <containedEdges identifier="E367" sources="//@children.187/@ports.1" targets="//@children.193/@ports.3"/>
+  <containedEdges identifier="E368" sources="//@children.188/@ports.0" targets="//@children.185/@ports.0"/>
+  <containedEdges identifier="E369" sources="//@children.190/@ports.1" targets="//@children.196/@ports.0"/>
+  <containedEdges identifier="E370" sources="//@children.192/@ports.2" targets="//@children.190/@ports.0"/>
+  <containedEdges identifier="E371" sources="//@children.193/@ports.0" targets="//@children.185/@ports.2"/>
+  <containedEdges identifier="E372" sources="//@children.194/@ports.2" targets="//@children.185/@ports.0"/>
+  <containedEdges identifier="E373" sources="//@children.195/@ports.0" targets="//@children.197/@ports.0"/>
+  <containedEdges identifier="E374" sources="//@children.196/@ports.2" targets="//@children.185/@ports.0"/>
+  <containedEdges identifier="E375" sources="//@children.197/@ports.1" targets="//@children.194/@ports.0"/>
+  <containedEdges identifier="E376" sources="//@children.197/@ports.1" targets="//@children.196/@ports.0"/>
+  <containedEdges identifier="E377" sources="//@children.198/@ports.2" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E378" sources="//@children.199/@ports.1" targets="//@children.200/@ports.0"/>
+  <containedEdges identifier="E379" sources="//@children.199/@ports.1" targets="//@children.210/@ports.0"/>
+  <containedEdges identifier="E380" sources="//@children.200/@ports.2" targets="//@children.203/@ports.0"/>
+  <containedEdges identifier="E381" sources="//@children.200/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E382" sources="//@children.201/@ports.0" targets="//@children.200/@ports.0"/>
+  <containedEdges identifier="E383" sources="//@children.202/@ports.2" targets="//@children.204/@ports.0"/>
+  <containedEdges identifier="E384" sources="//@children.203/@ports.1" targets="//@children.204/@ports.0"/>
+  <containedEdges identifier="E385" sources="//@children.204/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E386" sources="//@children.205/@ports.1" targets="//@children.198/@ports.0"/>
+  <containedEdges identifier="E387" sources="//@children.205/@ports.1" targets="//@children.213/@ports.0"/>
+  <containedEdges identifier="E388" sources="//@children.206/@ports.1" targets="//@children.199/@ports.0"/>
+  <containedEdges identifier="E389" sources="//@children.207/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E390" sources="//@children.208/@ports.1" targets="//@children.214/@ports.2"/>
+  <containedEdges identifier="E391" sources="//@children.208/@ports.1" targets="//@children.214/@ports.3"/>
+  <containedEdges identifier="E392" sources="//@children.209/@ports.0" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E393" sources="//@children.211/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E394" sources="//@children.213/@ports.2" targets="//@children.211/@ports.0"/>
+  <containedEdges identifier="E395" sources="//@children.214/@ports.0" targets="//@children.206/@ports.2"/>
+  <containedEdges identifier="E396" sources="//@children.215/@ports.2" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E397" sources="//@children.216/@ports.0" targets="//@children.218/@ports.0"/>
+  <containedEdges identifier="E398" sources="//@children.217/@ports.2" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E399" sources="//@children.218/@ports.1" targets="//@children.215/@ports.0"/>
+  <containedEdges identifier="E400" sources="//@children.218/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E401" sources="//@children.219/@ports.2" targets="//@children.228/@ports.0"/>
+  <containedEdges identifier="E402" sources="//@children.220/@ports.1" targets="//@children.221/@ports.0"/>
+  <containedEdges identifier="E403" sources="//@children.220/@ports.1" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E404" sources="//@children.221/@ports.2" targets="//@children.224/@ports.0"/>
+  <containedEdges identifier="E405" sources="//@children.221/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E406" sources="//@children.222/@ports.0" targets="//@children.221/@ports.0"/>
+  <containedEdges identifier="E407" sources="//@children.223/@ports.2" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E408" sources="//@children.224/@ports.1" targets="//@children.225/@ports.0"/>
+  <containedEdges identifier="E409" sources="//@children.225/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E410" sources="//@children.226/@ports.1" targets="//@children.219/@ports.0"/>
+  <containedEdges identifier="E411" sources="//@children.226/@ports.1" targets="//@children.234/@ports.0"/>
+  <containedEdges identifier="E412" sources="//@children.227/@ports.1" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E413" sources="//@children.228/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E414" sources="//@children.229/@ports.1" targets="//@children.235/@ports.2"/>
+  <containedEdges identifier="E415" sources="//@children.229/@ports.1" targets="//@children.235/@ports.3"/>
+  <containedEdges identifier="E416" sources="//@children.230/@ports.0" targets="//@children.227/@ports.0"/>
+  <containedEdges identifier="E417" sources="//@children.232/@ports.1" targets="//@children.238/@ports.0"/>
+  <containedEdges identifier="E418" sources="//@children.234/@ports.2" targets="//@children.232/@ports.0"/>
+  <containedEdges identifier="E419" sources="//@children.235/@ports.0" targets="//@children.227/@ports.2"/>
+  <containedEdges identifier="E420" sources="//@children.236/@ports.2" targets="//@children.227/@ports.0"/>
+  <containedEdges identifier="E421" sources="//@children.237/@ports.0" targets="//@children.239/@ports.0"/>
+  <containedEdges identifier="E422" sources="//@children.238/@ports.2" targets="//@children.227/@ports.0"/>
+  <containedEdges identifier="E423" sources="//@children.239/@ports.1" targets="//@children.236/@ports.0"/>
+  <containedEdges identifier="E424" sources="//@children.239/@ports.1" targets="//@children.238/@ports.0"/>
+  <containedEdges identifier="E425" sources="//@children.240/@ports.2" targets="//@children.249/@ports.0"/>
+  <containedEdges identifier="E426" sources="//@children.241/@ports.1" targets="//@children.242/@ports.0"/>
+  <containedEdges identifier="E427" sources="//@children.241/@ports.1" targets="//@children.252/@ports.0"/>
+  <containedEdges identifier="E428" sources="//@children.242/@ports.2" targets="//@children.245/@ports.0"/>
+  <containedEdges identifier="E429" sources="//@children.242/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E430" sources="//@children.243/@ports.0" targets="//@children.242/@ports.0"/>
+  <containedEdges identifier="E431" sources="//@children.244/@ports.2" targets="//@children.246/@ports.0"/>
+  <containedEdges identifier="E432" sources="//@children.245/@ports.1" targets="//@children.246/@ports.0"/>
+  <containedEdges identifier="E433" sources="//@children.246/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E434" sources="//@children.247/@ports.1" targets="//@children.240/@ports.0"/>
+  <containedEdges identifier="E435" sources="//@children.247/@ports.1" targets="//@children.255/@ports.0"/>
+  <containedEdges identifier="E436" sources="//@children.248/@ports.1" targets="//@children.241/@ports.0"/>
+  <containedEdges identifier="E437" sources="//@children.249/@ports.1" targets="//@children.257/@ports.0"/>
+  <containedEdges identifier="E438" sources="//@children.250/@ports.1" targets="//@children.256/@ports.2"/>
+  <containedEdges identifier="E439" sources="//@children.250/@ports.1" targets="//@children.256/@ports.3"/>
+  <containedEdges identifier="E440" sources="//@children.251/@ports.0" targets="//@children.248/@ports.0"/>
+  <containedEdges identifier="E441" sources="//@children.253/@ports.1" targets="//@children.259/@ports.0"/>
+  <containedEdges identifier="E442" sources="//@children.255/@ports.2" targets="//@children.253/@ports.0"/>
+  <containedEdges identifier="E443" sources="//@children.256/@ports.0" targets="//@children.248/@ports.2"/>
+  <containedEdges identifier="E444" sources="//@children.257/@ports.2" targets="//@children.248/@ports.0"/>
+  <containedEdges identifier="E445" sources="//@children.258/@ports.0" targets="//@children.260/@ports.0"/>
+  <containedEdges identifier="E446" sources="//@children.259/@ports.2" targets="//@children.248/@ports.0"/>
+  <containedEdges identifier="E447" sources="//@children.260/@ports.1" targets="//@children.257/@ports.0"/>
+  <containedEdges identifier="E448" sources="//@children.260/@ports.1" targets="//@children.259/@ports.0"/>
+  <containedEdges identifier="E449" sources="//@children.261/@ports.2" targets="//@children.270/@ports.0"/>
+  <containedEdges identifier="E450" sources="//@children.262/@ports.1" targets="//@children.263/@ports.0"/>
+  <containedEdges identifier="E451" sources="//@children.262/@ports.1" targets="//@children.273/@ports.0"/>
+  <containedEdges identifier="E452" sources="//@children.263/@ports.2" targets="//@children.266/@ports.0"/>
+  <containedEdges identifier="E453" sources="//@children.263/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E454" sources="//@children.264/@ports.0" targets="//@children.263/@ports.0"/>
+  <containedEdges identifier="E455" sources="//@children.265/@ports.2" targets="//@children.267/@ports.0"/>
+  <containedEdges identifier="E456" sources="//@children.266/@ports.1" targets="//@children.267/@ports.0"/>
+  <containedEdges identifier="E457" sources="//@children.267/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E458" sources="//@children.268/@ports.1" targets="//@children.261/@ports.0"/>
+  <containedEdges identifier="E459" sources="//@children.268/@ports.1" targets="//@children.276/@ports.0"/>
+  <containedEdges identifier="E460" sources="//@children.269/@ports.1" targets="//@children.262/@ports.0"/>
+  <containedEdges identifier="E461" sources="//@children.270/@ports.1" targets="//@children.278/@ports.0"/>
+  <containedEdges identifier="E462" sources="//@children.271/@ports.1" targets="//@children.277/@ports.2"/>
+  <containedEdges identifier="E463" sources="//@children.271/@ports.1" targets="//@children.277/@ports.3"/>
+  <containedEdges identifier="E464" sources="//@children.272/@ports.0" targets="//@children.269/@ports.0"/>
+  <containedEdges identifier="E465" sources="//@children.274/@ports.1" targets="//@children.280/@ports.0"/>
+  <containedEdges identifier="E466" sources="//@children.276/@ports.2" targets="//@children.274/@ports.0"/>
+  <containedEdges identifier="E467" sources="//@children.277/@ports.0" targets="//@children.269/@ports.2"/>
+  <containedEdges identifier="E468" sources="//@children.278/@ports.2" targets="//@children.269/@ports.0"/>
+  <containedEdges identifier="E469" sources="//@children.279/@ports.0" targets="//@children.281/@ports.0"/>
+  <containedEdges identifier="E470" sources="//@children.280/@ports.2" targets="//@children.269/@ports.0"/>
+  <containedEdges identifier="E471" sources="//@children.281/@ports.1" targets="//@children.278/@ports.0"/>
+  <containedEdges identifier="E472" sources="//@children.281/@ports.1" targets="//@children.280/@ports.0"/>
+  <containedEdges identifier="E473" sources="//@children.282/@ports.2" targets="//@children.291/@ports.0"/>
+  <containedEdges identifier="E474" sources="//@children.283/@ports.1" targets="//@children.284/@ports.0"/>
+  <containedEdges identifier="E475" sources="//@children.283/@ports.1" targets="//@children.294/@ports.0"/>
+  <containedEdges identifier="E476" sources="//@children.284/@ports.2" targets="//@children.287/@ports.0"/>
+  <containedEdges identifier="E477" sources="//@children.284/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E478" sources="//@children.285/@ports.0" targets="//@children.284/@ports.0"/>
+  <containedEdges identifier="E479" sources="//@children.286/@ports.2" targets="//@children.288/@ports.0"/>
+  <containedEdges identifier="E480" sources="//@children.287/@ports.1" targets="//@children.288/@ports.0"/>
+  <containedEdges identifier="E481" sources="//@children.288/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E482" sources="//@children.289/@ports.1" targets="//@children.282/@ports.0"/>
+  <containedEdges identifier="E483" sources="//@children.289/@ports.1" targets="//@children.297/@ports.0"/>
+  <containedEdges identifier="E484" sources="//@children.290/@ports.1" targets="//@children.283/@ports.0"/>
+  <containedEdges identifier="E485" sources="//@children.291/@ports.1" targets="//@children.299/@ports.0"/>
+  <containedEdges identifier="E486" sources="//@children.292/@ports.1" targets="//@children.298/@ports.2"/>
+  <containedEdges identifier="E487" sources="//@children.292/@ports.1" targets="//@children.298/@ports.3"/>
+  <containedEdges identifier="E488" sources="//@children.293/@ports.0" targets="//@children.290/@ports.0"/>
+  <containedEdges identifier="E489" sources="//@children.295/@ports.1" targets="//@children.301/@ports.0"/>
+  <containedEdges identifier="E490" sources="//@children.297/@ports.2" targets="//@children.295/@ports.0"/>
+  <containedEdges identifier="E491" sources="//@children.298/@ports.0" targets="//@children.290/@ports.2"/>
+  <containedEdges identifier="E492" sources="//@children.299/@ports.2" targets="//@children.290/@ports.0"/>
+  <containedEdges identifier="E493" sources="//@children.300/@ports.0" targets="//@children.302/@ports.0"/>
+  <containedEdges identifier="E494" sources="//@children.301/@ports.2" targets="//@children.290/@ports.0"/>
+  <containedEdges identifier="E495" sources="//@children.302/@ports.1" targets="//@children.299/@ports.0"/>
+  <containedEdges identifier="E496" sources="//@children.302/@ports.1" targets="//@children.301/@ports.0"/>
+  <containedEdges identifier="E497" sources="//@children.303/@ports.0" targets="//@children.315/@ports.3"/>
+  <containedEdges identifier="E498" sources="//@children.303/@ports.0" targets="//@children.321/@ports.3"/>
+  <containedEdges identifier="E499" sources="//@children.303/@ports.0" targets="//@children.324/@ports.2"/>
+  <containedEdges identifier="E500" sources="//@children.304/@ports.1" targets="//@children.303/@ports.1"/>
+  <containedEdges identifier="E501" sources="//@children.304/@ports.1" targets="//@children.303/@ports.2"/>
+  <containedEdges identifier="E502" sources="//@children.304/@ports.1" targets="//@children.322/@ports.0"/>
+  <containedEdges identifier="E503" sources="//@children.304/@ports.1" targets="//@children.323/@ports.0"/>
+  <containedEdges identifier="E504" sources="//@children.305/@ports.0" targets="//@children.306/@ports.0"/>
+  <containedEdges identifier="E505" sources="//@children.305/@ports.0" targets="//@children.310/@ports.1"/>
+  <containedEdges identifier="E506" sources="//@children.305/@ports.0" targets="//@children.313/@ports.0"/>
+  <containedEdges identifier="E507" sources="//@children.305/@ports.0" targets="//@children.315/@ports.2"/>
+  <containedEdges identifier="E508" sources="//@children.307/@ports.0" targets="//@children.305/@ports.3"/>
+  <containedEdges identifier="E509" sources="//@children.307/@ports.0" targets="//@children.308/@ports.0"/>
+  <containedEdges identifier="E510" sources="//@children.307/@ports.4" targets="//@children.309/@ports.0"/>
+  <containedEdges identifier="E511" sources="//@children.308/@ports.1" targets="//@children.306/@ports.0"/>
+  <containedEdges identifier="E512" sources="//@children.309/@ports.1" targets="//@children.306/@ports.0"/>
+  <containedEdges identifier="E513" sources="//@children.310/@ports.2" targets="//@children.311/@ports.0"/>
+  <containedEdges identifier="E514" sources="//@children.311/@ports.2" targets="//@children.312/@ports.0"/>
+  <containedEdges identifier="E515" sources="//@children.312/@ports.1" targets="//@children.314/@ports.0"/>
+  <containedEdges identifier="E516" sources="//@children.313/@ports.2" targets="//@children.306/@ports.0"/>
+  <containedEdges identifier="E517" sources="//@children.313/@ports.2" targets="//@children.316/@ports.1"/>
+  <containedEdges identifier="E518" sources="//@children.313/@ports.2" targets="//@children.319/@ports.0"/>
+  <containedEdges identifier="E519" sources="//@children.313/@ports.2" targets="//@children.321/@ports.2"/>
+  <containedEdges identifier="E520" sources="//@children.314/@ports.2" targets="//@children.313/@ports.0"/>
+  <containedEdges identifier="E521" sources="//@children.315/@ports.0" targets="//@children.310/@ports.0"/>
+  <containedEdges identifier="E522" sources="//@children.316/@ports.2" targets="//@children.317/@ports.0"/>
+  <containedEdges identifier="E523" sources="//@children.317/@ports.2" targets="//@children.318/@ports.0"/>
+  <containedEdges identifier="E524" sources="//@children.318/@ports.1" targets="//@children.320/@ports.0"/>
+  <containedEdges identifier="E525" sources="//@children.319/@ports.2" targets="//@children.306/@ports.0"/>
+  <containedEdges identifier="E526" sources="//@children.319/@ports.2" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E527" sources="//@children.319/@ports.2" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E528" sources="//@children.319/@ports.2" targets="//@children.69/@ports.2"/>
+  <containedEdges identifier="E529" sources="//@children.319/@ports.2" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E530" sources="//@children.319/@ports.2" targets="//@children.90/@ports.2"/>
+  <containedEdges identifier="E531" sources="//@children.319/@ports.2" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E532" sources="//@children.319/@ports.2" targets="//@children.111/@ports.2"/>
+  <containedEdges identifier="E533" sources="//@children.319/@ports.2" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E534" sources="//@children.319/@ports.2" targets="//@children.132/@ports.2"/>
+  <containedEdges identifier="E535" sources="//@children.319/@ports.2" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E536" sources="//@children.319/@ports.2" targets="//@children.153/@ports.2"/>
+  <containedEdges identifier="E537" sources="//@children.319/@ports.2" targets="//@children.160/@ports.0"/>
+  <containedEdges identifier="E538" sources="//@children.319/@ports.2" targets="//@children.174/@ports.2"/>
+  <containedEdges identifier="E539" sources="//@children.319/@ports.2" targets="//@children.181/@ports.0"/>
+  <containedEdges identifier="E540" sources="//@children.319/@ports.2" targets="//@children.195/@ports.2"/>
+  <containedEdges identifier="E541" sources="//@children.319/@ports.2" targets="//@children.202/@ports.0"/>
+  <containedEdges identifier="E542" sources="//@children.319/@ports.2" targets="//@children.216/@ports.2"/>
+  <containedEdges identifier="E543" sources="//@children.319/@ports.2" targets="//@children.223/@ports.0"/>
+  <containedEdges identifier="E544" sources="//@children.319/@ports.2" targets="//@children.237/@ports.2"/>
+  <containedEdges identifier="E545" sources="//@children.319/@ports.2" targets="//@children.244/@ports.0"/>
+  <containedEdges identifier="E546" sources="//@children.319/@ports.2" targets="//@children.258/@ports.2"/>
+  <containedEdges identifier="E547" sources="//@children.319/@ports.2" targets="//@children.265/@ports.0"/>
+  <containedEdges identifier="E548" sources="//@children.319/@ports.2" targets="//@children.279/@ports.2"/>
+  <containedEdges identifier="E549" sources="//@children.319/@ports.2" targets="//@children.286/@ports.0"/>
+  <containedEdges identifier="E550" sources="//@children.319/@ports.2" targets="//@children.300/@ports.2"/>
+  <containedEdges identifier="E551" sources="//@children.320/@ports.2" targets="//@children.319/@ports.0"/>
+  <containedEdges identifier="E552" sources="//@children.321/@ports.0" targets="//@children.316/@ports.0"/>
+  <containedEdges identifier="E553" sources="//@children.322/@ports.2" targets="//@children.328/@ports.0"/>
+  <containedEdges identifier="E554" sources="//@children.323/@ports.2" targets="//@children.336/@ports.0"/>
+  <containedEdges identifier="E555" sources="//@children.324/@ports.1" targets="//@children.307/@ports.1"/>
+  <containedEdges identifier="E556" sources="//@children.324/@ports.1" targets="//@children.315/@ports.1"/>
+  <containedEdges identifier="E557" sources="//@children.324/@ports.1" targets="//@children.321/@ports.1"/>
+  <containedEdges identifier="E558" sources="//@children.325/@ports.0" targets="//@children.327/@ports.0"/>
+  <containedEdges identifier="E559" sources="//@children.326/@ports.1" targets="//@children.327/@ports.0"/>
+  <containedEdges identifier="E560" sources="//@children.327/@ports.1" targets="//@children.324/@ports.0"/>
+  <containedEdges identifier="E561" sources="//@children.328/@ports.1" targets="//@children.329/@ports.0"/>
+  <containedEdges identifier="E562" sources="//@children.329/@ports.1" targets="//@children.333/@ports.0"/>
+  <containedEdges identifier="E563" sources="//@children.330/@ports.2" targets="//@children.333/@ports.0"/>
+  <containedEdges identifier="E564" sources="//@children.331/@ports.0" targets="//@children.330/@ports.0"/>
+  <containedEdges identifier="E565" sources="//@children.332/@ports.0" targets="//@children.334/@ports.0"/>
+  <containedEdges identifier="E566" sources="//@children.333/@ports.2" targets="//@children.334/@ports.0"/>
+  <containedEdges identifier="E567" sources="//@children.334/@ports.2" targets="//@children.324/@ports.0"/>
+  <containedEdges identifier="E568" sources="//@children.335/@ports.0" targets="//@children.330/@ports.1"/>
+  <containedEdges identifier="E569" sources="//@children.336/@ports.1" targets="//@children.337/@ports.0"/>
+  <containedEdges identifier="E570" sources="//@children.337/@ports.1" targets="//@children.341/@ports.0"/>
+  <containedEdges identifier="E571" sources="//@children.338/@ports.2" targets="//@children.341/@ports.0"/>
+  <containedEdges identifier="E572" sources="//@children.339/@ports.0" targets="//@children.338/@ports.0"/>
+  <containedEdges identifier="E573" sources="//@children.340/@ports.0" targets="//@children.342/@ports.0"/>
+  <containedEdges identifier="E574" sources="//@children.341/@ports.2" targets="//@children.342/@ports.0"/>
+  <containedEdges identifier="E575" sources="//@children.342/@ports.2" targets="//@children.324/@ports.0"/>
+  <containedEdges identifier="E576" sources="//@children.343/@ports.0" targets="//@children.338/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_ucbpower_DataReadingExample.elkg
+++ b/realworld/ptolemy/flattened/ptango_ucbpower_DataReadingExample.elkg
@@ -1,0 +1,452 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="10.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="134.0" text="OnlineDataFileReader2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="128.0" text="LocalDataFileReader2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="183.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="183.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="89.0" text="JSONToToken2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="10.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="26.0" text="data"/>
+    <ports identifier="P38" x="61.0" y="20.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="26.0" text="data"/>
+    <ports identifier="P39" x="61.0" y="20.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="28.0" text="Start"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="95.0" text="ReadOnlineData"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="102.0" text="ReadOnlineData2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="121.0" text="LocalDataFileReader"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.12/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.18/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.19/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.20/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.20/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.23/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.24/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.25/@ports.2" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.25/@ports.3" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.26/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.26/@ports.0" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E25" sources="//@children.27/@ports.3" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.29/@ports.1" targets="//@children.28/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_ucbpower_UCBPowerForServer.elkg
+++ b/realworld/ptolemy/flattened/ptango_ucbpower_UCBPowerForServer.elkg
@@ -1,0 +1,1014 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="419.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="419.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="10.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="27.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="121.0" text="LocalDataFileReader"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="112.0" text="ConfigurationSelect"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="256.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="256.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="425.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="67.0" text="DisplayText"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="10.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="27.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="121.0" text="LocalDataFileReader"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="112.0" text="ConfigurationSelect"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="256.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="256.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="425.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="67.0" text="DisplayText"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="10.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="27.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="121.0" text="LocalDataFileReader"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="112.0" text="ConfigurationSelect"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="256.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="256.0" y="8.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="425.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="67.0" text="DisplayText"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.3" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.12/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.20/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.22/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.22/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.23/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.24/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.25/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.27/@ports.3" targets="//@children.32/@ports.2"/>
+  <containedEdges identifier="E26" sources="//@children.28/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.29/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.30/@ports.0" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.31/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.33/@ports.2" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.34/@ports.1" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.34/@ports.2" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.35/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.35/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.36/@ports.0" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.38/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.39/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.41/@ports.1" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.43/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.43/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.44/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.45/@ports.0" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.46/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.48/@ports.3" targets="//@children.53/@ports.2"/>
+  <containedEdges identifier="E46" sources="//@children.49/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.50/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.51/@ports.0" targets="//@children.48/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.52/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.53/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.54/@ports.2" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.55/@ports.1" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.55/@ports.2" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.56/@ports.1" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.56/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.57/@ports.0" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.59/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.60/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.62/@ports.1" targets="//@children.64/@ports.2"/>
+  <containedEdges identifier="E60" sources="//@children.64/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.64/@ports.1" targets="//@children.61/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptango_ucbpowerptera_UCBPowerPtera.elkg
+++ b/realworld/ptolemy/flattened/ptango_ucbpowerptera_UCBPowerPtera.elkg
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="55.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="130.0" text="VisualModelReference"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="-1.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="131.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="27.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="55.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="130.0" text="VisualModelReference"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="-1.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="131.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="27.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25 //@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="55.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="130.0" text="VisualModelReference"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="-1.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="131.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="27.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.4/@ports.4"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.4/@ports.5"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.4/@ports.6"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.0" targets="//@children.12/@ports.4"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.0" targets="//@children.12/@ports.5"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.0" targets="//@children.12/@ports.6"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.17/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.17/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.0" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.3" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.0" targets="//@children.20/@ports.4"/>
+  <containedEdges identifier="E32" sources="//@children.22/@ports.0" targets="//@children.20/@ports.5"/>
+  <containedEdges identifier="E33" sources="//@children.23/@ports.0" targets="//@children.20/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptera_adaptivecarwash_AdaptiveCarWash.elkg
+++ b/realworld/ptolemy/flattened/ptera_adaptivecarwash_AdaptiveCarWash.elkg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="InitQueue"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="18.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="60.0" text="InitServers"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="18.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="85.0" text="SetQueueSize"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="24.0" text="Run"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="32.0" text="Enter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="28.0" text="Start"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Leave"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="58.0" text="ReadInput"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="135.0" text="InitModelWithContainer"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="113.0" text="SwitchToSlowMode"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="56.0" text="TooSlow?"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="111.0" text="SwitchToFastMode"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="54.0" text="TooFast?"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptera_adaptivecarwash_AdaptiveCarWashFSM.elkg
+++ b/realworld/ptolemy/flattened/ptera_adaptivecarwash_AdaptiveCarWashFSM.elkg
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="InitQueue"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="60.0" text="InitServers"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="56.0" text="queueOut"/>
+    <ports identifier="P7" y="13.666666984558105" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" y="27.33333396911621" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" x="61.0" y="13.666666984558105" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" x="61.0" y="27.33333396911621" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="32.0" text="Enter"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="28.0" text="Start"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Leave"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="17.0" text="Init"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="24.0" text="Run"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="69.0" text="UpdateMST"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptera_simultaneouscarwash_SimultaneousCarWash.elkg
+++ b/realworld/ptolemy/flattened/ptera_simultaneouscarwash_SimultaneousCarWash.elkg
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="63.0" text="InitQueue1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="18.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="InitServers1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="18.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="InitServers2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="18.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="InitQueue2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="18.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="24.0" text="Run"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="52.0" text="Simulate"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="WaitForInput"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="32.0" text="Enter"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="28.0" text="Start"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Leave"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="17.0" text="Init"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.4/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptera_trafficlight_TrafficLight.elkg
+++ b/realworld/ptolemy/flattened/ptera_trafficlight_TrafficLight.elkg
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Normal"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="17.0" text="Init"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="76.0" text="ReactToError"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="29.0" text="Error"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="ReactToOK"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="69.0" text="StartNormal"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="57.0" text="StartError"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="33.0" text="CRed"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="45.0" text="CGreen"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="47.0" text="CYellow"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="17.0" text="Init"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="33.0" text="PRed"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="45.0" text="PGreen"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="90.0" text="TurnYellowLight"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="17.0" text="Init"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="17.0" text="Init"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="29.0" text="Error"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="19.0" text="OK"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pthales_AdaptiveBeamSyntactic.elkg
+++ b/realworld/ptolemy/flattened/pthales_AdaptiveBeamSyntactic.elkg
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="112.0" text="ApplyAdaptiveFilter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="CovarCalculation"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="113.0" text="Weight_Calculation"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="ApplyFilter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Matrix_invert"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="110.0" text="PulseCompression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="83.0" text="SteerVectCalc"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="91.0" text="DopplerFiltering"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="GenPulseX4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="62.0" text="Gen_Echo"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="64.0" text="Add_Noise"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="AddJammer"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Decim"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="61.0" text="Check_Inv"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="103.0" text="EnhancedDoppler"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.5/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pthales_adaptivebeamforming_AdaptiveBeamForming.elkg
+++ b/realworld/ptolemy/flattened/pthales_adaptivebeamforming_AdaptiveBeamForming.elkg
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="112.0" text="ApplyAdaptiveFilter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="CovarCalculation"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="113.0" text="Weight_Calculation"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="ApplyFilter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Matrix_invert"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="110.0" text="PulseCompression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="83.0" text="SteerVectCalc"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="91.0" text="DopplerFiltering"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="GenPulseX4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="62.0" text="Gen_Echo"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="64.0" text="Add_Noise"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="AddJammer"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Decim"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="61.0" text="Check_Inv"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="103.0" text="EnhancedDoppler"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.5/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pthales_adaptivebeamforming_UCB_ABF.elkg
+++ b/realworld/ptolemy/flattened/pthales_adaptivebeamforming_UCB_ABF.elkg
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="112.0" text="ApplyAdaptiveFilter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="CovarCalculation"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="113.0" text="Weight_Calculation"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="ApplyFilter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Matrix_invert"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="110.0" text="PulseCompression"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="83.0" text="SteerVectCalc"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="91.0" text="DopplerFiltering"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="GenPulseX4"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="62.0" text="Gen_Echo"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="64.0" text="Add_Noise"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="AddJammer"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Decim"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="61.0" text="Check_Inv"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="103.0" text="EnhancedDoppler"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="26.0" y="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="26.0" y="40.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.4" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.3" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.3" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.3" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.3" targets="//@children.13/@ports.4"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.3" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.3" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.3" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.3" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.3/@ports.4"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.2" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.2" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.3" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.3" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.3" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.3" targets="//@children.5/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pthales_dynamic_ThalesDynamicModalModelPN.elkg
+++ b/realworld/ptolemy/flattened/pthales_dynamic_ThalesDynamicModalModelPN.elkg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="163.0" text="PthalesRemoveHeaderActor"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="170.0" text="PthalesRemoveHeaderActor2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.4/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/pthales_fft_FFT.elkg
+++ b/realworld/ptolemy/flattened/pthales_fft_FFT.elkg
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="266.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="266.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="232.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="232.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="85.0" width="196.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="196.0" y="38.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="23.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="54.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="107.0" text="SequenceToMatrix"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="108.0" text="DoubleMatrixToJAI"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="110.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="110.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="24.0" text="FFT"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="24.0" text="FFT"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="107.0" text="SequenceToMatrix"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="108.0" text="DoubleMatrixToJAI"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="121.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="121.0" y="8.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_actuatorpattern_ActuatorPattern1.elkg
+++ b/realworld/ptolemy/flattened/ptides_actuatorpattern_ActuatorPattern1.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="73.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="73.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_actuatorpattern_ActuatorPattern2.elkg
+++ b/realworld/ptolemy/flattened/ptides_actuatorpattern_ActuatorPattern2.elkg
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="73.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="73.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="132.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_controller_Controller.elkg
+++ b/realworld/ptolemy/flattened/ptides_controller_Controller.elkg
@@ -1,0 +1,1371 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="Controller2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5 //@containedEdges.14 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.26 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35 //@containedEdges.46 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.47 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.43 //@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.36 //@containedEdges.58 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.59 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.55 //@containedEdges.56 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.60 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.76 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.69 //@containedEdges.80 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.81 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.75 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.77 //@containedEdges.78 //@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.82 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.70 //@containedEdges.92 //@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.93 //@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.87 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P188" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.89 //@containedEdges.90 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.94 //@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.6/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.8/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.9/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.10/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.13/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.14/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.14/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.15/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.15/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.21/@ports.2" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.22/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.22/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.23/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.23/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.23/@ports.2" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.24/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.25/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.2" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.29/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.31/@ports.1" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.33/@ports.2" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.34/@ports.2" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.35/@ports.1" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.36/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.37/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.38/@ports.2" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.39/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.39/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.40/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.40/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.40/@ports.2" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.41/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.42/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.43/@ports.2" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.43/@ports.2" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.44/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.45/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.46/@ports.2" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.47/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.47/@ports.2" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.48/@ports.2" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.48/@ports.2" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.48/@ports.2" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.49/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.50/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.51/@ports.2" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.51/@ports.2" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.52/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.53/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.54/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.55/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.56/@ports.1" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.58/@ports.1" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.59/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.60/@ports.2" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.61/@ports.2" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.62/@ports.1" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.63/@ports.0" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.64/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.65/@ports.2" targets="//@children.67/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.66/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.66/@ports.2" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.67/@ports.2" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.67/@ports.2" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.67/@ports.2" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.68/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.69/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.70/@ports.2" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.70/@ports.2" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.71/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.72/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.73/@ports.2" targets="//@children.75/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.74/@ports.2" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.74/@ports.2" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.75/@ports.2" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.75/@ports.2" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.75/@ports.2" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E93" sources="//@children.76/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.77/@ports.1" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.78/@ports.2" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.78/@ports.2" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.79/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.80/@ports.1" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.81/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.82/@ports.1" targets="//@children.62/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_cosimulation_CoSimulation.elkg
+++ b/realworld/ptolemy/flattened/ptides_cosimulation_CoSimulation.elkg
@@ -1,0 +1,1157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="65.0" text="RampMAG"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="15.0" y="-8.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="38.0" y="-8.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="87.0" text="SpectrumMAG"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="15.0" y="-8.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="38.0" y="-8.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="getData"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="174.0" text="avoidZeroDelayLoopException"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="sendData"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="124.0" text="resumeDiscreteClock"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="78.0" text="resumeRamp"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="99.0" text="resumeSpectrum"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="56.0" text="Spectrum"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="56.0" text="Register3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="9.0" text="P"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="56.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="56.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="54.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="54.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="61.0" text="TrueGate2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="54.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="9.0" text="P"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.43 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="77.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.44 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="61.0" text="TrueGate2"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@containedEdges.52 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61 //@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.65 //@containedEdges.66 //@containedEdges.69 //@containedEdges.83 //@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.55 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="48.0" text="Equals2"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.57 //@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="61.0" text="TrueGate2"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="48.0" text="Equals3"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.59 //@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="61.0" text="TrueGate3"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.5 //@containedEdges.15 //@containedEdges.95 //@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.80 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="56.0" text="Register3"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="48.0" text="Equals4"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.61 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="61.0" text="TrueGate4"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="56.0" text="Register4"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P140" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="48.0" text="Equals5"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.63 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="61.0" text="TrueGate5"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="56.0" text="Register5"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.94 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="25.0" width="192.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="192.0" y="8.5" outgoingEdges="//@containedEdges.94 //@containedEdges.95 //@containedEdges.96 //@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="380.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="380.0" y="8.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="25.0" width="213.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="213.0" y="8.5" outgoingEdges="//@containedEdges.99 //@containedEdges.100 //@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="56.0" text="Spectrum"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.3" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.3" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.3" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.4" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.6/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.6/@ports.0" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.7/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.7/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.8/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.15/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.16/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.16/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.16/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.18/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.20/@ports.1" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.21/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.22/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.23/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.24/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.25/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.26/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.27/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.27/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.28/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.28/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.29/@ports.1" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.29/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.30/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.31/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.32/@ports.1" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.33/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.34/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.35/@ports.1" targets="//@children.3/@ports.5"/>
+  <containedEdges identifier="E52" sources="//@children.35/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.36/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.36/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.37/@ports.1" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.37/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.37/@ports.1" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.37/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.37/@ports.1" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.37/@ports.1" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.37/@ports.1" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.37/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.37/@ports.1" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.37/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.38/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.39/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.40/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.41/@ports.0" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.42/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.43/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.44/@ports.1" targets="//@children.53/@ports.2"/>
+  <containedEdges identifier="E72" sources="//@children.45/@ports.0" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.46/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.47/@ports.1" targets="//@children.54/@ports.2"/>
+  <containedEdges identifier="E75" sources="//@children.48/@ports.0" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.49/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.50/@ports.1" targets="//@children.55/@ports.2"/>
+  <containedEdges identifier="E78" sources="//@children.51/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E79" sources="//@children.52/@ports.1" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.53/@ports.1" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.54/@ports.1" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E82" sources="//@children.54/@ports.1" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E83" sources="//@children.55/@ports.1" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E84" sources="//@children.56/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.57/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.58/@ports.1" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.59/@ports.1" targets="//@children.60/@ports.2"/>
+  <containedEdges identifier="E88" sources="//@children.60/@ports.1" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E89" sources="//@children.61/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.62/@ports.0" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.63/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.64/@ports.1" targets="//@children.65/@ports.2"/>
+  <containedEdges identifier="E93" sources="//@children.65/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E94" sources="//@children.67/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.68/@ports.0" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.68/@ports.0" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.68/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E98" sources="//@children.68/@ports.0" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.69/@ports.0" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.70/@ports.0" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.70/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E102" sources="//@children.70/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.71/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.72/@ports.0" targets="//@children.71/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_distributedpowerplant_DistributedPowerPlant.elkg
+++ b/realworld/ptolemy/flattened/ptides_distributedpowerplant_DistributedPowerPlant.elkg
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="9.25" y="-8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="9.25" y="41.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="26.5" y="-8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="43.75" y="41.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="43.75" y="-8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="75.0" text="sensorSignal"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="39.0" text="Plotter"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="46.0" text="Plotter2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="71.0" text="PlantControl"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="-1.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="6.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="13.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="20.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="46.0" text="Plotter3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="64.0" text="LocalClock"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="78.0" text="MissDetector"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="92.0" text="StatusClassifier"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="95.0" text="ResettableTimer"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.4" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.5" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.8" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.0" targets="//@children.10/@ports.7"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.3" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.14/@ports.3" targets="//@children.10/@ports.6"/>
+  <containedEdges identifier="E24" sources="//@children.15/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.0" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_errorhandling_ErrorHandling.elkg
+++ b/realworld/ptolemy/flattened/ptides_errorhandling_ErrorHandling.elkg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="80.0" text="InitializeDelay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="59.0" text="missedN2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="116.0" text="ErrorHandlingAction"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="59.0" text="missedN2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="123.0" text="ErrorHandlingAction2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_multiplatformtdma_MultiPlatformTDMA.elkg
+++ b/realworld/ptolemy/flattened/ptides_multiplatformtdma_MultiPlatformTDMA.elkg
@@ -1,0 +1,715 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="78.0" text="CurrentTime4"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="78.0" text="CurrentTime5"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="51.0" text="Display5"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="78.0" text="CurrentTime6"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="51.0" text="Display6"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="63.0" text="Remainder"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="70.0" text="Remainder2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="92.0" text="BooleanSelect2"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="80.0" text="AddSubtract4"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="80.0" text="AddSubtract5"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="70.0" text="Remainder3"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.36 //@containedEdges.37 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="75.0" text="Comparator3"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="92.0" text="BooleanSelect3"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="80.0" text="AddSubtract6"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.34 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="84.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="76.0" text="TimedDelay3"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.13/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.13/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.13/@ports.2" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.14/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.14/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.3" targets="//@children.39/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.2" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.21/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.2" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.2" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.22/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.2" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.24/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.25/@ports.3" targets="//@children.40/@ports.2"/>
+  <containedEdges identifier="E31" sources="//@children.26/@ports.2" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.28/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.29/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.29/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.29/@ports.2" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.30/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.30/@ports.1" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.30/@ports.1" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.31/@ports.2" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E41" sources="//@children.32/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.32/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.33/@ports.3" targets="//@children.41/@ports.2"/>
+  <containedEdges identifier="E44" sources="//@children.34/@ports.2" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.35/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.36/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.37/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.38/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.39/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.40/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.41/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.42/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.43/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.44/@ports.0" targets="//@children.44/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithCurrentLocalTime.elkg
+++ b/realworld/ptolemy/flattened/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithCurrentLocalTime.elkg
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="80.0" text="samplePeriod"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="90.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="49.0" text="Resume"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="111.0" text="SingleEventStartup"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="38.0" text="Pause"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.10 //@containedEdges.11 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="124.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="124.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="96.0" text="incrementOutput"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="96.0" text="incrementOutput"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.0" targets="//@children.16/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithoutCurrentLocalTime.elkg
+++ b/realworld/ptolemy/flattened/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithoutCurrentLocalTime.elkg
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="80.0" text="samplePeriod"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="90.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="49.0" text="Resume"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="111.0" text="SingleEventStartup"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="38.0" text="Pause"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.10 //@containedEdges.11 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="124.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="124.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="96.0" text="incrementOutput"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="96.0" text="incrementOutput"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="55.0" text="IsPresent"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.1" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_powerplant_PowerPlant.elkg
+++ b/realworld/ptolemy/flattened/ptides_powerplant_PowerPlant.elkg
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="9.25" y="-8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="9.25" y="41.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="26.5" y="-8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="43.75" y="41.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="43.75" y="-8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="75.0" text="sensorSignal"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="95.0" text="ResettableTimer"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="39.0" text="Plotter"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="46.0" text="Plotter2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="71.0" text="PlantControl"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="-1.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="6.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="13.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="20.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="46.0" text="Plotter3"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="64.0" text="LocalClock"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="78.0" text="MissDetector"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="92.0" text="StatusClassifier"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.4" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.5" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.8" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.0" targets="//@children.17/@ports.7"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.19/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.20/@ports.3" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.21/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.21/@ports.3" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.3" targets="//@children.17/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_printingpress_PrintingPress.elkg
+++ b/realworld/ptolemy/flattened/ptides_printingpress_PrintingPress.elkg
@@ -1,0 +1,5007 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.83 //@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="106.0" text="feedPaperRadius2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="152.0" text="reserveFeedPaperRadius2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.346">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="40.0" text="omega"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="407.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="119.0" text="initialRadiusSquared"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="65.0" text="coreRadius"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.32 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.45 //@containedEdges.46 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.44 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="91.0" text="coreMassScale"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.61 //@containedEdges.62 //@containedEdges.63 //@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.65 //@containedEdges.66 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.73 //@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.71 //@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66 //@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.75 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.76 //@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.62 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.83 //@containedEdges.84 //@containedEdges.85 //@containedEdges.86 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="103.0" text="PeriodicSampler3"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="219.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@containedEdges.88 //@containedEdges.89 //@containedEdges.90 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.92" incomingEdges="//@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.94" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.97 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.101" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P197" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.106 //@containedEdges.107 //@containedEdges.108 //@containedEdges.109 //@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.111 //@containedEdges.112 //@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.118 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.362">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.112 //@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.120 //@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.121 //@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.107 //@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.127 //@containedEdges.128 //@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="103.0" text="PeriodicSampler3"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="103.0" text="PeriodicSampler4"/>
+    <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.133 //@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="25.0" width="407.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="119.0" text="initialRadiusSquared"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.137 //@containedEdges.138 //@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="58.0" text="constzero"/>
+    <ports identifier="P269" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="40.0" text="omega"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="65.0" text="constzero2"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.330">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="65.0" text="coreRadius"/>
+    <ports identifier="P277" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.143 //@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.110 //@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P287" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="45.0" text="Select2"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.139 //@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.149 //@containedEdges.150 //@containedEdges.151 //@containedEdges.152 //@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.156 //@containedEdges.157 //@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P302" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P304" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P307" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+    <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P309" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+    <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P311" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P316" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.155 //@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P319" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.167 //@containedEdges.168 //@containedEdges.169 //@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="91.0" text="coreMassScale"/>
+    <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.172" incomingEdges="//@containedEdges.306">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P325" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.174" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P327" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P332" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P335" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P341" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.177 //@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P346" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P348" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P351" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.178 //@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P353" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P354" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P356" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P357" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.183" incomingEdges="//@containedEdges.307">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P359" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P361" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.185 //@containedEdges.186" incomingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P362" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P365" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P366" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P367" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.188 //@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P368" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P370" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.190 //@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P372" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P373" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P374" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P377" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P378" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P380" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P381" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.196 //@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P383" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P384" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P385" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.198 //@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P388" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P390" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P392" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P394" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P395" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P396" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P398" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P400" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P401" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P402" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.219">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P404" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.195 //@containedEdges.201 //@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P406" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P408" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P409" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P411" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P412" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P413" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.202 //@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P415" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P416" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P418" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P419" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P420" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P423" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P424" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P425" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P426" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P427" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P429" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P430" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P431" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P432" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.219 //@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P433" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P434" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P436" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.223 //@containedEdges.224" incomingEdges="//@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P437" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P438" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P439" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P440" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P441" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P442" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.226 //@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P443" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P444" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P445" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.228 //@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P447" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P448" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N176" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L176" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P450" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P451" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P452" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N177" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P453" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P454" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P456" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.234 //@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P458" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.236">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P459" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N181" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L181" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P461" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.236 //@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P462" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P463" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N182" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L182" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P465" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N183" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L183" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P467" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N184" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L184" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P469" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P470" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P471" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N185" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L185" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P472" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P473" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N186" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L186" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P475" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P476" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P477" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N187" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L187" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P478" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P479" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N188" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L188" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.233 //@containedEdges.239 //@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P481" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N189" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L189" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P482" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P483" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P484" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N190" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L190" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P486" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P487" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P488" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N191" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L191" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P489" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.240 //@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P490" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N192" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L192" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P491" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N193" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L193" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P493" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P494" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N194" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L194" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P495" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N195" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P497" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P498" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P499" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N196" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L196" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P501" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P502" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N197" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L197" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P503" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P504" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P505" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N198" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L198" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P506" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P507" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.257 //@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N199" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L199" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P508" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P509" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N200" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L200" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.260" incomingEdges="//@containedEdges.325">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P511" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N201" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L201" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P512" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P513" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.262" incomingEdges="//@containedEdges.261">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N202" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L202" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P514" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.263 //@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N203" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L203" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P516" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P517" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.265 //@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N204" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L204" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P518" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P519" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N205" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L205" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P520" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N206" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L206" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P523" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P524" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N207" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L207" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P525" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.269">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P526" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.270">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N208" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L208" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P528" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.271 //@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N209" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L209" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P529" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.271">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P530" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.273">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N210" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L210" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P531" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P532" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.272">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N211" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L211" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P533" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.273 //@containedEdges.274">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P534" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P535" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N212" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L212" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P536" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.275">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P537" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.276">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N213" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L213" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P538" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P539" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.277">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N214" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L214" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P540" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P541" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P542" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.278">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P543" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.279">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N215" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L215" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P544" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P545" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.280">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N216" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L216" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P547" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P548" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.281">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P549" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N217" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L217" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.295">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P551" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.283">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N218" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L218" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.270 //@containedEdges.276 //@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P553" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N219" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L219" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P554" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.263">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P555" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P556" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.284">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N220" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L220" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.282">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P558" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P559" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.285">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P560" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N221" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L221" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.277 //@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P562" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.287 //@containedEdges.288">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N222" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L222" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P563" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.289">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P564" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.286">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N223" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L223" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P565" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P566" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.290">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N224" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L224" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P567" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P568" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N225" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L225" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.291">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P570" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.292">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P571" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N226" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L226" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P573" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P574" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.301">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N227" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L227" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P576" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P577" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N228" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L228" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P578" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.293">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P579" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.295 //@containedEdges.296">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N229" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L229" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.294">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P581" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.297">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N230" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L230" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P582" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P583" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N231" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L231" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P584" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P585" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.287">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N232" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L232" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.288 //@containedEdges.299">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P587" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.300">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P588" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.298">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N233" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L233" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P589" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.301 //@containedEdges.302">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N234" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L234" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P592" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.304" incomingEdges="//@containedEdges.303">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N235" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L235" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P594" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.306 //@containedEdges.307" incomingEdges="//@containedEdges.305">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N236" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L236" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P595" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P596" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P597" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N237" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L237" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P598" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.308">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P600" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P601" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P602" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N238" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L238" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P604" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P605" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.309 //@containedEdges.310 //@containedEdges.311 //@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N239" height="25.0" width="111.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L239" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P606" height="8.0" width="8.0" x="111.0" y="8.5" outgoingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P607" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.309">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N240" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L240" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P608" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.314">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P609" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N241" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L241" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P610" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.320">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P611" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N242" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L242" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P612" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.313">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P613" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.315">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P614" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N243" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L243" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P615" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P616" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.310">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N244" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L244" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.311">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P618" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N245" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L245" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.317">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P620" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.318">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P621" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N246" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L246" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P622" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.312">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P623" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.320">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N247" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L247" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P624" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.316">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P625" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N248" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L248" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P626" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.321">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P627" height="8.0" width="8.0" x="66.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N249" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L249" height="15.0" width="61.0" text="TrueGate2"/>
+    <ports identifier="P628" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.319">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P629" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N250" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L250" height="15.0" width="66.0" text="Sequence2"/>
+    <ports identifier="P630" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.322">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P631" height="8.0" width="8.0" x="66.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N251" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L251" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.323" incomingEdges="//@containedEdges.304">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P633" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.323">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N252" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L252" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P634" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P635" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.325 //@containedEdges.326 //@containedEdges.327" incomingEdges="//@containedEdges.324">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N253" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L253" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P636" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P637" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.328">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N254" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L254" height="15.0" width="101.0" text="CompositeActor7"/>
+    <ports identifier="P638" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.329">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P639" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.330" incomingEdges="//@containedEdges.329">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N255" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L255" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P641" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P642" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N256" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L256" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P643" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.331">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P645" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P646" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P647" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N257" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L257" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P648" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P649" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P650" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N258" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L258" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P651" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.332">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P653" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P654" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P655" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N259" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L259" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P656" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.333 //@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P657" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P658" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P659" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P660" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@containedEdges.335">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N260" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L260" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P661" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.333">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P662" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.335 //@containedEdges.336 //@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P663" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.340">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N261" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L261" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P664" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.336">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P665" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P666" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.341">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N262" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L262" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P667" height="8.0" width="8.0" x="36.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.334">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N263" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L263" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P669" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P670" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.337">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N264" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L264" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P671" height="8.0" width="8.0" x="29.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P672" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.338">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N265" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L265" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P673" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.339">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P674" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P675" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N266" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L266" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P676" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.340 //@containedEdges.341 //@containedEdges.342">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P677" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N267" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L267" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P678" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.343" incomingEdges="//@containedEdges.262">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P679" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.343">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N268" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L268" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P680" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.344" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P681" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.344">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N269" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L269" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P682" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P683" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.346" incomingEdges="//@containedEdges.345">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N270" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L270" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P684" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.347" incomingEdges="//@containedEdges.326">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P685" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.347">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N271" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L271" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P686" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P687" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P688" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N272" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L272" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P689" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.348">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P690" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P691" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P692" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P693" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N273" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L273" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P695" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.349 //@containedEdges.350">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P696" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N274" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L274" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P698" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.351 //@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P699" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N275" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L275" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P701" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.353">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P702" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N276" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L276" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P703" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.353">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P704" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.351">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P705" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.354">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N277" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L277" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P706" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P707" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.349">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N278" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L278" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P708" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P709" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N279" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L279" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P710" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.352">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P711" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P712" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N280" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L280" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P713" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.350 //@containedEdges.355">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P714" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P715" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.356">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N281" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L281" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.357">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P717" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P718" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N282" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L282" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P719" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.358" incomingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P720" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.358">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N283" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L283" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P721" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.359" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P722" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.359">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N284" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L284" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P723" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.360" incomingEdges="//@containedEdges.327">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P724" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.360">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N285" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L285" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P725" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P726" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.362" incomingEdges="//@containedEdges.361">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N286" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L286" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P727" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P728" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P729" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N287" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L287" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P730" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.363">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P731" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P732" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P733" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P734" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N288" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L288" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P735" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P736" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.364 //@containedEdges.365">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P737" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N289" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L289" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P738" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P739" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.366 //@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P740" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N290" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L290" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P741" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P742" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P743" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N291" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L291" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P744" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.368">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P745" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.366">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P746" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.369">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N292" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L292" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P747" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P748" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.364">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N293" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L293" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P749" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.371">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P750" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N294" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L294" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P751" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.367">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P752" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P753" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N295" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L295" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P754" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P755" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P756" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N296" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L296" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.365 //@containedEdges.370">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P758" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.372">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P759" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.371">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N297" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L297" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P760" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.373" incomingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P761" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.373">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N298" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L298" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P762" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.374">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N299" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L299" height="15.0" width="86.0" text="NonStrictTest2"/>
+    <ports identifier="P763" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N300" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L300" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P764" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P765" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.374">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P766" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N301" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L301" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P767" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.375">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P768" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P769" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P770" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P771" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N302" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L302" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+    <ports identifier="P772" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P773" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@containedEdges.376">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.298/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.5/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.1" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.1" targets="//@children.270/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.1" targets="//@children.235/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.2" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.24/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.25/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.26/@ports.1" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.26/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.26/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.27/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.27/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.28/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.29/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.30/@ports.1" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.31/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.31/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.31/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.31/@ports.1" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.31/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.32/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.33/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.34/@ports.1" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.34/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.34/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.35/@ports.2" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.36/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.37/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.38/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.39/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.40/@ports.1" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.41/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.42/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.43/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.43/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.43/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.43/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.44/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.45/@ports.2" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.45/@ports.2" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.45/@ports.2" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.45/@ports.2" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.46/@ports.2" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.46/@ports.2" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.46/@ports.2" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.47/@ports.2" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.48/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.49/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.50/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.50/@ports.1" targets="//@children.63/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.51/@ports.2" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.52/@ports.2" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.53/@ports.2" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E77" sources="//@children.53/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.54/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.55/@ports.0" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.56/@ports.2" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.57/@ports.2" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.58/@ports.2" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.59/@ports.0" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.60/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.60/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.60/@ports.1" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.60/@ports.1" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.60/@ports.1" targets="//@children.254/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.63/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.63/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E91" sources="//@children.63/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E92" sources="//@children.63/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E93" sources="//@children.64/@ports.0" targets="//@children.64/@ports.1"/>
+  <containedEdges identifier="E94" sources="//@children.65/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E95" sources="//@children.65/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.67/@ports.0" targets="//@children.66/@ports.2"/>
+  <containedEdges identifier="E97" sources="//@children.68/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.69/@ports.2" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.69/@ports.2" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.70/@ports.1" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E101" sources="//@children.73/@ports.0" targets="//@children.73/@ports.1"/>
+  <containedEdges identifier="E102" sources="//@children.73/@ports.1" targets="//@children.267/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.75/@ports.0" targets="//@children.74/@ports.2"/>
+  <containedEdges identifier="E104" sources="//@children.77/@ports.0" targets="//@children.76/@ports.2"/>
+  <containedEdges identifier="E105" sources="//@children.78/@ports.2" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.79/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.81/@ports.2" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.81/@ports.2" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.81/@ports.2" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.81/@ports.2" targets="//@children.104/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.81/@ports.2" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.82/@ports.2" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E113" sources="//@children.82/@ports.2" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.82/@ports.2" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.83/@ports.2" targets="//@children.82/@ports.1"/>
+  <containedEdges identifier="E116" sources="//@children.84/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.85/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.86/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.87/@ports.2" targets="//@children.83/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.88/@ports.2" targets="//@children.83/@ports.1"/>
+  <containedEdges identifier="E121" sources="//@children.89/@ports.2" targets="//@children.91/@ports.1"/>
+  <containedEdges identifier="E122" sources="//@children.89/@ports.2" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.90/@ports.0" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.91/@ports.0" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.92/@ports.2" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.93/@ports.2" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.94/@ports.2" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.95/@ports.1" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.95/@ports.1" targets="//@children.285/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.95/@ports.1" targets="//@children.299/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.96/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.98/@ports.1" targets="//@children.256/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.99/@ports.2" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.100/@ports.1" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E135" sources="//@children.100/@ports.1" targets="//@children.101/@ports.1"/>
+  <containedEdges identifier="E136" sources="//@children.101/@ports.0" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E137" sources="//@children.102/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.103/@ports.1" targets="//@children.107/@ports.1"/>
+  <containedEdges identifier="E139" sources="//@children.103/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.103/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.104/@ports.0" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.105/@ports.2" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.106/@ports.0" targets="//@children.111/@ports.2"/>
+  <containedEdges identifier="E144" sources="//@children.107/@ports.0" targets="//@children.108/@ports.1"/>
+  <containedEdges identifier="E145" sources="//@children.107/@ports.0" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.108/@ports.2" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.109/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.110/@ports.1" targets="//@children.112/@ports.2"/>
+  <containedEdges identifier="E149" sources="//@children.111/@ports.1" targets="//@children.105/@ports.1"/>
+  <containedEdges identifier="E150" sources="//@children.112/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.112/@ports.1" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.112/@ports.1" targets="//@children.117/@ports.1"/>
+  <containedEdges identifier="E153" sources="//@children.112/@ports.1" targets="//@children.118/@ports.1"/>
+  <containedEdges identifier="E154" sources="//@children.112/@ports.1" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E155" sources="//@children.113/@ports.1" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.114/@ports.2" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.115/@ports.1" targets="//@children.116/@ports.1"/>
+  <containedEdges identifier="E158" sources="//@children.115/@ports.1" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.115/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E160" sources="//@children.116/@ports.2" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E161" sources="//@children.117/@ports.0" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.118/@ports.0" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.119/@ports.1" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E164" sources="//@children.120/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E165" sources="//@children.121/@ports.1" targets="//@children.123/@ports.1"/>
+  <containedEdges identifier="E166" sources="//@children.122/@ports.1" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E167" sources="//@children.123/@ports.2" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E168" sources="//@children.124/@ports.2" targets="//@children.87/@ports.1"/>
+  <containedEdges identifier="E169" sources="//@children.124/@ports.2" targets="//@children.89/@ports.1"/>
+  <containedEdges identifier="E170" sources="//@children.124/@ports.2" targets="//@children.90/@ports.1"/>
+  <containedEdges identifier="E171" sources="//@children.124/@ports.2" targets="//@children.93/@ports.1"/>
+  <containedEdges identifier="E172" sources="//@children.125/@ports.1" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.126/@ports.0" targets="//@children.126/@ports.1"/>
+  <containedEdges identifier="E174" sources="//@children.127/@ports.0" targets="//@children.127/@ports.1"/>
+  <containedEdges identifier="E175" sources="//@children.127/@ports.1" targets="//@children.282/@ports.0"/>
+  <containedEdges identifier="E176" sources="//@children.129/@ports.0" targets="//@children.128/@ports.2"/>
+  <containedEdges identifier="E177" sources="//@children.131/@ports.0" targets="//@children.130/@ports.2"/>
+  <containedEdges identifier="E178" sources="//@children.132/@ports.2" targets="//@children.134/@ports.1"/>
+  <containedEdges identifier="E179" sources="//@children.132/@ports.2" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E180" sources="//@children.133/@ports.1" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E181" sources="//@children.134/@ports.0" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E182" sources="//@children.135/@ports.1" targets="//@children.136/@ports.2"/>
+  <containedEdges identifier="E183" sources="//@children.136/@ports.1" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E184" sources="//@children.138/@ports.0" targets="//@children.138/@ports.1"/>
+  <containedEdges identifier="E185" sources="//@children.139/@ports.0" targets="//@children.139/@ports.1"/>
+  <containedEdges identifier="E186" sources="//@children.139/@ports.1" targets="//@children.281/@ports.0"/>
+  <containedEdges identifier="E187" sources="//@children.139/@ports.1" targets="//@children.296/@ports.0"/>
+  <containedEdges identifier="E188" sources="//@children.140/@ports.0" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E189" sources="//@children.141/@ports.0" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E190" sources="//@children.141/@ports.0" targets="//@children.164/@ports.2"/>
+  <containedEdges identifier="E191" sources="//@children.142/@ports.1" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.142/@ports.1" targets="//@children.144/@ports.1"/>
+  <containedEdges identifier="E193" sources="//@children.143/@ports.1" targets="//@children.145/@ports.1"/>
+  <containedEdges identifier="E194" sources="//@children.144/@ports.0" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E195" sources="//@children.145/@ports.2" targets="//@children.146/@ports.0"/>
+  <containedEdges identifier="E196" sources="//@children.146/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E197" sources="//@children.147/@ports.1" targets="//@children.148/@ports.0"/>
+  <containedEdges identifier="E198" sources="//@children.147/@ports.1" targets="//@children.149/@ports.1"/>
+  <containedEdges identifier="E199" sources="//@children.148/@ports.1" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E200" sources="//@children.149/@ports.0" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E201" sources="//@children.150/@ports.2" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E202" sources="//@children.151/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E203" sources="//@children.152/@ports.1" targets="//@children.160/@ports.0"/>
+  <containedEdges identifier="E204" sources="//@children.153/@ports.2" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E205" sources="//@children.153/@ports.3" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E206" sources="//@children.154/@ports.1" targets="//@children.153/@ports.1"/>
+  <containedEdges identifier="E207" sources="//@children.155/@ports.2" targets="//@children.141/@ports.1"/>
+  <containedEdges identifier="E208" sources="//@children.155/@ports.3" targets="//@children.159/@ports.0"/>
+  <containedEdges identifier="E209" sources="//@children.156/@ports.1" targets="//@children.155/@ports.1"/>
+  <containedEdges identifier="E210" sources="//@children.158/@ports.2" targets="//@children.153/@ports.0"/>
+  <containedEdges identifier="E211" sources="//@children.159/@ports.2" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E212" sources="//@children.159/@ports.3" targets="//@children.161/@ports.1"/>
+  <containedEdges identifier="E213" sources="//@children.160/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E214" sources="//@children.161/@ports.0" targets="//@children.160/@ports.0"/>
+  <containedEdges identifier="E215" sources="//@children.162/@ports.1" targets="//@children.159/@ports.1"/>
+  <containedEdges identifier="E216" sources="//@children.163/@ports.0" targets="//@children.164/@ports.0"/>
+  <containedEdges identifier="E217" sources="//@children.164/@ports.1" targets="//@children.158/@ports.1"/>
+  <containedEdges identifier="E218" sources="//@children.165/@ports.1" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E219" sources="//@children.166/@ports.1" targets="//@children.168/@ports.0"/>
+  <containedEdges identifier="E220" sources="//@children.167/@ports.1" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E221" sources="//@children.167/@ports.1" targets="//@children.162/@ports.0"/>
+  <containedEdges identifier="E222" sources="//@children.168/@ports.1" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E223" sources="//@children.169/@ports.0" targets="//@children.169/@ports.1"/>
+  <containedEdges identifier="E224" sources="//@children.169/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E225" sources="//@children.169/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E226" sources="//@children.170/@ports.0" targets="//@children.185/@ports.0"/>
+  <containedEdges identifier="E227" sources="//@children.171/@ports.0" targets="//@children.188/@ports.0"/>
+  <containedEdges identifier="E228" sources="//@children.171/@ports.0" targets="//@children.194/@ports.2"/>
+  <containedEdges identifier="E229" sources="//@children.172/@ports.1" targets="//@children.173/@ports.0"/>
+  <containedEdges identifier="E230" sources="//@children.172/@ports.1" targets="//@children.174/@ports.1"/>
+  <containedEdges identifier="E231" sources="//@children.173/@ports.1" targets="//@children.175/@ports.1"/>
+  <containedEdges identifier="E232" sources="//@children.174/@ports.0" targets="//@children.175/@ports.0"/>
+  <containedEdges identifier="E233" sources="//@children.175/@ports.2" targets="//@children.176/@ports.0"/>
+  <containedEdges identifier="E234" sources="//@children.176/@ports.1" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E235" sources="//@children.177/@ports.1" targets="//@children.178/@ports.0"/>
+  <containedEdges identifier="E236" sources="//@children.177/@ports.1" targets="//@children.179/@ports.1"/>
+  <containedEdges identifier="E237" sources="//@children.178/@ports.1" targets="//@children.180/@ports.0"/>
+  <containedEdges identifier="E238" sources="//@children.179/@ports.0" targets="//@children.180/@ports.0"/>
+  <containedEdges identifier="E239" sources="//@children.180/@ports.2" targets="//@children.181/@ports.0"/>
+  <containedEdges identifier="E240" sources="//@children.181/@ports.1" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E241" sources="//@children.182/@ports.1" targets="//@children.190/@ports.0"/>
+  <containedEdges identifier="E242" sources="//@children.183/@ports.2" targets="//@children.172/@ports.0"/>
+  <containedEdges identifier="E243" sources="//@children.183/@ports.3" targets="//@children.177/@ports.0"/>
+  <containedEdges identifier="E244" sources="//@children.184/@ports.1" targets="//@children.183/@ports.1"/>
+  <containedEdges identifier="E245" sources="//@children.185/@ports.2" targets="//@children.171/@ports.1"/>
+  <containedEdges identifier="E246" sources="//@children.185/@ports.3" targets="//@children.189/@ports.0"/>
+  <containedEdges identifier="E247" sources="//@children.186/@ports.1" targets="//@children.185/@ports.1"/>
+  <containedEdges identifier="E248" sources="//@children.188/@ports.2" targets="//@children.183/@ports.0"/>
+  <containedEdges identifier="E249" sources="//@children.189/@ports.2" targets="//@children.182/@ports.0"/>
+  <containedEdges identifier="E250" sources="//@children.189/@ports.3" targets="//@children.191/@ports.1"/>
+  <containedEdges identifier="E251" sources="//@children.190/@ports.1" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E252" sources="//@children.191/@ports.0" targets="//@children.190/@ports.0"/>
+  <containedEdges identifier="E253" sources="//@children.192/@ports.1" targets="//@children.189/@ports.1"/>
+  <containedEdges identifier="E254" sources="//@children.193/@ports.0" targets="//@children.194/@ports.0"/>
+  <containedEdges identifier="E255" sources="//@children.194/@ports.1" targets="//@children.188/@ports.1"/>
+  <containedEdges identifier="E256" sources="//@children.195/@ports.1" targets="//@children.197/@ports.0"/>
+  <containedEdges identifier="E257" sources="//@children.196/@ports.1" targets="//@children.198/@ports.0"/>
+  <containedEdges identifier="E258" sources="//@children.197/@ports.1" targets="//@children.186/@ports.0"/>
+  <containedEdges identifier="E259" sources="//@children.197/@ports.1" targets="//@children.192/@ports.0"/>
+  <containedEdges identifier="E260" sources="//@children.198/@ports.1" targets="//@children.184/@ports.0"/>
+  <containedEdges identifier="E261" sources="//@children.199/@ports.0" targets="//@children.199/@ports.1"/>
+  <containedEdges identifier="E262" sources="//@children.200/@ports.0" targets="//@children.200/@ports.1"/>
+  <containedEdges identifier="E263" sources="//@children.200/@ports.1" targets="//@children.266/@ports.0"/>
+  <containedEdges identifier="E264" sources="//@children.201/@ports.0" targets="//@children.218/@ports.0"/>
+  <containedEdges identifier="E265" sources="//@children.201/@ports.0" targets="//@children.224/@ports.2"/>
+  <containedEdges identifier="E266" sources="//@children.202/@ports.1" targets="//@children.203/@ports.0"/>
+  <containedEdges identifier="E267" sources="//@children.202/@ports.1" targets="//@children.204/@ports.1"/>
+  <containedEdges identifier="E268" sources="//@children.203/@ports.1" targets="//@children.205/@ports.1"/>
+  <containedEdges identifier="E269" sources="//@children.204/@ports.0" targets="//@children.205/@ports.0"/>
+  <containedEdges identifier="E270" sources="//@children.205/@ports.2" targets="//@children.206/@ports.0"/>
+  <containedEdges identifier="E271" sources="//@children.206/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E272" sources="//@children.207/@ports.1" targets="//@children.208/@ports.0"/>
+  <containedEdges identifier="E273" sources="//@children.207/@ports.1" targets="//@children.209/@ports.1"/>
+  <containedEdges identifier="E274" sources="//@children.208/@ports.1" targets="//@children.210/@ports.0"/>
+  <containedEdges identifier="E275" sources="//@children.209/@ports.0" targets="//@children.210/@ports.0"/>
+  <containedEdges identifier="E276" sources="//@children.210/@ports.2" targets="//@children.211/@ports.0"/>
+  <containedEdges identifier="E277" sources="//@children.211/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E278" sources="//@children.212/@ports.1" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E279" sources="//@children.213/@ports.2" targets="//@children.202/@ports.0"/>
+  <containedEdges identifier="E280" sources="//@children.213/@ports.3" targets="//@children.207/@ports.0"/>
+  <containedEdges identifier="E281" sources="//@children.214/@ports.1" targets="//@children.213/@ports.1"/>
+  <containedEdges identifier="E282" sources="//@children.215/@ports.2" targets="//@children.201/@ports.1"/>
+  <containedEdges identifier="E283" sources="//@children.215/@ports.3" targets="//@children.219/@ports.0"/>
+  <containedEdges identifier="E284" sources="//@children.216/@ports.1" targets="//@children.215/@ports.1"/>
+  <containedEdges identifier="E285" sources="//@children.218/@ports.2" targets="//@children.213/@ports.0"/>
+  <containedEdges identifier="E286" sources="//@children.219/@ports.2" targets="//@children.212/@ports.0"/>
+  <containedEdges identifier="E287" sources="//@children.219/@ports.3" targets="//@children.221/@ports.1"/>
+  <containedEdges identifier="E288" sources="//@children.220/@ports.1" targets="//@children.230/@ports.1"/>
+  <containedEdges identifier="E289" sources="//@children.220/@ports.1" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E290" sources="//@children.221/@ports.0" targets="//@children.220/@ports.0"/>
+  <containedEdges identifier="E291" sources="//@children.222/@ports.1" targets="//@children.219/@ports.1"/>
+  <containedEdges identifier="E292" sources="//@children.223/@ports.0" targets="//@children.224/@ports.0"/>
+  <containedEdges identifier="E293" sources="//@children.224/@ports.1" targets="//@children.218/@ports.1"/>
+  <containedEdges identifier="E294" sources="//@children.225/@ports.1" targets="//@children.227/@ports.0"/>
+  <containedEdges identifier="E295" sources="//@children.226/@ports.1" targets="//@children.228/@ports.0"/>
+  <containedEdges identifier="E296" sources="//@children.227/@ports.1" targets="//@children.216/@ports.0"/>
+  <containedEdges identifier="E297" sources="//@children.227/@ports.1" targets="//@children.222/@ports.0"/>
+  <containedEdges identifier="E298" sources="//@children.228/@ports.1" targets="//@children.214/@ports.0"/>
+  <containedEdges identifier="E299" sources="//@children.229/@ports.0" targets="//@children.231/@ports.2"/>
+  <containedEdges identifier="E300" sources="//@children.230/@ports.0" targets="//@children.231/@ports.0"/>
+  <containedEdges identifier="E301" sources="//@children.231/@ports.1" targets="//@children.217/@ports.0"/>
+  <containedEdges identifier="E302" sources="//@children.232/@ports.0" targets="//@children.225/@ports.2"/>
+  <containedEdges identifier="E303" sources="//@children.232/@ports.0" targets="//@children.226/@ports.2"/>
+  <containedEdges identifier="E304" sources="//@children.233/@ports.0" targets="//@children.233/@ports.1"/>
+  <containedEdges identifier="E305" sources="//@children.233/@ports.1" targets="//@children.250/@ports.0"/>
+  <containedEdges identifier="E306" sources="//@children.234/@ports.0" targets="//@children.234/@ports.1"/>
+  <containedEdges identifier="E307" sources="//@children.234/@ports.1" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E308" sources="//@children.234/@ports.1" targets="//@children.138/@ports.0"/>
+  <containedEdges identifier="E309" sources="//@children.236/@ports.0" targets="//@children.235/@ports.2"/>
+  <containedEdges identifier="E310" sources="//@children.237/@ports.2" targets="//@children.238/@ports.1"/>
+  <containedEdges identifier="E311" sources="//@children.237/@ports.2" targets="//@children.242/@ports.1"/>
+  <containedEdges identifier="E312" sources="//@children.237/@ports.2" targets="//@children.243/@ports.0"/>
+  <containedEdges identifier="E313" sources="//@children.237/@ports.2" targets="//@children.245/@ports.0"/>
+  <containedEdges identifier="E314" sources="//@children.238/@ports.0" targets="//@children.241/@ports.0"/>
+  <containedEdges identifier="E315" sources="//@children.239/@ports.0" targets="//@children.237/@ports.1"/>
+  <containedEdges identifier="E316" sources="//@children.240/@ports.1" targets="//@children.241/@ports.1"/>
+  <containedEdges identifier="E317" sources="//@children.241/@ports.2" targets="//@children.246/@ports.0"/>
+  <containedEdges identifier="E318" sources="//@children.242/@ports.0" targets="//@children.244/@ports.0"/>
+  <containedEdges identifier="E319" sources="//@children.243/@ports.1" targets="//@children.244/@ports.1"/>
+  <containedEdges identifier="E320" sources="//@children.244/@ports.2" targets="//@children.248/@ports.0"/>
+  <containedEdges identifier="E321" sources="//@children.245/@ports.1" targets="//@children.240/@ports.0"/>
+  <containedEdges identifier="E322" sources="//@children.246/@ports.1" targets="//@children.247/@ports.0"/>
+  <containedEdges identifier="E323" sources="//@children.248/@ports.1" targets="//@children.249/@ports.0"/>
+  <containedEdges identifier="E324" sources="//@children.250/@ports.0" targets="//@children.250/@ports.1"/>
+  <containedEdges identifier="E325" sources="//@children.251/@ports.0" targets="//@children.251/@ports.1"/>
+  <containedEdges identifier="E326" sources="//@children.251/@ports.1" targets="//@children.199/@ports.0"/>
+  <containedEdges identifier="E327" sources="//@children.251/@ports.1" targets="//@children.269/@ports.0"/>
+  <containedEdges identifier="E328" sources="//@children.251/@ports.1" targets="//@children.283/@ports.0"/>
+  <containedEdges identifier="E329" sources="//@children.252/@ports.0" targets="//@children.252/@ports.1"/>
+  <containedEdges identifier="E330" sources="//@children.253/@ports.0" targets="//@children.253/@ports.1"/>
+  <containedEdges identifier="E331" sources="//@children.253/@ports.1" targets="//@children.106/@ports.1"/>
+  <containedEdges identifier="E332" sources="//@children.255/@ports.0" targets="//@children.254/@ports.2"/>
+  <containedEdges identifier="E333" sources="//@children.257/@ports.0" targets="//@children.256/@ports.2"/>
+  <containedEdges identifier="E334" sources="//@children.258/@ports.0" targets="//@children.259/@ports.0"/>
+  <containedEdges identifier="E335" sources="//@children.258/@ports.0" targets="//@children.261/@ports.1"/>
+  <containedEdges identifier="E336" sources="//@children.259/@ports.1" targets="//@children.258/@ports.4"/>
+  <containedEdges identifier="E337" sources="//@children.259/@ports.1" targets="//@children.260/@ports.0"/>
+  <containedEdges identifier="E338" sources="//@children.259/@ports.1" targets="//@children.262/@ports.1"/>
+  <containedEdges identifier="E339" sources="//@children.260/@ports.1" targets="//@children.263/@ports.1"/>
+  <containedEdges identifier="E340" sources="//@children.262/@ports.0" targets="//@children.264/@ports.0"/>
+  <containedEdges identifier="E341" sources="//@children.265/@ports.0" targets="//@children.259/@ports.2"/>
+  <containedEdges identifier="E342" sources="//@children.265/@ports.0" targets="//@children.260/@ports.2"/>
+  <containedEdges identifier="E343" sources="//@children.265/@ports.0" targets="//@children.264/@ports.2"/>
+  <containedEdges identifier="E344" sources="//@children.266/@ports.0" targets="//@children.266/@ports.1"/>
+  <containedEdges identifier="E345" sources="//@children.267/@ports.0" targets="//@children.267/@ports.1"/>
+  <containedEdges identifier="E346" sources="//@children.268/@ports.0" targets="//@children.268/@ports.1"/>
+  <containedEdges identifier="E347" sources="//@children.268/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E348" sources="//@children.269/@ports.0" targets="//@children.269/@ports.1"/>
+  <containedEdges identifier="E349" sources="//@children.271/@ports.0" targets="//@children.270/@ports.2"/>
+  <containedEdges identifier="E350" sources="//@children.272/@ports.1" targets="//@children.276/@ports.1"/>
+  <containedEdges identifier="E351" sources="//@children.272/@ports.1" targets="//@children.279/@ports.0"/>
+  <containedEdges identifier="E352" sources="//@children.273/@ports.1" targets="//@children.275/@ports.1"/>
+  <containedEdges identifier="E353" sources="//@children.273/@ports.1" targets="//@children.278/@ports.0"/>
+  <containedEdges identifier="E354" sources="//@children.274/@ports.1" targets="//@children.275/@ports.0"/>
+  <containedEdges identifier="E355" sources="//@children.275/@ports.2" targets="//@children.272/@ports.0"/>
+  <containedEdges identifier="E356" sources="//@children.276/@ports.0" targets="//@children.279/@ports.0"/>
+  <containedEdges identifier="E357" sources="//@children.277/@ports.0" targets="//@children.279/@ports.2"/>
+  <containedEdges identifier="E358" sources="//@children.279/@ports.1" targets="//@children.280/@ports.0"/>
+  <containedEdges identifier="E359" sources="//@children.281/@ports.0" targets="//@children.281/@ports.1"/>
+  <containedEdges identifier="E360" sources="//@children.282/@ports.0" targets="//@children.282/@ports.1"/>
+  <containedEdges identifier="E361" sources="//@children.283/@ports.0" targets="//@children.283/@ports.1"/>
+  <containedEdges identifier="E362" sources="//@children.284/@ports.0" targets="//@children.284/@ports.1"/>
+  <containedEdges identifier="E363" sources="//@children.284/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E364" sources="//@children.286/@ports.0" targets="//@children.285/@ports.2"/>
+  <containedEdges identifier="E365" sources="//@children.287/@ports.1" targets="//@children.291/@ports.1"/>
+  <containedEdges identifier="E366" sources="//@children.287/@ports.1" targets="//@children.295/@ports.0"/>
+  <containedEdges identifier="E367" sources="//@children.288/@ports.1" targets="//@children.290/@ports.1"/>
+  <containedEdges identifier="E368" sources="//@children.288/@ports.1" targets="//@children.293/@ports.0"/>
+  <containedEdges identifier="E369" sources="//@children.289/@ports.1" targets="//@children.290/@ports.0"/>
+  <containedEdges identifier="E370" sources="//@children.290/@ports.2" targets="//@children.287/@ports.0"/>
+  <containedEdges identifier="E371" sources="//@children.291/@ports.0" targets="//@children.295/@ports.0"/>
+  <containedEdges identifier="E372" sources="//@children.292/@ports.0" targets="//@children.295/@ports.2"/>
+  <containedEdges identifier="E373" sources="//@children.295/@ports.1" targets="//@children.294/@ports.0"/>
+  <containedEdges identifier="E374" sources="//@children.296/@ports.0" targets="//@children.296/@ports.1"/>
+  <containedEdges identifier="E375" sources="//@children.299/@ports.1" targets="//@children.297/@ports.0"/>
+  <containedEdges identifier="E376" sources="//@children.300/@ports.0" targets="//@children.299/@ports.2"/>
+  <containedEdges identifier="E377" sources="//@children.301/@ports.0" targets="//@children.301/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_printingpress_PrintingPress_AnimationsOnly.elkg
+++ b/realworld/ptolemy/flattened/ptides_printingpress_PrintingPress_AnimationsOnly.elkg
@@ -1,0 +1,2269 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="74.0" text="SetVariable7"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="76.0" text="SingleEvent4"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="74.0" text="SetVariable8"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="76.0" text="SingleEvent5"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="74.0" text="SetVariable9"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="76.0" text="SingleEvent6"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="76.0" text="SingleEvent7"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="71.0" text="startSecond"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="52.0" text="startFirst"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="70.0" text="stopSecond"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="81.0" text="SetVariable10"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="83.0" text="SingleEvent12"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="80.0" text="SetVariable11"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="82.0" text="SingleEvent11"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="81.0" text="SetVariable13"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="83.0" text="SingleEvent14"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="61.0" text="startMover"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="60.0" text="stopMover"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="83.0" text="SingleEvent16"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="81.0" text="SetVariable15"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="81.0" text="SetVariable17"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="83.0" text="SingleEvent17"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="81.0" text="SetVariable18"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="87.0" text="MultiplyDivide6"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="79.0" text="TrigFunction3"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="79.0" text="TrigFunction4"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="87.0" text="MultiplyDivide7"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="89.0" text="DiscreteClock4"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="87.0" text="MultiplyDivide8"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.34 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.38 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="89.0" text="DiscreteClock5"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="57.0" text="initRadius"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.46 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.47 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.52 //@containedEdges.53 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.51 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.55 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="57.0" text="initRadius"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.60 //@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.65 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.67 //@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.71 //@containedEdges.72 //@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.70 //@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.74 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="57.0" text="initRadius"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.79 //@containedEdges.80 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.84 //@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.85 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.86 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.90 //@containedEdges.91 //@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.89 //@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.93 //@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="57.0" text="initRadius"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.98 //@containedEdges.99 //@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.103 //@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.104 //@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.105 //@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.109 //@containedEdges.110 //@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.108 //@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.112 //@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P273" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P277" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="57.0" text="initRadius"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.117 //@containedEdges.118 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P284" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.121 //@containedEdges.122 //@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P289" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P290" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.127 //@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="87.0" text="MultiplyDivide6"/>
+    <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.128 //@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="79.0" text="TrigFunction3"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="79.0" text="TrigFunction4"/>
+    <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P310" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="87.0" text="MultiplyDivide7"/>
+    <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.129 //@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P314" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P316" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="89.0" text="DiscreteClock4"/>
+    <ports identifier="P319" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.133 //@containedEdges.134 //@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P322" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="87.0" text="MultiplyDivide8"/>
+    <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.132 //@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.136 //@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="25.0" width="20.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P327" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="89.0" text="DiscreteClock5"/>
+    <ports identifier="P331" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P335" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="57.0" text="initRadius"/>
+    <ports identifier="P336" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P338" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.142 //@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P341" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P343" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P347" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P348" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P349" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.14/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.17/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.18/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.18/@ports.0" targets="//@children.51/@ports.4"/>
+  <containedEdges identifier="E12" sources="//@children.18/@ports.0" targets="//@children.134/@ports.3"/>
+  <containedEdges identifier="E13" sources="//@children.19/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E14" sources="//@children.19/@ports.0" targets="//@children.51/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.20/@ports.0" targets="//@children.134/@ports.4"/>
+  <containedEdges identifier="E16" sources="//@children.22/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.24/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.26/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.27/@ports.0" targets="//@children.136/@ports.3"/>
+  <containedEdges identifier="E20" sources="//@children.28/@ports.0" targets="//@children.136/@ports.4"/>
+  <containedEdges identifier="E21" sources="//@children.29/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.34/@ports.0" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.35/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.35/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.35/@ports.1" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.36/@ports.0" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.40/@ports.2" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.41/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.42/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.43/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.44/@ports.2" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.44/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.45/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.46/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.47/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.47/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.47/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.48/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.48/@ports.2" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.49/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.50/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.51/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.52/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.56/@ports.2" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.57/@ports.2" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.58/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.59/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.60/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.60/@ports.2" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.61/@ports.0" targets="//@children.60/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.62/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.63/@ports.0" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.63/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.63/@ports.0" targets="//@children.66/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.64/@ports.2" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.64/@ports.2" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.65/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.66/@ports.0" targets="//@children.64/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.67/@ports.0" targets="//@children.68/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.68/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.68/@ports.0" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.68/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.72/@ports.2" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.73/@ports.2" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.74/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.75/@ports.1" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.76/@ports.2" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.76/@ports.2" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.77/@ports.0" targets="//@children.76/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.78/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.79/@ports.0" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.79/@ports.0" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.79/@ports.0" targets="//@children.82/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.80/@ports.2" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.80/@ports.2" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.81/@ports.0" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.82/@ports.0" targets="//@children.80/@ports.1"/>
+  <containedEdges identifier="E79" sources="//@children.83/@ports.0" targets="//@children.84/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.84/@ports.0" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.84/@ports.0" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.84/@ports.0" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E83" sources="//@children.88/@ports.2" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.89/@ports.2" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.90/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E86" sources="//@children.91/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.92/@ports.2" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.92/@ports.2" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.93/@ports.0" targets="//@children.92/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.94/@ports.0" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.95/@ports.0" targets="//@children.94/@ports.1"/>
+  <containedEdges identifier="E92" sources="//@children.95/@ports.0" targets="//@children.97/@ports.1"/>
+  <containedEdges identifier="E93" sources="//@children.95/@ports.0" targets="//@children.98/@ports.1"/>
+  <containedEdges identifier="E94" sources="//@children.96/@ports.2" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.96/@ports.2" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.97/@ports.0" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.98/@ports.0" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E98" sources="//@children.99/@ports.0" targets="//@children.100/@ports.1"/>
+  <containedEdges identifier="E99" sources="//@children.100/@ports.0" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.100/@ports.0" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.100/@ports.0" targets="//@children.93/@ports.1"/>
+  <containedEdges identifier="E102" sources="//@children.104/@ports.2" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.105/@ports.2" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.106/@ports.1" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.107/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.108/@ports.2" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.108/@ports.2" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.109/@ports.0" targets="//@children.108/@ports.1"/>
+  <containedEdges identifier="E109" sources="//@children.110/@ports.0" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.111/@ports.0" targets="//@children.110/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.111/@ports.0" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E112" sources="//@children.111/@ports.0" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E113" sources="//@children.112/@ports.2" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.112/@ports.2" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.113/@ports.0" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.114/@ports.0" targets="//@children.112/@ports.1"/>
+  <containedEdges identifier="E117" sources="//@children.115/@ports.0" targets="//@children.116/@ports.1"/>
+  <containedEdges identifier="E118" sources="//@children.116/@ports.0" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.116/@ports.0" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.116/@ports.0" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E121" sources="//@children.117/@ports.0" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.118/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.118/@ports.1" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.118/@ports.1" targets="//@children.128/@ports.1"/>
+  <containedEdges identifier="E125" sources="//@children.119/@ports.0" targets="//@children.118/@ports.2"/>
+  <containedEdges identifier="E126" sources="//@children.123/@ports.2" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.124/@ports.2" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.125/@ports.1" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.126/@ports.1" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.127/@ports.2" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.127/@ports.2" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.128/@ports.0" targets="//@children.127/@ports.1"/>
+  <containedEdges identifier="E133" sources="//@children.129/@ports.0" targets="//@children.131/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.130/@ports.0" targets="//@children.129/@ports.1"/>
+  <containedEdges identifier="E135" sources="//@children.130/@ports.0" targets="//@children.132/@ports.1"/>
+  <containedEdges identifier="E136" sources="//@children.130/@ports.0" targets="//@children.133/@ports.1"/>
+  <containedEdges identifier="E137" sources="//@children.131/@ports.2" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.131/@ports.2" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E139" sources="//@children.132/@ports.0" targets="//@children.131/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.133/@ports.0" targets="//@children.131/@ports.1"/>
+  <containedEdges identifier="E141" sources="//@children.134/@ports.0" targets="//@children.135/@ports.1"/>
+  <containedEdges identifier="E142" sources="//@children.135/@ports.0" targets="//@children.117/@ports.1"/>
+  <containedEdges identifier="E143" sources="//@children.136/@ports.0" targets="//@children.137/@ports.1"/>
+  <containedEdges identifier="E144" sources="//@children.136/@ports.0" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E145" sources="//@children.137/@ports.0" targets="//@children.138/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_ptidessynchrophasor_PtidesSynchrophasor.elkg
+++ b/realworld/ptolemy/flattened/ptides_ptidessynchrophasor_PtidesSynchrophasor.elkg
@@ -1,0 +1,445 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="62.0" text="Sinewave2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="16.0" text="IIR"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="23.0" text="IIR2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="16.0" text="IIR"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="23.0" text="IIR2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="100.0" text="SetControlOutput"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.12/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.13/@ports.0" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.15/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.16/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.17/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.18/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.19/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.20/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.22/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.23/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.24/@ports.1" targets="//@children.21/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_srinptides_SRinPtides.elkg
+++ b/realworld/ptolemy/flattened/ptides_srinptides_SRinPtides.elkg
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="95.0" text="NonStrictDelay2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="95.0" text="NonStrictDelay2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="95.0" text="NonStrictDelay2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="95.0" text="NonStrictDelay2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="95.0" text="NonStrictDelay2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.19/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.21/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.22/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.23/@ports.1" targets="//@children.22/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_srinptides_SRinPtidesLoop.elkg
+++ b/realworld/ptolemy/flattened/ptides_srinptides_SRinPtidesLoop.elkg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.6 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="95.0" text="NonStrictDelay2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="95.0" text="NonStrictDelay3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="14.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="95.0" text="NonStrictDelay2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="95.0" text="NonStrictDelay3"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_trex_TREX.elkg
+++ b/realworld/ptolemy/flattened/ptides_trex_TREX.elkg
@@ -1,0 +1,2030 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="407.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="119.0" text="initialRadiusSquared"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="58.0" text="constzero"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="40.0" text="omega"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="65.0" text="constzero2"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="65.0" text="coreRadius"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.5 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="45.0" text="Select2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.28 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.38 //@containedEdges.39 //@containedEdges.40 //@containedEdges.41 //@containedEdges.42 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.46 //@containedEdges.47 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.57 //@containedEdges.58 //@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="91.0" text="coreMassScale"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.63 //@containedEdges.64" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.66 //@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.68 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.74 //@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.76 //@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.73 //@containedEdges.79 //@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.80 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.97 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.100" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.102 //@containedEdges.103" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="101.0" text="CompositeActor7"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.105 //@containedEdges.106" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.107" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.108" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="101.0" text="CompositeActor8"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.110 //@containedEdges.111" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="25.0" width="136.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="53.0" text="TimeGap"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.116 //@containedEdges.117 //@containedEdges.118 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.120 //@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.120 //@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.127 //@containedEdges.128 //@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.115 //@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.131" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.132" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.134" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P248" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.136 //@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.138 //@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.137 //@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.144" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P275" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P284" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P286" height="8.0" width="8.0" x="9.333333015441895" y="46.0" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.147 //@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P289" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.150 //@containedEdges.151 //@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P295" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="128.0" text="contactControlMonitor"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.155 //@containedEdges.156 //@containedEdges.157 //@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.10/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.21/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.22/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.23/@ports.0" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E33" sources="//@children.24/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.24/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.25/@ports.2" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.26/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.27/@ports.1" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E38" sources="//@children.28/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.29/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.29/@ports.1" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.29/@ports.1" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.29/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.29/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.29/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.30/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.31/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.32/@ports.1" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.32/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.32/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.33/@ports.2" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.34/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.35/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.36/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.37/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.38/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.39/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.40/@ports.2" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.41/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E59" sources="//@children.41/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.41/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.41/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.42/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.43/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.43/@ports.1" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.43/@ports.1" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.44/@ports.0" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.45/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.45/@ports.0" targets="//@children.68/@ports.2"/>
+  <containedEdges identifier="E69" sources="//@children.46/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E70" sources="//@children.46/@ports.1" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.47/@ports.1" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E72" sources="//@children.48/@ports.0" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.49/@ports.2" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.50/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.51/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.51/@ports.1" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E77" sources="//@children.52/@ports.1" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.53/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.54/@ports.2" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.55/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.56/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.57/@ports.2" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.57/@ports.3" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.58/@ports.1" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E85" sources="//@children.59/@ports.2" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.59/@ports.3" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.60/@ports.1" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.62/@ports.2" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.63/@ports.2" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.63/@ports.3" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E91" sources="//@children.64/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.65/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.66/@ports.1" targets="//@children.63/@ports.1"/>
+  <containedEdges identifier="E94" sources="//@children.67/@ports.0" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.68/@ports.1" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E96" sources="//@children.69/@ports.1" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.70/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.71/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.71/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.72/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.73/@ports.0" targets="//@children.73/@ports.1"/>
+  <containedEdges identifier="E102" sources="//@children.74/@ports.0" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E103" sources="//@children.74/@ports.1" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.74/@ports.1" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.75/@ports.0" targets="//@children.75/@ports.1"/>
+  <containedEdges identifier="E106" sources="//@children.75/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E107" sources="//@children.75/@ports.1" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.76/@ports.0" targets="//@children.76/@ports.1"/>
+  <containedEdges identifier="E109" sources="//@children.77/@ports.0" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E110" sources="//@children.78/@ports.0" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.78/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.78/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.80/@ports.0" targets="//@children.79/@ports.2"/>
+  <containedEdges identifier="E114" sources="//@children.81/@ports.0" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.82/@ports.0" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.83/@ports.0" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.85/@ports.1" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E118" sources="//@children.85/@ports.1" targets="//@children.83/@ports.1"/>
+  <containedEdges identifier="E119" sources="//@children.85/@ports.1" targets="//@children.86/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.85/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.86/@ports.2" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.86/@ports.2" targets="//@children.91/@ports.2"/>
+  <containedEdges identifier="E123" sources="//@children.87/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.88/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.89/@ports.2" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.91/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.92/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.93/@ports.1" targets="//@children.82/@ports.1"/>
+  <containedEdges identifier="E129" sources="//@children.93/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.93/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.94/@ports.2" targets="//@children.95/@ports.2"/>
+  <containedEdges identifier="E132" sources="//@children.96/@ports.0" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E133" sources="//@children.97/@ports.0" targets="//@children.97/@ports.1"/>
+  <containedEdges identifier="E134" sources="//@children.98/@ports.0" targets="//@children.98/@ports.1"/>
+  <containedEdges identifier="E135" sources="//@children.98/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.100/@ports.0" targets="//@children.99/@ports.2"/>
+  <containedEdges identifier="E137" sources="//@children.101/@ports.1" targets="//@children.105/@ports.1"/>
+  <containedEdges identifier="E138" sources="//@children.101/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E139" sources="//@children.103/@ports.1" targets="//@children.104/@ports.1"/>
+  <containedEdges identifier="E140" sources="//@children.103/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.104/@ports.2" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.105/@ports.0" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.106/@ports.0" targets="//@children.108/@ports.2"/>
+  <containedEdges identifier="E144" sources="//@children.108/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E145" sources="//@children.109/@ports.0" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E146" sources="//@children.111/@ports.0" targets="//@children.110/@ports.2"/>
+  <containedEdges identifier="E147" sources="//@children.112/@ports.0" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.113/@ports.2" targets="//@children.115/@ports.1"/>
+  <containedEdges identifier="E149" sources="//@children.113/@ports.2" targets="//@children.117/@ports.1"/>
+  <containedEdges identifier="E150" sources="//@children.114/@ports.1" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E151" sources="//@children.115/@ports.0" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.115/@ports.0" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.115/@ports.0" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.116/@ports.1" targets="//@children.112/@ports.1"/>
+  <containedEdges identifier="E155" sources="//@children.117/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.118/@ports.1" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.119/@ports.1" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E158" sources="//@children.120/@ports.1" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.121/@ports.1" targets="//@children.122/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_trex_TREXNetworkV1.elkg
+++ b/realworld/ptolemy/flattened/ptides_trex_TREXNetworkV1.elkg
@@ -1,0 +1,2093 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="407.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="119.0" text="initialRadiusSquared"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="58.0" text="constzero"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="40.0" text="omega"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="65.0" text="constzero2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="65.0" text="coreRadius"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.6 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="45.0" text="Select2"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.29 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.39 //@containedEdges.40 //@containedEdges.41 //@containedEdges.42 //@containedEdges.43 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.47 //@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.46 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.58 //@containedEdges.59 //@containedEdges.60 //@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="91.0" text="coreMassScale"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.63" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.65 //@containedEdges.66" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="101.0" text="CompositeActor7"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.68 //@containedEdges.69" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.70" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.71" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="136.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.77 //@containedEdges.78 //@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="79.0" text="VariableDelay"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="9.333333015441895" y="46.0" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.82 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.85 //@containedEdges.86 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="128.0" text="contactControlMonitor"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.90 //@containedEdges.91 //@containedEdges.92 //@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.94" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="101.0" text="CompositeActor8"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.96 //@containedEdges.97" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.99" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="53.0" text="TimeGap"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.102 //@containedEdges.103 //@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.105 //@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.105 //@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.109" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.112 //@containedEdges.113" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P210" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.115 //@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.117 //@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.123 //@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.125 //@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.122 //@containedEdges.128 //@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.129 //@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P268" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P275" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.146 //@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.149" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.150" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.152" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P295" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.154 //@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.156 //@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P307" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P308" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P310" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P314" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.155 //@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P316" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.2" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.21/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.21/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.22/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.23/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.24/@ports.0" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.25/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.25/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.26/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.27/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.28/@ports.1" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.29/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.30/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.30/@ports.1" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.30/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.30/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.30/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.30/@ports.1" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.31/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.32/@ports.2" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.33/@ports.1" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.33/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.33/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.34/@ports.2" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.35/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.36/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.37/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.38/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.39/@ports.1" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E57" sources="//@children.40/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.41/@ports.2" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.42/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.42/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.42/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.42/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.43/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.44/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.45/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.45/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E67" sources="//@children.45/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.46/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.46/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.46/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.47/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E72" sources="//@children.48/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.49/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.50/@ports.0" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.52/@ports.1" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.53/@ports.1" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.54/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.55/@ports.1" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E79" sources="//@children.55/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.55/@ports.1" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.57/@ports.2" targets="//@children.56/@ports.2"/>
+  <containedEdges identifier="E82" sources="//@children.58/@ports.0" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.59/@ports.2" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E84" sources="//@children.59/@ports.2" targets="//@children.63/@ports.1"/>
+  <containedEdges identifier="E85" sources="//@children.60/@ports.1" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.61/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.61/@ports.0" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.61/@ports.0" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.62/@ports.1" targets="//@children.58/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.63/@ports.0" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.64/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.65/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.66/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.67/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E95" sources="//@children.69/@ports.0" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E96" sources="//@children.70/@ports.0" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E97" sources="//@children.70/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.70/@ports.1" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.71/@ports.0" targets="//@children.71/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.71/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.73/@ports.0" targets="//@children.72/@ports.2"/>
+  <containedEdges identifier="E102" sources="//@children.74/@ports.0" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.75/@ports.1" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E104" sources="//@children.75/@ports.1" targets="//@children.76/@ports.1"/>
+  <containedEdges identifier="E105" sources="//@children.75/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.76/@ports.2" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.76/@ports.2" targets="//@children.79/@ports.2"/>
+  <containedEdges identifier="E108" sources="//@children.77/@ports.2" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.79/@ports.1" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.81/@ports.0" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.83/@ports.0" targets="//@children.82/@ports.2"/>
+  <containedEdges identifier="E112" sources="//@children.84/@ports.0" targets="//@children.84/@ports.1"/>
+  <containedEdges identifier="E113" sources="//@children.84/@ports.1" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.84/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.85/@ports.0" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.86/@ports.0" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.86/@ports.0" targets="//@children.109/@ports.2"/>
+  <containedEdges identifier="E118" sources="//@children.87/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.87/@ports.1" targets="//@children.89/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.88/@ports.1" targets="//@children.90/@ports.1"/>
+  <containedEdges identifier="E121" sources="//@children.89/@ports.0" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.90/@ports.2" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.91/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.92/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.92/@ports.1" targets="//@children.94/@ports.1"/>
+  <containedEdges identifier="E126" sources="//@children.93/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.94/@ports.0" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.95/@ports.2" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.96/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.97/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.98/@ports.2" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.98/@ports.3" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.99/@ports.1" targets="//@children.98/@ports.1"/>
+  <containedEdges identifier="E134" sources="//@children.100/@ports.2" targets="//@children.86/@ports.1"/>
+  <containedEdges identifier="E135" sources="//@children.100/@ports.3" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.101/@ports.1" targets="//@children.100/@ports.1"/>
+  <containedEdges identifier="E137" sources="//@children.103/@ports.2" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.104/@ports.2" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E139" sources="//@children.104/@ports.3" targets="//@children.106/@ports.1"/>
+  <containedEdges identifier="E140" sources="//@children.105/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.106/@ports.0" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.107/@ports.1" targets="//@children.104/@ports.1"/>
+  <containedEdges identifier="E143" sources="//@children.108/@ports.0" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.109/@ports.1" targets="//@children.103/@ports.1"/>
+  <containedEdges identifier="E145" sources="//@children.110/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.111/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.112/@ports.1" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.112/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E149" sources="//@children.113/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.114/@ports.0" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E151" sources="//@children.115/@ports.0" targets="//@children.115/@ports.1"/>
+  <containedEdges identifier="E152" sources="//@children.116/@ports.0" targets="//@children.116/@ports.1"/>
+  <containedEdges identifier="E153" sources="//@children.116/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.118/@ports.0" targets="//@children.117/@ports.2"/>
+  <containedEdges identifier="E155" sources="//@children.119/@ports.1" targets="//@children.123/@ports.1"/>
+  <containedEdges identifier="E156" sources="//@children.119/@ports.1" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.121/@ports.1" targets="//@children.122/@ports.1"/>
+  <containedEdges identifier="E158" sources="//@children.121/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.122/@ports.2" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E160" sources="//@children.123/@ports.0" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E161" sources="//@children.124/@ports.0" targets="//@children.126/@ports.2"/>
+  <containedEdges identifier="E162" sources="//@children.126/@ports.1" targets="//@children.120/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_trex_TREXNoNetworkAllDigital.elkg
+++ b/realworld/ptolemy/flattened/ptides_trex_TREXNoNetworkAllDigital.elkg
@@ -1,0 +1,2058 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="73.0" text="WaitingTime"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="ModelDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="87.0" text="MultiplyDivide4"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="MultiplyDivide5"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="407.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="119.0" text="initialRadiusSquared"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="58.0" text="constzero"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="40.0" text="omega"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="65.0" text="constzero2"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="65.0" text="coreRadius"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.37 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.7 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="45.0" text="Select2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.33 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.43 //@containedEdges.44 //@containedEdges.45 //@containedEdges.46 //@containedEdges.47 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="114.0" text="UnaryMathFunction"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.51 //@containedEdges.52 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.50 //@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.62 //@containedEdges.63 //@containedEdges.64 //@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="91.0" text="coreMassScale"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.67" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.69 //@containedEdges.70" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="101.0" text="CompositeActor7"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.72 //@containedEdges.73" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.74" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.75" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="101.0" text="CompositeActor8"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.77" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.78" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="25.0" width="136.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="53.0" text="TimeGap"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.82 //@containedEdges.83 //@containedEdges.84 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.86 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.86 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.93 //@containedEdges.94 //@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.81 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="9.333333015441895" y="46.0" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.98 //@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.101 //@containedEdges.102 //@containedEdges.103 //@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="128.0" text="contactControlMonitor"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.107 //@containedEdges.108 //@containedEdges.109 //@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.111" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.114 //@containedEdges.115" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.117 //@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.119 //@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P213" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.125 //@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.127 //@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P234" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.124 //@containedEdges.130 //@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="44.0" text="Merge4"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.131 //@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P256" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P269" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.148 //@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.151" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.152" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.154" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P284" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P287" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P290" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.156 //@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P295" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.158 //@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P300" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P302" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="37.0" text="Select"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.157 //@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P309" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.2" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.2" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.21/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.22/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.23/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.24/@ports.1" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.24/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.24/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.25/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.26/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.27/@ports.0" targets="//@children.32/@ports.2"/>
+  <containedEdges identifier="E38" sources="//@children.28/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.28/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.29/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.30/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.31/@ports.1" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E43" sources="//@children.32/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.33/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.33/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.33/@ports.1" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.33/@ports.1" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.33/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.33/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.34/@ports.1" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.35/@ports.2" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.36/@ports.1" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.36/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.36/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.37/@ports.2" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.38/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.39/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.40/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.41/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.42/@ports.1" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.43/@ports.1" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.44/@ports.2" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.45/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.45/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E65" sources="//@children.45/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.45/@ports.2" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.46/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E68" sources="//@children.47/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E69" sources="//@children.48/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.48/@ports.1" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E71" sources="//@children.48/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.49/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E73" sources="//@children.49/@ports.1" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.49/@ports.1" targets="//@children.75/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.50/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.51/@ports.0" targets="//@children.51/@ports.1"/>
+  <containedEdges identifier="E77" sources="//@children.52/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E78" sources="//@children.52/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E79" sources="//@children.53/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.54/@ports.0" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.55/@ports.0" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.56/@ports.0" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.58/@ports.1" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E84" sources="//@children.58/@ports.1" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E85" sources="//@children.58/@ports.1" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.58/@ports.1" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.59/@ports.2" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E88" sources="//@children.59/@ports.2" targets="//@children.64/@ports.2"/>
+  <containedEdges identifier="E89" sources="//@children.60/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E90" sources="//@children.61/@ports.1" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.62/@ports.2" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.64/@ports.1" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.65/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.66/@ports.1" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E95" sources="//@children.66/@ports.1" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.66/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.67/@ports.2" targets="//@children.68/@ports.2"/>
+  <containedEdges identifier="E98" sources="//@children.69/@ports.0" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.70/@ports.2" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.70/@ports.2" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E101" sources="//@children.71/@ports.1" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E102" sources="//@children.72/@ports.0" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.72/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E104" sources="//@children.72/@ports.0" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.72/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.73/@ports.1" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E107" sources="//@children.74/@ports.0" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.75/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.76/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.77/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.78/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.80/@ports.0" targets="//@children.80/@ports.1"/>
+  <containedEdges identifier="E113" sources="//@children.82/@ports.0" targets="//@children.81/@ports.2"/>
+  <containedEdges identifier="E114" sources="//@children.83/@ports.0" targets="//@children.83/@ports.1"/>
+  <containedEdges identifier="E115" sources="//@children.83/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.83/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.84/@ports.0" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.85/@ports.0" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.85/@ports.0" targets="//@children.108/@ports.2"/>
+  <containedEdges identifier="E120" sources="//@children.86/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.86/@ports.1" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E122" sources="//@children.87/@ports.1" targets="//@children.89/@ports.1"/>
+  <containedEdges identifier="E123" sources="//@children.88/@ports.0" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.89/@ports.2" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.90/@ports.1" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.91/@ports.1" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.91/@ports.1" targets="//@children.93/@ports.1"/>
+  <containedEdges identifier="E128" sources="//@children.92/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.93/@ports.0" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.94/@ports.2" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.95/@ports.1" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.96/@ports.1" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.97/@ports.2" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E134" sources="//@children.97/@ports.3" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E135" sources="//@children.98/@ports.1" targets="//@children.97/@ports.1"/>
+  <containedEdges identifier="E136" sources="//@children.99/@ports.2" targets="//@children.85/@ports.1"/>
+  <containedEdges identifier="E137" sources="//@children.99/@ports.3" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.100/@ports.1" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E139" sources="//@children.102/@ports.2" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.103/@ports.2" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.103/@ports.3" targets="//@children.105/@ports.1"/>
+  <containedEdges identifier="E142" sources="//@children.104/@ports.1" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.105/@ports.0" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.106/@ports.1" targets="//@children.103/@ports.1"/>
+  <containedEdges identifier="E145" sources="//@children.107/@ports.0" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.108/@ports.1" targets="//@children.102/@ports.1"/>
+  <containedEdges identifier="E147" sources="//@children.109/@ports.1" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.110/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E149" sources="//@children.111/@ports.1" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.111/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.112/@ports.1" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.113/@ports.0" targets="//@children.113/@ports.1"/>
+  <containedEdges identifier="E153" sources="//@children.114/@ports.0" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E154" sources="//@children.115/@ports.0" targets="//@children.115/@ports.1"/>
+  <containedEdges identifier="E155" sources="//@children.115/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.117/@ports.0" targets="//@children.116/@ports.2"/>
+  <containedEdges identifier="E157" sources="//@children.118/@ports.1" targets="//@children.122/@ports.1"/>
+  <containedEdges identifier="E158" sources="//@children.118/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.120/@ports.1" targets="//@children.121/@ports.1"/>
+  <containedEdges identifier="E160" sources="//@children.120/@ports.1" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E161" sources="//@children.121/@ports.2" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.122/@ports.0" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.123/@ports.0" targets="//@children.125/@ports.2"/>
+  <containedEdges identifier="E164" sources="//@children.125/@ports.1" targets="//@children.119/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_trex_TREXPtidesMulticoreDirector.elkg
+++ b/realworld/ptolemy/flattened/ptides_trex_TREXPtidesMulticoreDirector.elkg
@@ -1,0 +1,492 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="89.0" text="DiscreteClock4"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="24.0" text="Test"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="32.0" text="Test2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="32.0" text="Test3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="136.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="53.0" text="TimeGap"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="49.0" text="Register"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="56.0" text="Register2"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="87.0" text="MultiplyDivide3"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="54.0" text="TrueGate"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.2" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.22/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.23/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.24/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.25/@ports.2" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.26/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.1" targets="//@children.8/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptides_tte_TTE.elkg
+++ b/realworld/ptolemy/flattened/ptides_tte_TTE.elkg
@@ -1,0 +1,1720 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="111.0" text="RecordAssembler3"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="111.0" text="RecordAssembler4"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="110.0" text="PreemptableServer"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="117.0" text="PreemptableServer2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.29 //@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="47.0" text="Switch3"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="128.0" text="RecordDisassembler3"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="47.0" text="Switch4"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.39 //@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="128.0" text="RecordDisassembler4"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29 //@containedEdges.34 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="44.0" text="Merge5"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30 //@containedEdges.35 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="44.0" text="Merge6"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31 //@containedEdges.36 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="117.0" text="PreemptableServer2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="117.0" text="PreemptableServer4"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="117.0" text="PreemptableServer5"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="60.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.47 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="111.0" text="RecordAssembler4"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.57 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.55 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="110.0" text="PreemptableServer"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.58 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="117.0" text="PreemptableServer2"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.61 //@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.64 //@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.58 //@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.67 //@containedEdges.68 //@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P145" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="111.0" text="RecordAssembler4"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="44.0" text="Merge3"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.82 //@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.80 //@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="110.0" text="PreemptableServer"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.83 //@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="117.0" text="PreemptableServer2"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.86 //@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.83 //@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.89 //@containedEdges.90 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="69.0" text="TimeDelay4"/>
+    <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="86.0" text="SensorHandler"/>
+    <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="93.0" text="SensorHandler2"/>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="93.0" text="SensorHandler3"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="69.0" text="TimeDelay3"/>
+    <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P252" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="86.0" text="SensorHandler"/>
+    <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="93.0" text="SensorHandler2"/>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.4/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.13/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.0" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.0" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.3" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.23/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.24/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.25/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.25/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.25/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.26/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.26/@ports.2" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E35" sources="//@children.27/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.27/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.27/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.28/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.28/@ports.2" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E40" sources="//@children.29/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.29/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.29/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.30/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.30/@ports.2" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E45" sources="//@children.31/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.32/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.33/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.37/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.38/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.39/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.40/@ports.0" targets="//@children.39/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.41/@ports.1" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.42/@ports.0" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.43/@ports.0" targets="//@children.42/@ports.2"/>
+  <containedEdges identifier="E55" sources="//@children.44/@ports.1" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.45/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.45/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.46/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.46/@ports.2" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.46/@ports.2" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.47/@ports.1" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.48/@ports.1" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E63" sources="//@children.48/@ports.1" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.49/@ports.0" targets="//@children.48/@ports.2"/>
+  <containedEdges identifier="E65" sources="//@children.50/@ports.1" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.50/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.51/@ports.0" targets="//@children.50/@ports.2"/>
+  <containedEdges identifier="E68" sources="//@children.52/@ports.1" targets="//@children.54/@ports.2"/>
+  <containedEdges identifier="E69" sources="//@children.52/@ports.1" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.52/@ports.1" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.53/@ports.0" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.54/@ports.3" targets="//@children.47/@ports.2"/>
+  <containedEdges identifier="E73" sources="//@children.55/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.56/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E75" sources="//@children.57/@ports.0" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E76" sources="//@children.58/@ports.0" targets="//@children.57/@ports.2"/>
+  <containedEdges identifier="E77" sources="//@children.59/@ports.1" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E78" sources="//@children.60/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.61/@ports.0" targets="//@children.60/@ports.2"/>
+  <containedEdges identifier="E80" sources="//@children.62/@ports.1" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E81" sources="//@children.63/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.63/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.64/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.64/@ports.2" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.64/@ports.2" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.65/@ports.1" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.66/@ports.1" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.66/@ports.1" targets="//@children.58/@ports.1"/>
+  <containedEdges identifier="E89" sources="//@children.67/@ports.0" targets="//@children.66/@ports.2"/>
+  <containedEdges identifier="E90" sources="//@children.68/@ports.1" targets="//@children.70/@ports.2"/>
+  <containedEdges identifier="E91" sources="//@children.68/@ports.1" targets="//@children.71/@ports.1"/>
+  <containedEdges identifier="E92" sources="//@children.68/@ports.1" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E93" sources="//@children.69/@ports.0" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.70/@ports.3" targets="//@children.65/@ports.2"/>
+  <containedEdges identifier="E95" sources="//@children.71/@ports.0" targets="//@children.70/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.72/@ports.0" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E97" sources="//@children.73/@ports.1" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.74/@ports.1" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.75/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.76/@ports.1" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.81/@ports.0" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.82/@ports.0" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.83/@ports.0" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.84/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.85/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.86/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.87/@ports.1" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.88/@ports.1" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.89/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.93/@ports.0" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.94/@ports.0" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.96/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.97/@ports.1" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.99/@ports.1" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.100/@ports.1" targets="//@children.99/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_brewery_Brewery.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_brewery_Brewery.elkg
@@ -1,0 +1,421 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19 //@containedEdges.21 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="ActuatorSetup"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="91.0" text="ActuatorSetup2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="86.0" text="SensorHandler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="35.0" text="Tank2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="1.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="37.0">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="46.0" text="Reactor"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="1.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="37.0">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="91.0" text="ZeroOrderHold3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="91.0" text="ZeroOrderHold4"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="35.0" text="Tank1"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="1.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="37.0">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.4" targets="//@children.13/@ports.6"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.4" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.4" targets="//@children.14/@ports.6"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.19/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.4" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.4" targets="//@children.20/@ports.6"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.0" targets="//@children.14/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_brewery_BreweryWireless.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_brewery_BreweryWireless.elkg
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14 //@containedEdges.16 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="84.0" text="ActuatorSetup"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="91.0" text="ActuatorSetup2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="86.0" text="SensorHandler"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="27.0" text="Tank"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="1.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="37.0">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="46.0" text="Reactor"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="1.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="37.0">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="35.0" text="Tank2"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="1.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="37.0">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.4/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.4" targets="//@children.12/@ports.6"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.4" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.4" targets="//@children.13/@ports.6"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.15/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.16/@ports.4" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.4" targets="//@children.16/@ports.6"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.19/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.20/@ports.1" targets="//@children.16/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorContactorLoadFMU.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorContactorLoadFMU.elkg
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="174.0" text="GeneratorContractorLoadFMU"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="105.0" text="AnythingToDouble"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorPtides.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorPtides.elkg
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="26.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="42.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="88.0" text="DesiredVoltage"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXFMU.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXFMU.elkg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="200.0" text="GeneratorContactorLoadSimXFMU"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMU.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMU.elkg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="200.0" text="GeneratorContactorLoadSimXFMU"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="91.0" text="onOffSupervisor"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMUMetronomy.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMUMetronomy.elkg
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="91.0" text="onOffSupervisor"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.1" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.1" targets="//@children.21/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithBusNotAsAspect.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithBusNotAsAspect.elkg
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="23.0" text="Bus"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="17.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="122.0" text="messageToController"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="139.0" text="messageFromController"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.1" targets="//@children.8/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithLogging.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithLogging.elkg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="130.0" text="ExecutionRequestPort"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="138.0" text="ExecutionRequestPort2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="18.0" text="in3"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7 //@containedEdges.9 //@containedEdges.11 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="101.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="129.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="129.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="76.0" text="StringConst3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="83.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.0" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithProcessor.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithProcessor.elkg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.14/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithSpecificationAsAspect.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithSpecificationAsAspect.elkg
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="contactor"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="118.0" text="SpecificationMonitor"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="98.0" text="ThrowModelError"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="24.0" text="fault"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="31.0" text="onOff"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="128.0" text="RecordDisassembler3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="41.0" text="voltage"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="24.0" text="fault"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="118.0" text="SpecificationMonitor"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.1" targets="//@children.19/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_BouncingBall.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_BouncingBall.elkg
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="61.0" text="Ball Model"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="75.0" text="Copy1:Const"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Collisions.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Collisions.elkg
@@ -1,0 +1,545 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="96.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="17.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="CollisionDetector"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16 //@containedEdges.25 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19 //@containedEdges.30 //@containedEdges.32 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="79.0" text="VariableDelay"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="96.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="17.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.3" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.4" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.4" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.3" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.3" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.3" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.2" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.3" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.14/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.14/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.15/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.18/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.20/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.21/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.21/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.22/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.23/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.25/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.26/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.26/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.27/@ports.0" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E41" sources="//@children.28/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.29/@ports.0" targets="//@children.30/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Controllers.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Controllers.elkg
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Sampler1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="TimedPlotter1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3 //@containedEdges.14 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.26 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="63.0" text="Controller1"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="63.0" text="Controller2"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.2" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.20/@ports.2" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.21/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.22/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.23/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.24/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.25/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.26/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.27/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_EvaderAndPursuer.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_EvaderAndPursuer.elkg
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="94.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="94.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="48.0" text="Random"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="modal model"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="81.0" text="Accumulator2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="70.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="70.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Poisson"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="68.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="46.0" text="Pursuer"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.3" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.17/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_GuardedCount.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_GuardedCount.elkg
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="DisplayCount"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="84.0" text="DisplayEnable"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="40.0" text="Default"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="48.0" text="Default2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Sequence2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="When"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="132.0" text="DisplayCountRequests"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Inspection.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Inspection.elkg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="119.0" text="Poisson Bus Arrivals"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="107.0" text="Passenger Arrivals"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="128.0" text="Poisson Waiting Time"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="Timed Plotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="59.0" text="Histogram"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="116.0" text="Regular Bus Arrivals"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="Regular Waiting Time"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="179.0" text="Display Average Waiting Times"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.18 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="76.0" text="SingleEvent0"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="53.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.0" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_OrderedMerge.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_OrderedMerge.elkg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="OrderedMerge"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="90.0" text="OrderedMerge2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="6.5" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="117.0" text="Limit on powers of 5"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Router.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_Router.elkg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="107.0" text="Record Assembler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="Sequence Count"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="36.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Square"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="Master Clock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="97.0" text="String Sequence"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="Record Disassembler"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="63.0" text="Sequencer"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="119.0" text="Display As Received"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="127.0" text="Display Resequenced"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="82.0" text="ChannelModel"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_SigmaDelta.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_SigmaDelta.elkg
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="31.0" text="delay"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="FIR Filter"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="Quantizer"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="DEPlot"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="90.0" text="Moving Average"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="117.0" text="Average 50 samples"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="75.0" text="Current Time"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="20.0" text="Sin"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="31.0" text="Add1"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="41.0" text="Scale1"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="88.0" text="ContinuousPlot"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.11 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_TimingParadox.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_TimingParadox.elkg
@@ -1,0 +1,553 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Clock2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19 //@containedEdges.24 //@containedEdges.29 //@containedEdges.34 //@containedEdges.39 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Rician"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="44.0" text="Rician2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.7/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.7/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.7/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.7/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.9/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.10/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.11/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.12/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.13/@ports.0" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.14/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.15/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.16/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.17/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E33" sources="//@children.18/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.19/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.20/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.21/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.21/@ports.0" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E38" sources="//@children.22/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.23/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.24/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.25/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.25/@ports.0" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E43" sources="//@children.26/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.27/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.28/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.29/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.29/@ports.0" targets="//@children.31/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.30/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.31/@ports.1" targets="//@children.28/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_TransmitAntennaPattern.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_TransmitAntennaPattern.elkg
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="99.0" text="CartesianToPolar"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="104.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="99.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="83.0" text="AntennaModel"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.3" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.2" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_ViterbiDecoder.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_ViterbiDecoder.elkg
@@ -1,0 +1,431 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="93.0" text="ViterbiDecoder2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.2" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_BouncingBall.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_BouncingBall.elkg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="61.0" text="Ball Model"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="84.0" text="Translate3D10"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="75.0" text="Copy1:Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_LevelCrossingDetectorDetectsGlitches.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_LevelCrossingDetectorDetectsGlitches.elkg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="111.0" text="SignalWithGlitches"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="118.0" text="Integral of the Signal"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="174.0" text="Detected Threshold Crossings"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="168.0" text="Piecewise Continuous Signal"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="143.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="143.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="95.0" text="Detected Events"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="137.0" text="LevelCrossingDetector1"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="137.0" text="LevelCrossingDetector3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_Pendulum3D.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_Pendulum3D.elkg
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="22.625" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.6 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="34.875" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="79.0" text="Displacement"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="40.0" text="Angles"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="Angular Velocities"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="86.0" text="ViewScreen3D"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9 //@containedEdges.12 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="33.0" text="stage"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="47.0" text="Cone3D"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="33.0" text="string"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="Translate3D3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="30.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.3" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.5" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_SigmaDelta.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_execdemos_demos_hyvisualdemos_SigmaDelta.elkg
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="31.0" text="delay"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="FIR Filter"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="Quantizer"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="DEPlot"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="90.0" text="Moving Average"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="117.0" text="Average 50 samples"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="75.0" text="Current Time"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="20.0" text="Sin"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="31.0" text="Add1"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="41.0" text="Scale0"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="41.0" text="Scale1"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="39.0" text="CTPlot"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.11 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_faultmodels_CommunicationAnomalyDetectionCQM.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_faultmodels_CommunicationAnomalyDetectionCQM.elkg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="93.0" text="OutgoingPacket"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="LatencyEstimate"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="TrainOrTest?2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TrainOrTest?"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="110.0" text="SequenceToArray2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="93.0" text="IncomingPacket"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="10.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="87.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="90.0" text="CompareLabels"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="66.0" text="CountTrues"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="40.0" text="priors2"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="54.0" text="Average2"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="54.0" text="Average3"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="104.0" text="SequencePlotter2"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="33.0" text="Mean"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="77.0" text="Std Deviation"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="92.0" text="TransitionMatrix"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="172.0" text="ParameterEstimatorGaussian"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="1.600000023841858" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="11.199999809265137" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="140.0" text="HMMGaussianClassifier"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="11.0" text="in"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.43 //@containedEdges.44 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="123.0" text="CommunicationDelay"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.46 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="79.0" text="UpdateLabels"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="106.0" text="UpdateCQMToken"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="112.0" text="LatencyDistribution"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.54 //@containedEdges.55 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.54 //@containedEdges.55 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.3" targets="//@children.30/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.3" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.14/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.15/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.18/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.19/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.19/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.20/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.21/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.22/@ports.1" targets="//@children.30/@ports.4"/>
+  <containedEdges identifier="E35" sources="//@children.23/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.23/@ports.1" targets="//@children.30/@ports.5"/>
+  <containedEdges identifier="E37" sources="//@children.24/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.24/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.29/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.29/@ports.3" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.29/@ports.4" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.29/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.30/@ports.3" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.31/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.31/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.31/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.33/@ports.1" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E48" sources="//@children.33/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.33/@ports.2" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.33/@ports.2" targets="//@children.39/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.34/@ports.1" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.35/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.36/@ports.0" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.37/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.39/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.39/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.39/@ports.1" targets="//@children.38/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_faultmodels_ExpectationMaximization.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_faultmodels_ExpectationMaximization.elkg
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="55.0" width="153.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="19.0" text="tau"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="153.0" y="23.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="sum_tau"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="59.0" text="tau_n*x_n"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="33.0" text="tau_n"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="51.0" text="next_mu"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="70.0" text="tau_average"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="122.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="122.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="94.0" text="MovingAverage3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="66.0" text="tau_n*x_n2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="78.0" text="samplesigma"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="96.0" text="observationArray"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.2" targets="//@children.8/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.10/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.15/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_faultmodels_GMMConvergenceAnalysis.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_faultmodels_GMMConvergenceAnalysis.elkg
@@ -1,0 +1,687 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="75.0" text="ChooseIndex"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="ChooseN"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="38.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="29.0" text="MSE"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="MSE2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="110.0" text="SequenceToArray2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="55.0" width="153.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="19.0" text="tau"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="153.0" y="23.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="51.0" text="sum_tau"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="59.0" text="tau_n*x_n"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="33.0" text="tau_n"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="51.0" text="next_mu"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="70.0" text="tau_average"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="122.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="122.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="94.0" text="MovingAverage3"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="66.0" text="tau_n*x_n2"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="78.0" text="samplesigma"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.33 //@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="96.0" text="observationArray"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="111.0" text="Mean Convergence"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="60.0" text="Distributor"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="67.0" text="Distributor2"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.40 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="67.0" text="Distributor3"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="116.0" text="Sigma Convergence"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.2" targets="//@children.26/@ports.3"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.23/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.24/@ports.2" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E26" sources="//@children.24/@ports.2" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.25/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.25/@ports.1" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.2" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.29/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.33/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.33/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.33/@ports.1" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.34/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.36/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.37/@ports.1" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.38/@ports.1" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.39/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.39/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.40/@ports.1" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.41/@ports.1" targets="//@children.42/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_fuelsystem_FuelSystemErrorHandling.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_fuelsystem_FuelSystemErrorHandling.elkg
@@ -1,0 +1,673 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.10 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.0 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="87.0" text="FaultGenerator"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="76.0" text="LMT_inConst"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="102.0" text="FuelConsumption"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="78.0" text="AltitudeConst"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="98.0" text="actualOutFlowTT"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="136.0" text="LMT2LFT_plus_TT2LFT"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.44 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="92.0" text="WatchdogClock"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="139.0" text="LMT2LFT_plus_LMT2TT"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="58.0" text="HeartBeat"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="68.0" text="ErrorTrigger"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="93.0" text="LeftFuelTransfer"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.46 //@containedEdges.47 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.33/@ports.6"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.2" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.8/@ports.4"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.8/@ports.5"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.2" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.0" targets="//@children.14/@ports.4"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.0" targets="//@children.14/@ports.5"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.2" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.18/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.18/@ports.2" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E31" sources="//@children.20/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.21/@ports.0" targets="//@children.20/@ports.4"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.0" targets="//@children.20/@ports.5"/>
+  <containedEdges identifier="E34" sources="//@children.23/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.24/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.25/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.26/@ports.2" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.26/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.27/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.28/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.29/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.30/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.31/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.32/@ports.1" targets="//@children.33/@ports.7"/>
+  <containedEdges identifier="E45" sources="//@children.33/@ports.3" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.33/@ports.3" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.33/@ports.5" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.33/@ports.5" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.33/@ports.5" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.33/@ports.4" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.33/@ports.3" targets="//@children.8/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_probabilisticmodels_ChannelFaultModel.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_probabilisticmodels_ChannelFaultModel.elkg
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.7 //@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="57.0" text="Receiver2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="57.0" text="Receiver3"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.8" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="57.0" text="Receiver4"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.10" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="57.0" text="Receiver1"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.12" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="11.0" text="i1"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="15.0" text="o1"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="69.0" text="PacketDrop"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="11.0" text="i2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="11.0" text="i1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="15.0" text="o1"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="76.0" text="StuckAtFault"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="84.0" text="StuckAtFault3"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="15.0" text="o2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="11.0" text="i2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.0" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_probabilisticmodels_GMMConvergenceAnalysis.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_probabilisticmodels_GMMConvergenceAnalysis.elkg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="75.0" text="ChooseIndex"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="ChooseN"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="38.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="29.0" text="MSE"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="MSE2"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="110.0" text="SequenceToArray2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="55.0" width="153.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="19.0" text="tau"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="153.0" y="23.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="51.0" text="sum_tau"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="59.0" text="tau_n*x_n"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="33.0" text="tau_n"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="51.0" text="next_mu"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="70.0" text="tau_average"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="122.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="122.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="94.0" text="MovingAverage3"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="66.0" text="tau_n*x_n2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="78.0" text="samplesigma"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="96.0" text="observationArray"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="111.0" text="Mean Convergence"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="60.0" text="Distributor"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="67.0" text="Distributor2"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="67.0" text="Distributor3"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="116.0" text="Sigma Convergence"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.20/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.2" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.2" targets="//@children.27/@ports.3"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.24/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.25/@ports.2" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.25/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.26/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.29/@ports.2" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.30/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.34/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.34/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.34/@ports.1" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.35/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.37/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.38/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.39/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.40/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.40/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.41/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.42/@ports.1" targets="//@children.43/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto32_GeneratorRegulatorProtectorSimXFMU.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto32_GeneratorRegulatorProtectorSimXFMU.elkg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="200.0" text="GeneratorContactorLoadSimXFMU"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="86.0" text="NonStrictTest2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.0" targets="//@children.13/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto_ChannelFaultModel.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto_ChannelFaultModel.elkg
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="Receiver2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="57.0" text="Receiver3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.8" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="57.0" text="Receiver4"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.10" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="57.0" text="Receiver1"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.11" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="24.0" text="Test"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="32.0" text="Test2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="32.0" text="Test3"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="11.0" text="i1"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="15.0" text="o1"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="69.0" text="PacketDrop"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="11.0" text="i2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="11.0" text="i1"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="15.0" text="o1"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="76.0" text="StuckAtFault"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="84.0" text="StuckAtFault3"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="15.0" text="o2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="11.0" text="i2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.0" targets="//@children.17/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto_FuelSystemErrorHandling.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto_FuelSystemErrorHandling.elkg
@@ -1,0 +1,691 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.0 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="FaultGenerator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="86.0" text="NonStrictTest2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="86.0" text="NonStrictTest3"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="76.0" text="LMT_inConst"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26 //@containedEdges.27 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="102.0" text="FuelConsumption"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="78.0" text="AltitudeConst"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="98.0" text="actualOutFlowTT"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="136.0" text="LMT2LFT_plus_TT2LFT"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.44 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="92.0" text="WatchdogClock"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="139.0" text="LMT2LFT_plus_LMT2TT"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="58.0" text="HeartBeat"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="68.0" text="ErrorTrigger"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="93.0" text="LeftFuelTransfer"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.46 //@containedEdges.47 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.35/@ports.6"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.10/@ports.4"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.10/@ports.5"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.2" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.0" targets="//@children.16/@ports.4"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.0" targets="//@children.16/@ports.5"/>
+  <containedEdges identifier="E25" sources="//@children.19/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.20/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.2" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.2" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.2" targets="//@children.35/@ports.2"/>
+  <containedEdges identifier="E31" sources="//@children.22/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.23/@ports.0" targets="//@children.22/@ports.4"/>
+  <containedEdges identifier="E33" sources="//@children.24/@ports.0" targets="//@children.22/@ports.5"/>
+  <containedEdges identifier="E34" sources="//@children.25/@ports.2" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.26/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.27/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.28/@ports.2" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.28/@ports.2" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.29/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.30/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.31/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.32/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.33/@ports.2" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.34/@ports.1" targets="//@children.35/@ports.7"/>
+  <containedEdges identifier="E45" sources="//@children.35/@ports.3" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.35/@ports.3" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.35/@ports.5" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.35/@ports.5" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.35/@ports.5" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.35/@ports.4" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.35/@ports.3" targets="//@children.10/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto_GMMConvergenceAnalysis.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto_GMMConvergenceAnalysis.elkg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="75.0" text="ChooseIndex"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="ChooseN"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="38.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="29.0" text="MSE"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="MSE2"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="110.0" text="SequenceToArray2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="55.0" width="153.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="19.0" text="tau"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="153.0" y="23.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="51.0" text="sum_tau"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="59.0" text="tau_n*x_n"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.18 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="33.0" text="tau_n"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="51.0" text="next_mu"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="70.0" text="tau_average"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="122.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="122.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="94.0" text="MovingAverage3"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="66.0" text="tau_n*x_n2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="78.0" text="samplesigma"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="96.0" text="observationArray"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="111.0" text="Mean Convergence"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="60.0" text="Distributor"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="67.0" text="Distributor2"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.41 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="67.0" text="Distributor3"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="116.0" text="Sigma Convergence"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.20/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.2" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.2" targets="//@children.27/@ports.3"/>
+  <containedEdges identifier="E23" sources="//@children.21/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.24/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.25/@ports.2" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.25/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.26/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.29/@ports.2" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.30/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.34/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.34/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.34/@ports.1" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.35/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.37/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.38/@ports.1" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.39/@ports.1" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.40/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.40/@ports.1" targets="//@children.43/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.41/@ports.1" targets="//@children.42/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.42/@ports.1" targets="//@children.43/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorFMUProtector.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorFMUProtector.elkg
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="42.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="88.0" text="DesiredVoltage"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="22.0" text="PID"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="119.0" text="onOffSupervisorFMU"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="26.0" y="40.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="24.0" text="Test"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="32.0" text="Test2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="32.0" text="Test3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="32.0" text="Test4"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="32.0" text="Test5"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="32.0" text="Test6"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="32.0" text="Test7"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.5/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.6/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.7/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.8/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.8/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorProtectorWithProcessor.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorProtectorWithProcessor.elkg
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="18.0" text="in1"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="18.0" text="in2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="44.0" text="Server2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.14/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorProtectorWithSpecification.elkg
+++ b/realworld/ptolemy/flattened/ptolemy_test_auto_GeneratorRegulatorProtectorWithSpecification.elkg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="118.0" text="SpecificationMonitor"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="SpecificationMonitor2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="98.0" text="ThrowModelError"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.3/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.5/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.2" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/python_recordmanipulation_RecordManipulation.elkg
+++ b/realworld/ptolemy/flattened/python_recordmanipulation_RecordManipulation.elkg
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="78.0" text="Recordmaker"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="78.0" text="Recordparser"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="78.0" text="RecordMerge"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="85.0" text="Recordmaker2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="24.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="83.0" text="Selectordialog"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="117.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="StringConst3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="117.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.8/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/qm_tcppackettxrx_TCPPacketTXRX.elkg
+++ b/realworld/ptolemy/flattened/qm_tcppackettxrx_TCPPacketTXRX.elkg
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="116.0" text="TCPPacketReceiver"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="123.0" text="TCPPacketReceiver2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/rendezvous_trialmodule_TrialModule.elkg
+++ b/realworld/ptolemy/flattened/rendezvous_trialmodule_TrialModule.elkg
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="106.0" text="BooleanSelect (B)"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.5 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="97.0" text="StringSubstring1"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="97.0" text="StringSubstring2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="74.0" text="StringLength"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="62.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="56.0" text="Ramp (B)"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="EmptyString"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.2" targets="//@children.18/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/rendezvous_trialmodule_TrialModuleNonBacktrack.elkg
+++ b/realworld/ptolemy/flattened/rendezvous_trialmodule_TrialModuleNonBacktrack.elkg
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.8 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="97.0" text="StringSubstring1"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="97.0" text="StringSubstring2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="74.0" text="StringLength"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="62.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="38.0" text="Empty"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.1" targets="//@children.13/@ports.3"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.2" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.2" targets="//@children.21/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.18/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/scr_safetyinjection_SafetyInjection.elkg
+++ b/realworld/ptolemy/flattened/scr_safetyinjection_SafetyInjection.elkg
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.32 //@containedEdges.34 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.2 //@containedEdges.7 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="120.0" text="ContinuousSinewave"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="33.0" text="Block"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Reset"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="104.0" text="ConvertToBoolean"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="111.0" text="ConvertToBoolean2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28 //@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="71.0" text="Reset_event"/>
+    <ports identifier="P21" y="6.833333492279053" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" y="13.666666984558105" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" y="20.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" x="30.5" y="41.0" incomingEdges="//@containedEdges.31 //@containedEdges.33 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P25" y="27.33333396911621" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" y="34.16666793823242" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="71.0" text="Reset_event"/>
+    <ports identifier="P27" y="6.833333492279053" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" y="13.666666984558105" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" y="20.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" x="61.0" y="20.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" y="27.33333396911621" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" y="34.16666793823242" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="71.0" text="Reset_event"/>
+    <ports identifier="P33" y="6.833333492279053" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" y="13.666666984558105" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" y="20.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" x="61.0" y="20.5" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" y="27.33333396911621" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" y="34.16666793823242" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="71.0" text="Reset_event"/>
+    <ports identifier="P39" y="6.833333492279053" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" y="13.666666984558105" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" y="20.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" x="61.0" y="20.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" y="27.33333396911621" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" y="34.16666793823242" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.0" targets="//@children.11/@ports.4"/>
+  <containedEdges identifier="E15" sources="//@children.6/@ports.0" targets="//@children.12/@ports.4"/>
+  <containedEdges identifier="E16" sources="//@children.6/@ports.0" targets="//@children.13/@ports.4"/>
+  <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.14/@ports.4"/>
+  <containedEdges identifier="E18" sources="//@children.7/@ports.0" targets="//@children.11/@ports.5"/>
+  <containedEdges identifier="E19" sources="//@children.7/@ports.0" targets="//@children.12/@ports.5"/>
+  <containedEdges identifier="E20" sources="//@children.7/@ports.0" targets="//@children.13/@ports.5"/>
+  <containedEdges identifier="E21" sources="//@children.7/@ports.0" targets="//@children.14/@ports.5"/>
+  <containedEdges identifier="E22" sources="//@children.8/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.8/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.8/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.8/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.10/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.10/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E30" sources="//@children.10/@ports.1" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E31" sources="//@children.10/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.12/@ports.3" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E33" sources="//@children.12/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.13/@ports.3" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E35" sources="//@children.13/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.14/@ports.3" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E37" sources="//@children.14/@ports.3" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/scr_trafficlight_TrafficLight.elkg
+++ b/realworld/ptolemy/flattened/scr_trafficlight_TrafficLight.elkg
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16 //@containedEdges.26 //@containedEdges.36 //@containedEdges.46 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17 //@containedEdges.27 //@containedEdges.37 //@containedEdges.47 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18 //@containedEdges.28 //@containedEdges.38 //@containedEdges.48 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19 //@containedEdges.29 //@containedEdges.39 //@containedEdges.49 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20 //@containedEdges.30 //@containedEdges.40 //@containedEdges.50 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="28.0" text="Cgrn"/>
+    <ports identifier="P17" y="20.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" x="10.166666984558105" y="41.0" incomingEdges="//@containedEdges.11 //@containedEdges.21 //@containedEdges.31 //@containedEdges.41 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" x="20.33333396911621" y="41.0" incomingEdges="//@containedEdges.12 //@containedEdges.22 //@containedEdges.32 //@containedEdges.42 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P20" x="30.5" y="41.0" incomingEdges="//@containedEdges.13 //@containedEdges.23 //@containedEdges.33 //@containedEdges.43 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P21" x="40.66666793823242" y="41.0" incomingEdges="//@containedEdges.14 //@containedEdges.24 //@containedEdges.34 //@containedEdges.44 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" x="50.83333206176758" y="41.0" incomingEdges="//@containedEdges.15 //@containedEdges.25 //@containedEdges.35 //@containedEdges.45 //@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="28.0" text="Cgrn"/>
+    <ports identifier="P23" y="20.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" x="61.0" y="6.833333492279053" outgoingEdges="//@containedEdges.11 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" x="61.0" y="13.666666984558105" outgoingEdges="//@containedEdges.12 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" x="61.0" y="20.5" outgoingEdges="//@containedEdges.13 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" x="61.0" y="27.33333396911621" outgoingEdges="//@containedEdges.14 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" x="61.0" y="34.16666793823242" outgoingEdges="//@containedEdges.15 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="28.0" text="Cgrn"/>
+    <ports identifier="P29" y="20.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" x="61.0" y="6.833333492279053" outgoingEdges="//@containedEdges.21 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" x="61.0" y="13.666666984558105" outgoingEdges="//@containedEdges.22 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" x="61.0" y="20.5" outgoingEdges="//@containedEdges.23 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" x="61.0" y="27.33333396911621" outgoingEdges="//@containedEdges.24 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" x="61.0" y="34.16666793823242" outgoingEdges="//@containedEdges.25 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="Cgrn"/>
+    <ports identifier="P35" y="20.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" x="61.0" y="6.833333492279053" outgoingEdges="//@containedEdges.31 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" x="61.0" y="13.666666984558105" outgoingEdges="//@containedEdges.32 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" x="61.0" y="20.5" outgoingEdges="//@containedEdges.33 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" x="61.0" y="27.33333396911621" outgoingEdges="//@containedEdges.34 //@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" x="61.0" y="34.16666793823242" outgoingEdges="//@containedEdges.35 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="28.0" text="Cgrn"/>
+    <ports identifier="P41" y="20.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" x="61.0" y="6.833333492279053" outgoingEdges="//@containedEdges.41 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" x="61.0" y="13.666666984558105" outgoingEdges="//@containedEdges.42 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" x="61.0" y="20.5" outgoingEdges="//@containedEdges.43 //@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" x="61.0" y="27.33333396911621" outgoingEdges="//@containedEdges.44 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" x="61.0" y="34.16666793823242" outgoingEdges="//@containedEdges.45 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="28.0" text="Cgrn"/>
+    <ports identifier="P47" y="20.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" x="61.0" y="6.833333492279053" outgoingEdges="//@containedEdges.51 //@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" x="61.0" y="13.666666984558105" outgoingEdges="//@containedEdges.52 //@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" x="61.0" y="20.5" outgoingEdges="//@containedEdges.53 //@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" x="61.0" y="27.33333396911621" outgoingEdges="//@containedEdges.54 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" x="61.0" y="34.16666793823242" outgoingEdges="//@containedEdges.55 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.3" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.4" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.5" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E17" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.8/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.8/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.8/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.9/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.9/@ports.3" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E25" sources="//@children.9/@ports.4" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E26" sources="//@children.9/@ports.5" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E27" sources="//@children.9/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.9/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.9/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.9/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.9/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.10/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.10/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.10/@ports.3" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E35" sources="//@children.10/@ports.4" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E36" sources="//@children.10/@ports.5" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E37" sources="//@children.10/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.10/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.10/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.10/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.10/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.11/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.11/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E44" sources="//@children.11/@ports.3" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E45" sources="//@children.11/@ports.4" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E46" sources="//@children.11/@ports.5" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E47" sources="//@children.11/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.11/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.11/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.11/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.11/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.12/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.12/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E54" sources="//@children.12/@ports.3" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E55" sources="//@children.12/@ports.4" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E56" sources="//@children.12/@ports.5" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E57" sources="//@children.12/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.12/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.12/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.12/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.12/@ports.5" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_CameraDetectView.elkg
+++ b/realworld/ptolemy/flattened/sdf_CameraDetectView.elkg
@@ -1,0 +1,530 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="65.0" text="ImageCopy"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="87.0" text="CameraReader"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="90.0" text="DrawResultSeq"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="73.0" text="ImageCopy2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="122.0" text="ImageRotateOpenCV"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="ChooseSeq"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="ImageRotate"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="ImageRotate2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="ImageRotate3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="81.0" text="ImageRotate4"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="65.0" text="ImageCopy"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="ImageCopy2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="ImageCopy3"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="73.0" text="ImageCopy4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="73.0" text="ImageCopy5"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="109.0" text="ImageConvertColor"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="76.0" text="ObjectDetect"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="109.0" text="ImageConvertColor"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="76.0" text="ObjectDetect"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="109.0" text="ImageConvertColor"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="76.0" text="ObjectDetect"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="109.0" text="ImageConvertColor"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="76.0" text="ObjectDetect"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="109.0" text="ImageConvertColor"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="76.0" text="ObjectDetect"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.1" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.11/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.19/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.21/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.22/@ports.1" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E31" sources="//@children.23/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.24/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.25/@ports.1" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E34" sources="//@children.26/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.27/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.28/@ports.1" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E37" sources="//@children.29/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.30/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.31/@ports.1" targets="//@children.7/@ports.6"/>
+  <containedEdges identifier="E40" sources="//@children.33/@ports.1" targets="//@children.32/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_CameraDetectView_3win.elkg
+++ b/realworld/ptolemy/flattened/sdf_CameraDetectView_3win.elkg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="90.0" text="DrawResultSeq"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="65.0" text="ImageCopy"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="CameraReader"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="109.0" text="ImageConvertColor"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="76.0" text="ObjectDetect"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="106.0" text="ImageDisplayGray"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="129.0" text="ImageDisplayEqualize"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="115.0" text="ImageDisplayResult"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_ImageDetectView_3.elkg
+++ b/realworld/ptolemy/flattened/sdf_ImageDetectView_3.elkg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="90.0" text="DrawResultSeq"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="65.0" text="ImageCopy"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="ImageReader"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="ImageDisplayRaw"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="109.0" text="ImageConvertColor"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="76.0" text="ObjectDetect"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="164.0" text="ImageDisplayAfterConvColor"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="115.0" text="ImageDisplayResult"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="135.0" text="ImageDisplayAfterCopy"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_adaptivemedian_AdaptiveMedian.elkg
+++ b/realworld/ptolemy/flattened/sdf_adaptivemedian_AdaptiveMedian.elkg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="95.0" text="JAIImageReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="107.0" text="JAIToDoubleMatrix"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="88.0" text="SaltAndPepper"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="94.0" text="Salt and Pepper"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="108.0" text="DoubleMatrixToJAI"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="92.0" text="AdaptiveMedian"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="115.0" text="DoubleMatrixToJAI2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="52.0" text="Repaired"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="Original Image"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="100.0" text="JAIBandCombine"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="85.0" text="JAIBandSelect"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="60.0" text="Greyscale"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_applyfft_ApplyFFT.elkg
+++ b/realworld/ptolemy/flattened/sdf_applyfft_ApplyFFT.elkg
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="79.0" text="Noise Source"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="24.0" text="FFT"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="84.0" text="ApplyFunction"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="70.0" text="ArrayPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="168.0" text="ApplyFunctionOverSequence"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="104.0" text="SequencePlotter2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_array_Array.elkg
+++ b/realworld/ptolemy/flattened/sdf_array_Array.elkg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="88.0" text="ArrayMaximum"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="84.0" text="ArrayMinimum"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="ArraySort"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="70.0" text="ArrayPlotter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="94.0" text="Maximum Value"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="90.0" text="Minimum Value"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="63.0" text="ArraySort2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="88.0" text="Minimum Index"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="78.0" text="ArrayAverage"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="83.0" text="Average Value"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="97.0" text="Minimum Value2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="ArrayExtract"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="32.83333206176758">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="77.0" text="ArrayPlotter2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.14/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_coltrandom_ColtRandom.elkg
+++ b/realworld/ptolemy/flattened/sdf_coltrandom_ColtRandom.elkg
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="51.0" text="ColtBeta"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="ColtBinomial"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="32.0" text="Test2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="92.0" text="ColtBreitWigner"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="84.0" text="ColtChiSquare"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="91.0" text="ColtExponential"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="32.0" text="Test3"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="32.0" text="Test4"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="32.0" text="Test5"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="128.0" text="ColtExponentialPower"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="70.0" text="ColtGamma"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="117.0" text="ColtHyperGeometric"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="90.0" text="ColtLogarithmic"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="32.0" text="Test6"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="32.0" text="Test7"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="32.0" text="Test8"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="32.0" text="Test9"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="105.0" text="HistogramPlotter4"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18 //@containedEdges.22 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="122.0" text="ColtNegativeBinomial"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="64.0" text="ColtNormal"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="71.0" text="ColtPoisson"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="99.0" text="ColtPoissonSlow"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="76.0" text="ColtStudentT"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="80.0" text="ColtVonMises"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="49.0" text="ColtZeta"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="38.0" text="Test11"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="39.0" text="Test12"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="39.0" text="Test13"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="39.0" text="Test14"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="39.0" text="Test15"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="39.0" text="Test16"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="39.0" text="Test17"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="105.0" text="HistogramPlotter1"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.3 //@containedEdges.5 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="105.0" text="HistogramPlotter2"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11 //@containedEdges.21 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="105.0" text="HistogramPlotter3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.9 //@containedEdges.13 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="105.0" text="HistogramPlotter5"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="24.0" text="Test"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.22/@ports.0" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.23/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.24/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.24/@ports.0" targets="//@children.35/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_convolutionalcoder_ConvolutionalCoder.elkg
+++ b/realworld/ptolemy/flattened/sdf_convolutionalcoder_ConvolutionalCoder.elkg
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="60.0" text="Scrambler"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="76.0" text="DeScrambler"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="58.0" text="Bernoulli2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="83.0" text="DeScrambler2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="86.0" text="ViterbiDecoder"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.5/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.5/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.18/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.19/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.22/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.23/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.24/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.25/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.26/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.27/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.28/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.29/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.30/@ports.2" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_croom_CRoom.elkg
+++ b/realworld/ptolemy/flattened/sdf_croom_CRoom.elkg
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="39.0" text="Plotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="54.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="27.0" text="TSet"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Room"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="52.0" text="RunTime"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="90.0" text="SimulationTime"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="131.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="25.0" text="gain"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.11/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_dftsubset_DFTSubSet.elkg
+++ b/realworld/ptolemy/flattened/sdf_dftsubset_DFTSubSet.elkg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="Commutator"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="96.0" text="SequenceScope"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="107.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="107.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="180.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="94.0" text="InputBlockDelay"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.9/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_gravitation_Gravitation.elkg
+++ b/realworld/ptolemy/flattened/sdf_gravitation_Gravitation.elkg
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="103.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="99.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="158.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="158.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="21.0" text="FIR"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="162.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="162.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="160.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="160.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="86.0" text="ViewScreen3D"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="99.0" text="ArrayToElements"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="20.799999237060547" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="99.0" text="ArrayToElements"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.17/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.1" targets="//@children.19/@ports.4"/>
+  <containedEdges identifier="E27" sources="//@children.21/@ports.1" targets="//@children.19/@ports.3"/>
+  <containedEdges identifier="E28" sources="//@children.21/@ports.1" targets="//@children.19/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_gravitation_GravitationWithCollisionDetection.elkg
+++ b/realworld/ptolemy/flattened/sdf_gravitation_GravitationWithCollisionDetection.elkg
@@ -1,0 +1,505 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="103.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="105.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="105.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="107.0" text="ElementsToArray2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="99.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="158.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="158.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="21.0" text="FIR"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="162.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="162.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="160.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="160.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="281.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="82.0" text="ArrayContains"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="88.0" text="ArrayMaximum"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="86.0" text="ViewScreen3D"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="99.0" text="ArrayToElements"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="58.0" text="Sphere3D"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="20.799999237060547" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="99.0" text="ArrayToElements"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.18/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.18/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.19/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.20/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.21/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.22/@ports.2" targets="//@children.18/@ports.4"/>
+  <containedEdges identifier="E32" sources="//@children.23/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.25/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.26/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.27/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.28/@ports.1" targets="//@children.27/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.28/@ports.1" targets="//@children.27/@ports.3"/>
+  <containedEdges identifier="E38" sources="//@children.28/@ports.1" targets="//@children.27/@ports.4"/>
+  <containedEdges identifier="E39" sources="//@children.29/@ports.1" targets="//@children.28/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_htvq_HTVQ2.elkg
+++ b/realworld/ptolemy/flattened/sdf_htvq_HTVQ2.elkg
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="92.0" text="DatagramWriter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="98.0" text="DatagramReader"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="60.0" text="1:Encoder"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="53.0" text="1:Source"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="99.0" text="1:Partition Image"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="1:Unpartition"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="85.0" text="1:Compressed"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="60.0" text="1:Decoder"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_imagereconstruction_ImageReconstruction.elkg
+++ b/realworld/ptolemy/flattened/sdf_imagereconstruction_ImageReconstruction.elkg
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="95.0" text="JAIImageReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="102.0" text="JAIImageReader2"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="JAIBorder"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="64.0" text="JAIBorder2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="JAIDFT"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="JAIDFT2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="79.0" text="JAIMagnitude"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="56.0" text="JAIPhase"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="112.0" text="JAIPolarToComplex"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="46.0" text="JAIIDFT"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="88.0" text="JAIDataConvert"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="46.0" text="JAICrop"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="Recovered Helen"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="82.0" text="Original Helen"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="96.0" text="Original Ptolemy"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="104.0" text="Combined Images"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="107.0" text="JAIBandCombine2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="93.0" text="JAIBandSelect2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="100.0" text="JAIBandCombine"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="85.0" text="JAIBandSelect"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.17/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.1" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
+++ b/realworld/ptolemy/flattened/sdf_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="1.8571428060531616" y="41.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="11.714285850524902" y="41.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="21.571428298950195" y="41.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.428571701049805" y="41.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.28571319580078" y="41.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="51.14285659790039" y="41.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="48.0" text="Sensors"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="63.0" y="-5.5625">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="63.0" y="-3.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="63.0" y="-0.6875">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="63.0" y="1.75">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="63.0" y="4.1875">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="63.0" y="6.625">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="63.0" y="9.0625" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="63.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="63.0" y="13.9375" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="63.0" y="16.375" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="63.0" y="18.8125">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="63.0" y="21.25">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="63.0" y="23.6875">
+      <properties key="org.eclipse.elk.port.index" value="12"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="63.0" y="26.125">
+      <properties key="org.eclipse.elk.port.index" value="13"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="63.0" y="28.5625">
+      <properties key="org.eclipse.elk.port.index" value="14"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-15"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="36.0" text="Drive2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="63.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="36.0" text="Drive3"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="63.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="36.0" text="Drive4"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="63.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="72.0" text="RotateAngle"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="75.0" text="UnitDistance"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="28.0" text="ADC"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="63.0" y="5.0" outgoingEdges="//@containedEdges.21 //@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="63.0" y="18.0" outgoingEdges="//@containedEdges.24 //@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="224.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="212.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="457.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="73.0" text="Expression5"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="473.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="73.0" text="Expression6"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything5"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything6"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.6" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.7" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.8" targets="//@children.13/@ports.3"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.8" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.9" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.7" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.1/@ports.15"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.1" targets="//@children.0/@ports.9"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.0/@ports.10"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.0" targets="//@children.10/@ports.4"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.12/@ports.4"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.0" targets="//@children.13/@ports.4"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.16/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.16/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.19/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.20/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.21/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.23/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.24/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.25/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.26/@ports.1" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E38" sources="//@children.27/@ports.1" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E39" sources="//@children.28/@ports.1" targets="//@children.0/@ports.5"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_iterateoverarray_IterateOverArray.elkg
+++ b/realworld/ptolemy/flattened/sdf_iterateoverarray_IterateOverArray.elkg
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="281.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="102.0" text="HammingWindow"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="113.0" text="SumArrayElements"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="59.0" text="Normalize"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="69.0" text="CreateArray"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="202.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="274.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="107.0" text="PlaneWavePhasor"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="274.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="323.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="31.0" text="expjx"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="323.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="430.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="430.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_matlabroom_MatlabRoom.elkg
+++ b/realworld/ptolemy/flattened/sdf_matlabroom_MatlabRoom.elkg
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="51.0" text="MATLAB"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="52.0" text="RunTime"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="SimulationTime"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="78.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="39.0" text="Plotter"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="54.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="27.0" text="TSet"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="131.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="59.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="25.0" text="gain"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.12/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_opencvreader_OpenCVReader.elkg
+++ b/realworld/ptolemy/flattened/sdf_opencvreader_OpenCVReader.elkg
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="OpenCVReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="30.0" text="Copy"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="22.0" text="Flip"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="24.0" text="Blur"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="29.0" text="Flip2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="30.0" text="Invert"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="78.0" text="ImageDisplay"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.13/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_orthogonalcom_OrthogonalCom.elkg
+++ b/realworld/ptolemy/flattened/sdf_orthogonalcom_OrthogonalCom.elkg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="bitSource"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="219.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="52.0" text="Symbol1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="235.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="52.0" text="Symbol2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="235.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="49.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="64.0" text="Multiplexor"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@containedEdges.2 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="55.0" text="addNoise"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="93.0" text="Gaussian Noise"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="62.0" text="correlator1"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="62.0" text="correlator2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="95.0" text="outputBitDisplay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="94.0" text="compareResults"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="57.0" text="Maximum"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.2" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_recordmanipulation_RecordManipulation.elkg
+++ b/realworld/ptolemy/flattened/sdf_recordmanipulation_RecordManipulation.elkg
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="78.0" text="Recordmaker"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="78.0" text="Recordparser"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="78.0" text="RecordMerge"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="85.0" text="Recordmaker2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="19.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="24.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="83.0" text="Selectordialog"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="117.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="StringConst3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="117.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.8/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_rijndaelencryption_RijndaelEncryption.elkg
+++ b/realworld/ptolemy/flattened/sdf_rijndaelencryption_RijndaelEncryption.elkg
@@ -1,0 +1,508 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="96.0" text="RoundSequence"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="61.0" text="UpSample"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="110.0" text="ArrayToSequence3"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="110.0" text="SequenceToArray3"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="94.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="508.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="508.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="203.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="203.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="74.0" text="modal model"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="61.0" text="UpSample"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="227.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="92.0" text="PadToTwoChars"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="61.0" text="UpSample"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="227.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="92.0" text="PadToTwoChars"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.27/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.28/@ports.1" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.29/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.30/@ports.1" targets="//@children.26/@ports.2"/>
+  <containedEdges identifier="E36" sources="//@children.31/@ports.0" targets="//@children.26/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_robot_robotWebService.elkg
+++ b/realworld/ptolemy/flattened/sdf_robot_robotWebService.elkg
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="30.0" text="Exec"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="57.0" text="FileWriter"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="306.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="93.0" text="AssumptionText"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="306.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="459.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="84.0" text="GuaranteeText"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="459.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_signature_Signature.elkg
+++ b/realworld/ptolemy/flattened/sdf_signature_Signature.elkg
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="104.0" text="PrivateKeyReader"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="101.0" text="PublicKeyReader"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="93.0" text="SignatureSigner"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="95.0" text="SignatureVerifier"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="77.0" text="Ramp Output"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.3" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_systemcommand_SystemCommand.elkg
+++ b/realworld/ptolemy/flattened/sdf_systemcommand_SystemCommand.elkg
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="105.0" text="SystemCommand"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="x1"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="15.0" text="x2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="133.0" text="StandardOutputStream"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="122.0" text="StandardErrorStream"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="105.0" text="AnythingToDouble"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="98.0" text="ThrowModelError"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="85.0" text="StringFunction"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="105.0" text="AnythingToDouble"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="113.0" text="ExpressionToToken"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="98.0" text="ThrowModelError"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.0" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_trellisdecoder_TrellisDecoder.elkg
+++ b/realworld/ptolemy/flattened/sdf_trellisdecoder_TrellisDecoder.elkg
@@ -1,0 +1,493 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Slicer"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="59.0" text="LineCoder"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="LineCoder2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="83.0" text="TrellisDecoder"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.0" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.0" targets="//@children.28/@ports.2"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.0" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sdf_viterbidecoder_ViterbiDecoder.elkg
+++ b/realworld/ptolemy/flattened/sdf_viterbidecoder_ViterbiDecoder.elkg
@@ -1,0 +1,431 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="93.0" text="ViterbiDecoder2"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.22/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.23/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.2" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/security_signature_Signature.elkg
+++ b/realworld/ptolemy/flattened/security_signature_Signature.elkg
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="104.0" text="PrivateKeyReader"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="101.0" text="PublicKeyReader"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="93.0" text="SignatureSigner"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="95.0" text="SignatureVerifier"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="77.0" text="Ramp Output"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.3" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/space_dopcenter_DOPCenter.elkg
+++ b/realworld/ptolemy/flattened/space_dopcenter_DOPCenter.elkg
@@ -1,0 +1,520 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Room"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="Occupants"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Room2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="Occupants2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Room3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.5" y="-8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="71.0" text="Occupants3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Room4"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="71.0" text="Occupants4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Room5"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="71.0" text="Occupants5"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Room6"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="71.0" text="Occupants6"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Room7"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="71.0" text="Occupants7"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Room8"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="71.0" text="Occupants8"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Room9"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="49.0" text="Room10"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="78.0" text="Occupants10"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="77.0" text="Occupants11"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="48.0" text="Room11"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="49.0" text="Room12"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="78.0" text="Occupants12"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="49.0" text="Room13"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="78.0" text="Occupants13"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="78.0" text="Occupants14"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="16.0" y="2.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="49.0" text="Room14"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="49.0" text="Room15"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="11.600000381469727">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="21.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="78.0" text="Occupants15"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="16.0" y="2.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="90.0" text="DatabaseQuery"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="152.0" text="ArrayOfRecordsRecorder2"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="12.0" width="16.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="71.0" text="Occupants9"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="2.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.16/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.20/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.21/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.23/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.26/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.27/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.29/@ports.0" targets="//@children.30/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_controlFlowDemo.elkg
+++ b/realworld/ptolemy/flattened/sr_controlFlowDemo.elkg
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="AccumLUB"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="36.0" text="EmitA"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="4.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="15.0" text="T1"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="4.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="36.0" text="EmitB"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="4.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="17.0" text="P1"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="32.0">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="17.0" text="P2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="32.0">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.8/@ports.6"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.7/@ports.5"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.9/@ports.5"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.6" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.4" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.5" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.4" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.6" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.4" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.6" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.6" targets="//@children.8/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_errorhandling_ErrorHandlingSynthesized.elkg
+++ b/realworld/ptolemy/flattened/sr_errorhandling_ErrorHandlingSynthesized.elkg
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Client2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Client1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="29.0" text="Error"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="51.0" text="Operator"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="SetVariable7"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="23.0" text="Sec"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="43.0" text="model1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.1" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.11/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.4" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.5" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.6" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_guardedcount_GuardedCount.elkg
+++ b/realworld/ptolemy/flattened/sr_guardedcount_GuardedCount.elkg
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="DisplayCount"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="84.0" text="DisplayEnable"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="40.0" text="Default"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="35.0" text="When"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="132.0" text="DisplayCountRequests"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_guardedcount_GuardedCountTimed.elkg
+++ b/realworld/ptolemy/flattened/sr_guardedcount_GuardedCountTimed.elkg
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="40.0" text="Default"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="35.0" text="When"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.2" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.9/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_irobothillclimbing_iRobotCreateVerification.elkg
+++ b/realworld/ptolemy/flattened/sr_irobothillclimbing_iRobotCreateVerification.elkg
@@ -1,0 +1,836 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Slope"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="-1.875" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="10.375" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="22.625" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="-1.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="6.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="13.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="20.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="27.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="34.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.75" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="34.875" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="-1.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="6.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="13.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="20.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="27.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="34.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="-1.875" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="10.375" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="22.625" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="34.875" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="48.0" text="Sensors"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="63.0" y="-5.5625">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="63.0" y="-3.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="63.0" y="-0.6875">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="63.0" y="1.75">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="63.0" y="4.1875">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="63.0" y="6.625">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="63.0" y="9.0625" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="63.0" y="11.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="63.0" y="13.9375" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="63.0" y="16.375" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="63.0" y="18.8125">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="63.0" y="21.25">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="63.0" y="23.6875">
+      <properties key="org.eclipse.elk.port.index" value="12"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="63.0" y="26.125">
+      <properties key="org.eclipse.elk.port.index" value="13"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="63.0" y="28.5625">
+      <properties key="org.eclipse.elk.port.index" value="14"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-15"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="39.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="47.0" text="Switch2"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="ADC"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="63.0" y="5.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="63.0" y="18.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="224.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="212.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="47.0" text="Switch2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@containedEdges.33 //@containedEdges.34 //@containedEdges.41 //@containedEdges.44 //@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="47.0" text="Switch3"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="457.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression5"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="473.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="73.0" text="Expression6"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="47.0" text="Switch5"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="47.0" text="Switch6"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="47.0" text="Switch4"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="119.0" text="BooleanToAnything5"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="119.0" text="BooleanToAnything6"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.53 //@containedEdges.54 //@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="36.0" text="Drive2"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="63.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="15.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="36.0" text="Drive3"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="63.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="15.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="31.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="36.0" text="Drive4"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="63.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="72.0" text="RotateAngle"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="75.0" text="UnitDistance"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="105.0" text="AnythingToDouble"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.6" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.7" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.8" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.9" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.10" targets="//@children.1/@ports.5"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.1/@ports.9"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.4" targets="//@children.1/@ports.10"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.11" targets="//@children.1/@ports.11"/>
+  <containedEdges identifier="E10" sources="//@children.0/@ports.12" targets="//@children.1/@ports.12"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.6" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.7" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.8" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.8" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.9" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.7" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.2/@ports.6" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.7/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.9/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.10/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.10/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.10/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.10/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.10/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.11/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.12/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.13/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.14/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.15/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.16/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.17/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.17/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.17/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.17/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.17/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.19/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.20/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.21/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.22/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.23/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.24/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.25/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.26/@ports.1" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.27/@ports.1" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.28/@ports.1" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.29/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.30/@ports.1" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E54" sources="//@children.31/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.31/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.31/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.32/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E58" sources="//@children.33/@ports.0" targets="//@children.36/@ports.2"/>
+  <containedEdges identifier="E59" sources="//@children.35/@ports.0" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E60" sources="//@children.38/@ports.0" targets="//@children.34/@ports.4"/>
+  <containedEdges identifier="E61" sources="//@children.38/@ports.0" targets="//@children.36/@ports.4"/>
+  <containedEdges identifier="E62" sources="//@children.39/@ports.0" targets="//@children.37/@ports.4"/>
+  <containedEdges identifier="E63" sources="//@children.40/@ports.1" targets="//@children.37/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_reflexgame_ReflexGame.elkg
+++ b/realworld/ptolemy/flattened/sr_reflexgame_ReflexGame.elkg
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="65.0" text="Start Timer"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="67.0" text="ButtonTime"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="modal model"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="48.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="29.0" text="Now!"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="48.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="37.0" text="Ready"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="119.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="119.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="89.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="89.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="33.0" text="Timer"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.3" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.4" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.17/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.17/@ports.0" targets="//@children.3/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_tokenring_TokenRing_complicated.elkg
+++ b/realworld/ptolemy/flattened/sr_tokenring_TokenRing_complicated.elkg
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Request1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="NonStrictDisplay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.20 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Request2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Request3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="123.0" text="1:BooleanToAnything"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="123.0" text="2:BooleanToAnything"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.19/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.22/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_tokenring_TokenRing_incompatible.elkg
+++ b/realworld/ptolemy/flattened/sr_tokenring_TokenRing_incompatible.elkg
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Request1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="NonStrictDisplay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.20 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Request2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Request3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="123.0" text="1:BooleanToAnything"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="123.0" text="2:BooleanToAnything"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.19/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.22/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_tokenring_TokenRing_original.elkg
+++ b/realworld/ptolemy/flattened/sr_tokenring_TokenRing_original.elkg
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Request1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="NonStrictDisplay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.20 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Request2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Request3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="123.0" text="1:BooleanToAnything"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="123.0" text="2:BooleanToAnything"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.19/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.22/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_tokenring_TokenRing_simplified.elkg
+++ b/realworld/ptolemy/flattened/sr_tokenring_TokenRing_simplified.elkg
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Request1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="NonStrictDisplay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.20 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Request2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Request3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="123.0" text="1:BooleanToAnything"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="123.0" text="2:BooleanToAnything"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="20.0" text="OR"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="35.0" text="AND2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.25 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="28.0" text="AND"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="37.0" text="NAND"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="87.0" text="NonStrictDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.15/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.17/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.18/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.19/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.20/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.21/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.22/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.1" targets="//@children.12/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/sr_trafficlight_WirelessDeployment.elkg
+++ b/realworld/ptolemy/flattened/sr_trafficlight_WirelessDeployment.elkg
@@ -1,0 +1,454 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="48.0" text="CarLight"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="0.1666666716337204" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="32.83333206176758" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="64.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="75.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="69.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="69.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.4" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.0/@ports.7"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.0/@ports.6"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.2" targets="//@children.12/@ports.5"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.2" targets="//@children.12/@ports.6"/>
+  <containedEdges identifier="E23" sources="//@children.20/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.21/@ports.2" targets="//@children.12/@ports.4"/>
+  <containedEdges identifier="E25" sources="//@children.22/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.23/@ports.2" targets="//@children.12/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/syntactic_AdaptiveBeamSyntactic.elkg
+++ b/realworld/ptolemy/flattened/syntactic_AdaptiveBeamSyntactic.elkg
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="112.0" text="ApplyAdaptiveFilter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="CovarCalculation"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="113.0" text="Weight_Calculation"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="ApplyFilter"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Matrix_invert"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="110.0" text="PulseCompression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="83.0" text="SteerVectCalc"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="91.0" text="DopplerFiltering"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="GenPulseX4"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="62.0" text="Gen_Echo"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="64.0" text="Add_Noise"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="AddJammer"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="37.0" text="Decim"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="61.0" text="Check_Inv"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.06943416595459" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.13886833190918" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.20830154418945" width="60.70830154418945">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="103.0" text="EnhancedDoppler"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.5/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/syntactic_LoopSyntactic2.elkg
+++ b/realworld/ptolemy/flattened/syntactic_LoopSyntactic2.elkg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="138.0" text="Outside-the-loop Plotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="127.0" text="Inside-the-loop Plotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.3" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/syntactic_LoopSyntacticC.elkg
+++ b/realworld/ptolemy/flattened/syntactic_LoopSyntacticC.elkg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="138.0" text="Outside-the-loop Plotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="127.0" text="Inside-the-loop Plotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="MovingAverage"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.0" targets="//@children.13/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/tdl_activerearsteeringct_ActiveRearSteeringCT.elkg
+++ b/realworld/ptolemy/flattened/tdl_activerearsteeringct_ActiveRearSteeringCT.elkg
@@ -1,0 +1,2566 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="sigGen"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="59.0" text="speedProf"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="52.0" text="Rad2deg"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.224">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="8.0" text="u"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.267">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="15.0" text="u2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.261 //@containedEdges.263 //@containedEdges.265">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.19 //@containedEdges.27 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.33 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.39 //@containedEdges.52 //@containedEdges.75 //@containedEdges.85 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40 //@containedEdges.41 //@containedEdges.42 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.46 //@containedEdges.47 //@containedEdges.48 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.53 //@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.61 //@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="62.0" text="EventFilter"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="69.0" text="EventFilter2"/>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="75.0" text="Comparator3"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.70 //@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.71 //@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="75.0" text="Comparator4"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P128" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="69.0" text="EventFilter3"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="89.0" text="LogicFunction3"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.67 //@containedEdges.77 //@containedEdges.87 //@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="75.0" text="Comparator5"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="89.0" text="LogicFunction4"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.80 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.81 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="75.0" text="Comparator6"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="25.0" width="24.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P149" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="69.0" text="EventFilter4"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="25.0" width="24.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="75.0" text="Comparator7"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.90 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="69.0" text="LogicalNot4"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="69.0" text="EventFilter5"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.94 //@containedEdges.95 //@containedEdges.96 //@containedEdges.97 //@containedEdges.98 //@containedEdges.99 //@containedEdges.100 //@containedEdges.101 //@containedEdges.102 //@containedEdges.103 //@containedEdges.104 //@containedEdges.105 //@containedEdges.106 //@containedEdges.107 //@containedEdges.108 //@containedEdges.109 //@containedEdges.110 //@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.113 //@containedEdges.114 //@containedEdges.115 //@containedEdges.116 //@containedEdges.117 //@containedEdges.118 //@containedEdges.119 //@containedEdges.120 //@containedEdges.121 //@containedEdges.122 //@containedEdges.123 //@containedEdges.124 //@containedEdges.125 //@containedEdges.126 //@containedEdges.127 //@containedEdges.128 //@containedEdges.129 //@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.190 //@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.131 //@containedEdges.132 //@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="44.0" text="state_0"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.134 //@containedEdges.135 //@containedEdges.136 //@containedEdges.137 //@containedEdges.138 //@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="78.0" text="stateAdder_0"/>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.162 //@containedEdges.163 //@containedEdges.164 //@containedEdges.165 //@containedEdges.178 //@containedEdges.182 //@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="44.0" text="state_1"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.141 //@containedEdges.142 //@containedEdges.143 //@containedEdges.144 //@containedEdges.145 //@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="78.0" text="stateAdder_1"/>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.166 //@containedEdges.167 //@containedEdges.168 //@containedEdges.169 //@containedEdges.179 //@containedEdges.183 //@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="44.0" text="state_2"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.148 //@containedEdges.149 //@containedEdges.150 //@containedEdges.151 //@containedEdges.152 //@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="78.0" text="stateAdder_2"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.170 //@containedEdges.171 //@containedEdges.172 //@containedEdges.173 //@containedEdges.180 //@containedEdges.184 //@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="44.0" text="state_3"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.155 //@containedEdges.156 //@containedEdges.157 //@containedEdges.158 //@containedEdges.159 //@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="78.0" text="stateAdder_3"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.174 //@containedEdges.175 //@containedEdges.176 //@containedEdges.177 //@containedEdges.181 //@containedEdges.185 //@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="81.0" text="feedback_0_0"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="81.0" text="feedback_0_1"/>
+    <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="81.0" text="feedback_0_2"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="81.0" text="feedback_0_3"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="81.0" text="feedback_1_0"/>
+    <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="81.0" text="feedback_1_1"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="81.0" text="feedback_1_2"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="81.0" text="feedback_1_3"/>
+    <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="81.0" text="feedback_2_0"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="81.0" text="feedback_2_1"/>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="81.0" text="feedback_2_2"/>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="81.0" text="feedback_2_3"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="81.0" text="feedback_3_0"/>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="81.0" text="feedback_3_1"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P222" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="81.0" text="feedback_3_2"/>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="81.0" text="feedback_3_3"/>
+    <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="36.0" text="b_0_0"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.94 //@containedEdges.113 //@containedEdges.206">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="36.0" text="b_1_0"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.95 //@containedEdges.114 //@containedEdges.207">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="36.0" text="b_2_0"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.96 //@containedEdges.115 //@containedEdges.208">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="36.0" text="b_3_0"/>
+    <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.97 //@containedEdges.116 //@containedEdges.209">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P234" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="36.0" text="b_0_1"/>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.100 //@containedEdges.119 //@containedEdges.212">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="36.0" text="b_1_1"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.101 //@containedEdges.120 //@containedEdges.213">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="36.0" text="b_2_1"/>
+    <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.102 //@containedEdges.121 //@containedEdges.214">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="36.0" text="b_3_1"/>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.103 //@containedEdges.122 //@containedEdges.215">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="36.0" text="b_0_2"/>
+    <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.106 //@containedEdges.125 //@containedEdges.218">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="36.0" text="b_1_2"/>
+    <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.107 //@containedEdges.126 //@containedEdges.219">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="36.0" text="b_2_2"/>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.108 //@containedEdges.127 //@containedEdges.220">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="36.0" text="b_3_2"/>
+    <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.109 //@containedEdges.128 //@containedEdges.221">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="78.0" text="outputAdder0"/>
+    <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.191 //@containedEdges.192 //@containedEdges.193 //@containedEdges.194 //@containedEdges.200 //@containedEdges.201 //@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="98.0" text="outputScale_0_0"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="98.0" text="outputScale_0_1"/>
+    <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P257" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="98.0" text="outputScale_0_2"/>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P259" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="98.0" text="outputScale_0_3"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="78.0" text="outputAdder1"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.196 //@containedEdges.197 //@containedEdges.198 //@containedEdges.199 //@containedEdges.203 //@containedEdges.204 //@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="98.0" text="outputScale_1_0"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="98.0" text="outputScale_1_1"/>
+    <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="98.0" text="outputScale_1_2"/>
+    <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="98.0" text="outputScale_1_3"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="99.0" text="feedThrough_0_0"/>
+    <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.98 //@containedEdges.117 //@containedEdges.210">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.200">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="99.0" text="feedThrough_0_1"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.104 //@containedEdges.123 //@containedEdges.216">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.201">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="99.0" text="feedThrough_0_2"/>
+    <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.110 //@containedEdges.129 //@containedEdges.222">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.202">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="99.0" text="feedThrough_1_0"/>
+    <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.99 //@containedEdges.118 //@containedEdges.211">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.203">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="99.0" text="feedThrough_1_1"/>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.105 //@containedEdges.124 //@containedEdges.217">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.204">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="99.0" text="feedThrough_1_2"/>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.111 //@containedEdges.130 //@containedEdges.223">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.205">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.243">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.206 //@containedEdges.207 //@containedEdges.208 //@containedEdges.209 //@containedEdges.210 //@containedEdges.211 //@containedEdges.212 //@containedEdges.213 //@containedEdges.214 //@containedEdges.215 //@containedEdges.216 //@containedEdges.217 //@containedEdges.218 //@containedEdges.219 //@containedEdges.220 //@containedEdges.221 //@containedEdges.222 //@containedEdges.223 //@containedEdges.224 //@containedEdges.225 //@containedEdges.226 //@containedEdges.227 //@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.233 //@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P289" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P292" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.230">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.229">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P294" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.231 //@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.231">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.233">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.232">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P298" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.234">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.230 //@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P304" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.236 //@containedEdges.237">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.235">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P306" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.238 //@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.238">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.240">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.239">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P310" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.241">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.236 //@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P316" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.243 //@containedEdges.244">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.242">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.245 //@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.245">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P320" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.247">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.246">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P322" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.248">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.237 //@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P325" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.249">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.251 //@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.251">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P332" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.253">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.252">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.254">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.244 //@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.255">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.257 //@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.257">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.259">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.258">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P346" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.260">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="64.0" text="delta_r_act"/>
+    <ports identifier="P347" y="8.199999809265137" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P348" y="16.399999618530273" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P349" y="24.600000381469727" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P350" x="61.0" y="20.5" outgoingEdges="//@containedEdges.261 //@containedEdges.262">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P351" y="32.79999923706055" incomingEdges="//@containedEdges.225">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="64.0" text="delta_r_act"/>
+    <ports identifier="P352" y="8.199999809265137" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P353" y="16.399999618530273" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P354" y="24.600000381469727" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P355" x="61.0" y="20.5" outgoingEdges="//@containedEdges.263 //@containedEdges.264">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P356" y="32.79999923706055" incomingEdges="//@containedEdges.226">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="64.0" text="delta_r_act"/>
+    <ports identifier="P357" y="8.199999809265137" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P358" y="16.399999618530273" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P359" y="24.600000381469727" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P360" x="61.0" y="20.5" outgoingEdges="//@containedEdges.265 //@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P361" y="32.79999923706055" incomingEdges="//@containedEdges.227">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="61.0" text="delta_r_sp"/>
+    <ports identifier="P362" y="8.199999809265137" incomingEdges="//@containedEdges.228">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P363" y="16.399999618530273" incomingEdges="//@containedEdges.256">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P364" y="24.600000381469727" incomingEdges="//@containedEdges.250">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P365" x="61.0" y="20.5" outgoingEdges="//@containedEdges.267 //@containedEdges.268">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P366" y="32.79999923706055" incomingEdges="//@containedEdges.262 //@containedEdges.264 //@containedEdges.266">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.6/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.7/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.7/@ports.1" targets="//@children.76/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.1" targets="//@children.157/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.158/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.159/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.19/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.21/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.22/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.23/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.24/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.25/@ports.1" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.26/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.27/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.28/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.29/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.30/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.31/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.32/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.33/@ports.1" targets="//@children.38/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.34/@ports.1" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.35/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.36/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.37/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.38/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.39/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.40/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.41/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.41/@ports.2" targets="//@children.157/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.41/@ports.2" targets="//@children.158/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.41/@ports.2" targets="//@children.159/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.42/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.42/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.42/@ports.0" targets="//@children.49/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.42/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.42/@ports.0" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.42/@ports.0" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.42/@ports.0" targets="//@children.66/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.42/@ports.0" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.43/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.44/@ports.0" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.44/@ports.0" targets="//@children.48/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.44/@ports.0" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.44/@ports.0" targets="//@children.56/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.44/@ports.0" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.44/@ports.0" targets="//@children.65/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.44/@ports.0" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.45/@ports.0" targets="//@children.46/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.46/@ports.2" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.47/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.47/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.48/@ports.2" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.49/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.50/@ports.1" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.51/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.52/@ports.1" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.53/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.54/@ports.2" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.55/@ports.1" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.55/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.56/@ports.2" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.57/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.58/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.59/@ports.1" targets="//@children.58/@ports.1"/>
+  <containedEdges identifier="E78" sources="//@children.60/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.61/@ports.1" targets="//@children.52/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.62/@ports.0" targets="//@children.63/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.63/@ports.2" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.64/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.64/@ports.1" targets="//@children.69/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.65/@ports.2" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.66/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.67/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.68/@ports.1" targets="//@children.67/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.69/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.70/@ports.0" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.71/@ports.0" targets="//@children.41/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.72/@ports.2" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.72/@ports.2" targets="//@children.74/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.73/@ports.1" targets="//@children.61/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.74/@ports.1" targets="//@children.71/@ports.1"/>
+  <containedEdges identifier="E95" sources="//@children.75/@ports.0" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.75/@ports.0" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E97" sources="//@children.75/@ports.0" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.75/@ports.0" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.75/@ports.0" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.75/@ports.0" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.75/@ports.0" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.75/@ports.0" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.75/@ports.0" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.75/@ports.0" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.75/@ports.0" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.75/@ports.0" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E107" sources="//@children.75/@ports.0" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E108" sources="//@children.75/@ports.0" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E109" sources="//@children.75/@ports.0" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.75/@ports.0" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E111" sources="//@children.75/@ports.0" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.75/@ports.0" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.76/@ports.1" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.77/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.77/@ports.1" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.77/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E117" sources="//@children.77/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E118" sources="//@children.77/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E119" sources="//@children.77/@ports.1" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.77/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.77/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.77/@ports.1" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.77/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E124" sources="//@children.77/@ports.1" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E125" sources="//@children.77/@ports.1" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.77/@ports.1" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E127" sources="//@children.77/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E128" sources="//@children.77/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E129" sources="//@children.77/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E130" sources="//@children.77/@ports.1" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E131" sources="//@children.77/@ports.1" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.78/@ports.1" targets="//@children.157/@ports.2"/>
+  <containedEdges identifier="E133" sources="//@children.78/@ports.1" targets="//@children.158/@ports.2"/>
+  <containedEdges identifier="E134" sources="//@children.78/@ports.1" targets="//@children.159/@ports.2"/>
+  <containedEdges identifier="E135" sources="//@children.79/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E136" sources="//@children.79/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E137" sources="//@children.79/@ports.1" targets="//@children.95/@ports.0"/>
+  <containedEdges identifier="E138" sources="//@children.79/@ports.1" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E139" sources="//@children.79/@ports.1" targets="//@children.116/@ports.0"/>
+  <containedEdges identifier="E140" sources="//@children.79/@ports.1" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E141" sources="//@children.80/@ports.2" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.81/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.81/@ports.1" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E144" sources="//@children.81/@ports.1" targets="//@children.96/@ports.0"/>
+  <containedEdges identifier="E145" sources="//@children.81/@ports.1" targets="//@children.100/@ports.0"/>
+  <containedEdges identifier="E146" sources="//@children.81/@ports.1" targets="//@children.117/@ports.0"/>
+  <containedEdges identifier="E147" sources="//@children.81/@ports.1" targets="//@children.122/@ports.0"/>
+  <containedEdges identifier="E148" sources="//@children.82/@ports.2" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E149" sources="//@children.83/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E150" sources="//@children.83/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E151" sources="//@children.83/@ports.1" targets="//@children.97/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.83/@ports.1" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.83/@ports.1" targets="//@children.118/@ports.0"/>
+  <containedEdges identifier="E154" sources="//@children.83/@ports.1" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E155" sources="//@children.84/@ports.2" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E156" sources="//@children.85/@ports.1" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E157" sources="//@children.85/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E158" sources="//@children.85/@ports.1" targets="//@children.98/@ports.0"/>
+  <containedEdges identifier="E159" sources="//@children.85/@ports.1" targets="//@children.102/@ports.0"/>
+  <containedEdges identifier="E160" sources="//@children.85/@ports.1" targets="//@children.119/@ports.0"/>
+  <containedEdges identifier="E161" sources="//@children.85/@ports.1" targets="//@children.124/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.86/@ports.2" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.87/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E164" sources="//@children.88/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E165" sources="//@children.89/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E166" sources="//@children.90/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E167" sources="//@children.91/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E168" sources="//@children.92/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E169" sources="//@children.93/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E170" sources="//@children.94/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E171" sources="//@children.95/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E172" sources="//@children.96/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.97/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E174" sources="//@children.98/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E175" sources="//@children.99/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E176" sources="//@children.100/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E177" sources="//@children.101/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E178" sources="//@children.102/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E179" sources="//@children.103/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E180" sources="//@children.104/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E181" sources="//@children.105/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E182" sources="//@children.106/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E183" sources="//@children.107/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E184" sources="//@children.108/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E185" sources="//@children.109/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E186" sources="//@children.110/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E187" sources="//@children.111/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E188" sources="//@children.112/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E189" sources="//@children.113/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E190" sources="//@children.114/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E191" sources="//@children.115/@ports.2" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.116/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E193" sources="//@children.117/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E194" sources="//@children.118/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E195" sources="//@children.119/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E196" sources="//@children.120/@ports.2" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E197" sources="//@children.121/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E198" sources="//@children.122/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E199" sources="//@children.123/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E200" sources="//@children.124/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E201" sources="//@children.125/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E202" sources="//@children.126/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E203" sources="//@children.127/@ports.1" targets="//@children.115/@ports.0"/>
+  <containedEdges identifier="E204" sources="//@children.128/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E205" sources="//@children.129/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E206" sources="//@children.130/@ports.1" targets="//@children.120/@ports.0"/>
+  <containedEdges identifier="E207" sources="//@children.131/@ports.1" targets="//@children.103/@ports.0"/>
+  <containedEdges identifier="E208" sources="//@children.131/@ports.1" targets="//@children.104/@ports.0"/>
+  <containedEdges identifier="E209" sources="//@children.131/@ports.1" targets="//@children.105/@ports.0"/>
+  <containedEdges identifier="E210" sources="//@children.131/@ports.1" targets="//@children.106/@ports.0"/>
+  <containedEdges identifier="E211" sources="//@children.131/@ports.1" targets="//@children.125/@ports.0"/>
+  <containedEdges identifier="E212" sources="//@children.131/@ports.1" targets="//@children.128/@ports.0"/>
+  <containedEdges identifier="E213" sources="//@children.131/@ports.1" targets="//@children.107/@ports.0"/>
+  <containedEdges identifier="E214" sources="//@children.131/@ports.1" targets="//@children.108/@ports.0"/>
+  <containedEdges identifier="E215" sources="//@children.131/@ports.1" targets="//@children.109/@ports.0"/>
+  <containedEdges identifier="E216" sources="//@children.131/@ports.1" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E217" sources="//@children.131/@ports.1" targets="//@children.126/@ports.0"/>
+  <containedEdges identifier="E218" sources="//@children.131/@ports.1" targets="//@children.129/@ports.0"/>
+  <containedEdges identifier="E219" sources="//@children.131/@ports.1" targets="//@children.111/@ports.0"/>
+  <containedEdges identifier="E220" sources="//@children.131/@ports.1" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E221" sources="//@children.131/@ports.1" targets="//@children.113/@ports.0"/>
+  <containedEdges identifier="E222" sources="//@children.131/@ports.1" targets="//@children.114/@ports.0"/>
+  <containedEdges identifier="E223" sources="//@children.131/@ports.1" targets="//@children.127/@ports.0"/>
+  <containedEdges identifier="E224" sources="//@children.131/@ports.1" targets="//@children.130/@ports.0"/>
+  <containedEdges identifier="E225" sources="//@children.131/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E226" sources="//@children.131/@ports.1" targets="//@children.157/@ports.4"/>
+  <containedEdges identifier="E227" sources="//@children.131/@ports.1" targets="//@children.158/@ports.4"/>
+  <containedEdges identifier="E228" sources="//@children.131/@ports.1" targets="//@children.159/@ports.4"/>
+  <containedEdges identifier="E229" sources="//@children.131/@ports.1" targets="//@children.160/@ports.0"/>
+  <containedEdges identifier="E230" sources="//@children.132/@ports.2" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E231" sources="//@children.133/@ports.2" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E232" sources="//@children.134/@ports.1" targets="//@children.135/@ports.0"/>
+  <containedEdges identifier="E233" sources="//@children.134/@ports.1" targets="//@children.136/@ports.0"/>
+  <containedEdges identifier="E234" sources="//@children.135/@ports.1" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E235" sources="//@children.136/@ports.1" targets="//@children.133/@ports.0"/>
+  <containedEdges identifier="E236" sources="//@children.137/@ports.2" targets="//@children.139/@ports.0"/>
+  <containedEdges identifier="E237" sources="//@children.138/@ports.2" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E238" sources="//@children.138/@ports.2" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E239" sources="//@children.139/@ports.1" targets="//@children.140/@ports.0"/>
+  <containedEdges identifier="E240" sources="//@children.139/@ports.1" targets="//@children.141/@ports.0"/>
+  <containedEdges identifier="E241" sources="//@children.140/@ports.1" targets="//@children.137/@ports.0"/>
+  <containedEdges identifier="E242" sources="//@children.141/@ports.1" targets="//@children.138/@ports.0"/>
+  <containedEdges identifier="E243" sources="//@children.142/@ports.2" targets="//@children.144/@ports.0"/>
+  <containedEdges identifier="E244" sources="//@children.143/@ports.2" targets="//@children.131/@ports.0"/>
+  <containedEdges identifier="E245" sources="//@children.143/@ports.2" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E246" sources="//@children.144/@ports.1" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E247" sources="//@children.144/@ports.1" targets="//@children.146/@ports.0"/>
+  <containedEdges identifier="E248" sources="//@children.145/@ports.1" targets="//@children.142/@ports.0"/>
+  <containedEdges identifier="E249" sources="//@children.146/@ports.1" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E250" sources="//@children.147/@ports.2" targets="//@children.149/@ports.0"/>
+  <containedEdges identifier="E251" sources="//@children.148/@ports.2" targets="//@children.160/@ports.2"/>
+  <containedEdges identifier="E252" sources="//@children.149/@ports.1" targets="//@children.150/@ports.0"/>
+  <containedEdges identifier="E253" sources="//@children.149/@ports.1" targets="//@children.151/@ports.0"/>
+  <containedEdges identifier="E254" sources="//@children.150/@ports.1" targets="//@children.147/@ports.0"/>
+  <containedEdges identifier="E255" sources="//@children.151/@ports.1" targets="//@children.148/@ports.0"/>
+  <containedEdges identifier="E256" sources="//@children.152/@ports.2" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E257" sources="//@children.153/@ports.2" targets="//@children.160/@ports.1"/>
+  <containedEdges identifier="E258" sources="//@children.154/@ports.1" targets="//@children.155/@ports.0"/>
+  <containedEdges identifier="E259" sources="//@children.154/@ports.1" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E260" sources="//@children.155/@ports.1" targets="//@children.152/@ports.0"/>
+  <containedEdges identifier="E261" sources="//@children.156/@ports.1" targets="//@children.153/@ports.0"/>
+  <containedEdges identifier="E262" sources="//@children.157/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E263" sources="//@children.157/@ports.3" targets="//@children.160/@ports.4"/>
+  <containedEdges identifier="E264" sources="//@children.158/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E265" sources="//@children.158/@ports.3" targets="//@children.160/@ports.4"/>
+  <containedEdges identifier="E266" sources="//@children.159/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E267" sources="//@children.159/@ports.3" targets="//@children.160/@ports.4"/>
+  <containedEdges identifier="E268" sources="//@children.160/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E269" sources="//@children.160/@ports.3" targets="//@children.132/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/tdl_activerearsteeringde_ActiveRearSteeringDE.elkg
+++ b/realworld/ptolemy/flattened/tdl_activerearsteeringde_ActiveRearSteeringDE.elkg
@@ -1,0 +1,1517 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="sigGen"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="59.0" text="speedProf"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="52.0" text="Rad2deg"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="8.0" text="u"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.19 //@containedEdges.27 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.33 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="25.0" width="72.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.39 //@containedEdges.52 //@containedEdges.75 //@containedEdges.85 //@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.40 //@containedEdges.41 //@containedEdges.42 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.44 //@containedEdges.45 //@containedEdges.46 //@containedEdges.47 //@containedEdges.48 //@containedEdges.49 //@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.53 //@containedEdges.54 //@containedEdges.55 //@containedEdges.56 //@containedEdges.57 //@containedEdges.58 //@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.61 //@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.62 //@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="62.0" text="EventFilter"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="61.0" text="LogicalNot"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="69.0" text="EventFilter2"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="75.0" text="Comparator3"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.70 //@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.71 //@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="75.0" text="Comparator4"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="69.0" text="EventFilter3"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="69.0" text="LogicalNot2"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="89.0" text="LogicFunction3"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.67 //@containedEdges.77 //@containedEdges.87 //@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="75.0" text="Comparator5"/>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="89.0" text="LogicFunction4"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.80 //@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.81 //@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="75.0" text="Comparator6"/>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="25.0" width="24.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="69.0" text="EventFilter4"/>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="69.0" text="LogicalNot3"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="24.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="75.0" text="Comparator7"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.90 //@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="69.0" text="LogicalNot4"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="69.0" text="EventFilter5"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="97.0" text="voltage converter"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="89.0" text="motor electrical"/>
+    <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.97 //@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="103.0" text="motor mechanical"/>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.100 //@containedEdges.101 //@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="17.0" text="phi"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.103 //@containedEdges.104 //@containedEdges.105 //@containedEdges.106 //@containedEdges.107 //@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="79.0" text="speed sensor"/>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="25.0" text="phi1"/>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P189" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P193" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.115 //@containedEdges.116 //@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="100.0" text="VectorAssembler"/>
+    <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.94 //@containedEdges.103 //@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="61.0" width="151.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="188.0" text="LinearDifferenceEquationSystem"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="26.5" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" x="151.0" y="15.0" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="151.0" y="38.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="64.0" text="delta_r_act"/>
+    <ports identifier="P203" y="8.199999809265137" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" y="16.399999618530273" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" y="24.600000381469727" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" x="61.0" y="20.5" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P207" y="32.79999923706055" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="64.0" text="delta_r_act"/>
+    <ports identifier="P208" y="8.199999809265137" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P209" y="16.399999618530273" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" y="24.600000381469727" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P211" x="61.0" y="20.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P212" y="32.79999923706055" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="64.0" text="delta_r_act"/>
+    <ports identifier="P213" y="8.199999809265137" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" y="16.399999618530273" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" y="24.600000381469727" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" x="61.0" y="20.5" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P217" y="32.79999923706055" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="61.0" text="delta_r_sp"/>
+    <ports identifier="P218" y="8.199999809265137" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" y="16.399999618530273" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" y="24.600000381469727" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" x="61.0" y="20.5" outgoingEdges="//@containedEdges.124 //@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P222" y="32.79999923706055" incomingEdges="//@containedEdges.121 //@containedEdges.122 //@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.1" targets="//@children.85/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.1" targets="//@children.91/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.92/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.93/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.20/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.22/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.23/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.24/@ports.1" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.25/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.26/@ports.0" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.27/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.28/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.29/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.30/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.31/@ports.2" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.32/@ports.1" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.33/@ports.1" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.34/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.35/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.36/@ports.0" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.37/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.38/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.39/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.40/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.40/@ports.2" targets="//@children.91/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.40/@ports.2" targets="//@children.92/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.40/@ports.2" targets="//@children.93/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.41/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.41/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.41/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.41/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.41/@ports.0" targets="//@children.56/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.41/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.41/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.41/@ports.0" targets="//@children.69/@ports.1"/>
+  <containedEdges identifier="E53" sources="//@children.42/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.43/@ports.0" targets="//@children.45/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.43/@ports.0" targets="//@children.47/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.43/@ports.0" targets="//@children.53/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.43/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E58" sources="//@children.43/@ports.0" targets="//@children.62/@ports.0"/>
+  <containedEdges identifier="E59" sources="//@children.43/@ports.0" targets="//@children.64/@ports.0"/>
+  <containedEdges identifier="E60" sources="//@children.43/@ports.0" targets="//@children.71/@ports.0"/>
+  <containedEdges identifier="E61" sources="//@children.44/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E62" sources="//@children.45/@ports.2" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.46/@ports.1" targets="//@children.49/@ports.0"/>
+  <containedEdges identifier="E64" sources="//@children.46/@ports.1" targets="//@children.50/@ports.0"/>
+  <containedEdges identifier="E65" sources="//@children.47/@ports.2" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E66" sources="//@children.48/@ports.0" targets="//@children.47/@ports.1"/>
+  <containedEdges identifier="E67" sources="//@children.49/@ports.1" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.50/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E69" sources="//@children.51/@ports.1" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.52/@ports.0" targets="//@children.53/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.53/@ports.2" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.54/@ports.1" targets="//@children.58/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.54/@ports.1" targets="//@children.59/@ports.0"/>
+  <containedEdges identifier="E74" sources="//@children.55/@ports.2" targets="//@children.54/@ports.0"/>
+  <containedEdges identifier="E75" sources="//@children.56/@ports.0" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.57/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E77" sources="//@children.58/@ports.1" targets="//@children.57/@ports.1"/>
+  <containedEdges identifier="E78" sources="//@children.59/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E79" sources="//@children.60/@ports.1" targets="//@children.51/@ports.0"/>
+  <containedEdges identifier="E80" sources="//@children.61/@ports.0" targets="//@children.62/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.62/@ports.2" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.63/@ports.1" targets="//@children.67/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.63/@ports.1" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E84" sources="//@children.64/@ports.2" targets="//@children.63/@ports.0"/>
+  <containedEdges identifier="E85" sources="//@children.65/@ports.0" targets="//@children.64/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.66/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E87" sources="//@children.67/@ports.1" targets="//@children.66/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.68/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E89" sources="//@children.69/@ports.0" targets="//@children.71/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.70/@ports.0" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E91" sources="//@children.71/@ports.2" targets="//@children.72/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.71/@ports.2" targets="//@children.73/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.72/@ports.1" targets="//@children.60/@ports.0"/>
+  <containedEdges identifier="E94" sources="//@children.73/@ports.1" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E95" sources="//@children.74/@ports.0" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E96" sources="//@children.75/@ports.0" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E97" sources="//@children.76/@ports.1" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E98" sources="//@children.77/@ports.1" targets="//@children.78/@ports.0"/>
+  <containedEdges identifier="E99" sources="//@children.77/@ports.1" targets="//@children.83/@ports.0"/>
+  <containedEdges identifier="E100" sources="//@children.78/@ports.2" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E101" sources="//@children.79/@ports.1" targets="//@children.80/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.79/@ports.1" targets="//@children.81/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.79/@ports.1" targets="//@children.84/@ports.0"/>
+  <containedEdges identifier="E104" sources="//@children.80/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E105" sources="//@children.80/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E106" sources="//@children.80/@ports.1" targets="//@children.91/@ports.4"/>
+  <containedEdges identifier="E107" sources="//@children.80/@ports.1" targets="//@children.92/@ports.4"/>
+  <containedEdges identifier="E108" sources="//@children.80/@ports.1" targets="//@children.93/@ports.4"/>
+  <containedEdges identifier="E109" sources="//@children.80/@ports.1" targets="//@children.94/@ports.0"/>
+  <containedEdges identifier="E110" sources="//@children.81/@ports.1" targets="//@children.94/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.82/@ports.1" targets="//@children.78/@ports.1"/>
+  <containedEdges identifier="E112" sources="//@children.83/@ports.1" targets="//@children.94/@ports.2"/>
+  <containedEdges identifier="E113" sources="//@children.84/@ports.1" targets="//@children.82/@ports.0"/>
+  <containedEdges identifier="E114" sources="//@children.85/@ports.1" targets="//@children.86/@ports.0"/>
+  <containedEdges identifier="E115" sources="//@children.86/@ports.1" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E116" sources="//@children.87/@ports.1" targets="//@children.91/@ports.2"/>
+  <containedEdges identifier="E117" sources="//@children.87/@ports.1" targets="//@children.92/@ports.2"/>
+  <containedEdges identifier="E118" sources="//@children.87/@ports.1" targets="//@children.93/@ports.2"/>
+  <containedEdges identifier="E119" sources="//@children.88/@ports.1" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E120" sources="//@children.89/@ports.1" targets="//@children.87/@ports.0"/>
+  <containedEdges identifier="E121" sources="//@children.90/@ports.1" targets="//@children.89/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.91/@ports.3" targets="//@children.94/@ports.4"/>
+  <containedEdges identifier="E123" sources="//@children.92/@ports.3" targets="//@children.94/@ports.4"/>
+  <containedEdges identifier="E124" sources="//@children.93/@ports.3" targets="//@children.94/@ports.4"/>
+  <containedEdges identifier="E125" sources="//@children.94/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E126" sources="//@children.94/@ports.3" targets="//@children.76/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/tm_controllers_Controllers.elkg
+++ b/realworld/ptolemy/flattened/tm_controllers_Controllers.elkg
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Sampler1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="TimedPlotter1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3 //@containedEdges.14 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="63.0" text="InputAdder"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.26 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="74.0" text="OutputAdder"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.27 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="62.0" text="Integrator0"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="65.0" text="Feedback0"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="78.0" text="Feedforward0"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="62.0" text="Integrator1"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="65.0" text="Feedback1"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="78.0" text="Feedforward1"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="63.0" text="Controller1"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="63.0" text="Controller2"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.2" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.18/@ports.2" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.19/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.2" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.20/@ports.2" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.21/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.22/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.23/@ports.2" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.24/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.25/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.26/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.27/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/tm_fft_FFT.elkg
+++ b/realworld/ptolemy/flattened/tm_fft_FFT.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="93.0" text="RealTimePlotter"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="24.0" text="FFT"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="96.0" text="SequenceScope"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Pulse"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="28.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/type_router_Router.elkg
+++ b/realworld/ptolemy/flattened/type_router_Router.elkg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="107.0" text="Record Assembler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="96.0" text="Sequence Count"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="36.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="42.0" text="Square"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="Master Clock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="97.0" text="String Sequence"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="Record Disassembler"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="63.0" text="Sequencer"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="119.0" text="Display As Received"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="127.0" text="Display Resequenced"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="82.0" text="ChannelModel"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/unit_staticunits_StaticUnits.elkg
+++ b/realworld/ptolemy/flattened/unit_staticunits_StaticUnits.elkg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="23.0" text="flow"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="110.0" text="growthAddSubtract"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="238.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="28.0" text="Limit"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="328.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="39.0" text="growth"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="243.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="181.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/unit_staticunits_StaticUnits2.elkg
+++ b/realworld/ptolemy/flattened/unit_staticunits_StaticUnits2.elkg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="49.0" text="flow rate"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="158.0" text="Convert Population to Joule"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="14.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="110.0" text="growthAddSubtract"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="238.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="28.0" text="Limit"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="328.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="39.0" text="growth"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="243.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="181.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/unit_units_Units.elkg
+++ b/realworld/ptolemy/flattened/unit_units_Units.elkg
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="DisplayVoltage"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="54.0" text="InUnitsOf"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="85.0" text="DisplayCurrent"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="41.0" text="Scale1"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="129.0" text="DisplayCurrentInAmps"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/verification_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
+++ b/realworld/ptolemy/flattened/verification_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="1.8571428060531616" y="41.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="11.714285850524902" y="41.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="21.571428298950195" y="41.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.428571701049805" y="41.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.28571319580078" y="41.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="51.14285659790039" y="41.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="48.0" text="Sensors"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="76.0" y="-5.5625">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="76.0" y="-3.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="76.0" y="-0.6875">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="76.0" y="1.75">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="76.0" y="4.1875">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="76.0" y="6.625">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="76.0" y="9.0625" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="76.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="76.0" y="13.9375" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="76.0" y="16.375" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="76.0" y="18.8125">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="76.0" y="21.25">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="76.0" y="23.6875">
+      <properties key="org.eclipse.elk.port.index" value="12"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="76.0" y="26.125">
+      <properties key="org.eclipse.elk.port.index" value="13"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="76.0" y="28.5625">
+      <properties key="org.eclipse.elk.port.index" value="14"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-15"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="36.0" text="Drive2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="76.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="36.0" text="Drive3"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="76.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="36.0" text="Drive4"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="76.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="72.0" text="RotateAngle"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="75.0" text="UnitDistance"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="28.0" text="ADC"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="76.0" y="5.0" outgoingEdges="//@containedEdges.21 //@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="76.0" y="18.0" outgoingEdges="//@containedEdges.24 //@containedEdges.25 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="224.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="212.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="457.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="73.0" text="Expression5"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="473.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="73.0" text="Expression6"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything5"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything6"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.6" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.7" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.8" targets="//@children.13/@ports.3"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.8" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.9" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.7" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.1/@ports.15"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.1" targets="//@children.0/@ports.9"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.0/@ports.10"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.0" targets="//@children.10/@ports.4"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.12/@ports.4"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.0" targets="//@children.13/@ports.4"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.16/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.16/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.16/@ports.1" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.1" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.19/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.20/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.21/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.23/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.24/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.25/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.26/@ports.1" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E38" sources="//@children.27/@ports.1" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E39" sources="//@children.28/@ports.1" targets="//@children.0/@ports.5"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/verification_irobothillclimbing_iRobotCreateVerification.elkg
+++ b/realworld/ptolemy/flattened/verification_irobothillclimbing_iRobotCreateVerification.elkg
@@ -1,0 +1,836 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Slope"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="-1.875" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="10.375" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="22.625" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="-1.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="6.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="13.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="20.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="27.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="34.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.75" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="34.875" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="-1.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="6.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="13.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="20.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="27.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="34.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="-1.875" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="10.375" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="22.625" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="34.875" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="48.0" text="Sensors"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="76.0" y="-5.5625">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="76.0" y="-3.125">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="76.0" y="-0.6875">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="76.0" y="1.75">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="76.0" y="4.1875">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="76.0" y="6.625">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="76.0" y="9.0625" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="76.0" y="11.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="76.0" y="13.9375" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="76.0" y="16.375" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="76.0" y="18.8125">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="76.0" y="21.25">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="76.0" y="23.6875">
+      <properties key="org.eclipse.elk.port.index" value="12"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="76.0" y="26.125">
+      <properties key="org.eclipse.elk.port.index" value="13"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="76.0" y="28.5625">
+      <properties key="org.eclipse.elk.port.index" value="14"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-15"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="39.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="47.0" text="Switch2"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="28.0" text="ADC"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="76.0" y="5.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="76.0" y="18.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="224.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="212.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="47.0" text="Switch2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@containedEdges.33 //@containedEdges.34 //@containedEdges.41 //@containedEdges.44 //@containedEdges.45 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="47.0" text="Switch3"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="457.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression5"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="473.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="73.0" text="Expression6"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="47.0" text="Switch5"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="47.0" text="Switch6"/>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="47.0" text="Switch4"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="119.0" text="BooleanToAnything2"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything4"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="119.0" text="BooleanToAnything5"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="119.0" text="BooleanToAnything6"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.53 //@containedEdges.54 //@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="36.0" text="Drive2"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="76.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="15.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="36.0" text="Drive3"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="76.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="15.399999618530273">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="31.0" width="76.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="36.0" text="Drive4"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="76.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="72.0" text="RotateAngle"/>
+    <ports identifier="P130" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.59 //@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="75.0" text="UnitDistance"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="105.0" text="AnythingToDouble"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.6" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.7" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.8" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.9" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.10" targets="//@children.1/@ports.5"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.1/@ports.9"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.4" targets="//@children.1/@ports.10"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.11" targets="//@children.1/@ports.11"/>
+  <containedEdges identifier="E10" sources="//@children.0/@ports.12" targets="//@children.1/@ports.12"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.6" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.7" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.8" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.8" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.9" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.7" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.2/@ports.6" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.3/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.7/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.9/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.10/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.10/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.10/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.10/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.10/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.11/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.12/@ports.0" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.13/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.14/@ports.0" targets="//@children.30/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.15/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.16/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.17/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.17/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.17/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.17/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.17/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.19/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.20/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.21/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.22/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.23/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E47" sources="//@children.24/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.25/@ports.1" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.26/@ports.1" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E50" sources="//@children.27/@ports.1" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E51" sources="//@children.28/@ports.1" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.29/@ports.1" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.30/@ports.1" targets="//@children.23/@ports.2"/>
+  <containedEdges identifier="E54" sources="//@children.31/@ports.0" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.31/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.31/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E57" sources="//@children.32/@ports.0" targets="//@children.37/@ports.2"/>
+  <containedEdges identifier="E58" sources="//@children.33/@ports.0" targets="//@children.36/@ports.2"/>
+  <containedEdges identifier="E59" sources="//@children.35/@ports.0" targets="//@children.34/@ports.2"/>
+  <containedEdges identifier="E60" sources="//@children.38/@ports.0" targets="//@children.34/@ports.4"/>
+  <containedEdges identifier="E61" sources="//@children.38/@ports.0" targets="//@children.36/@ports.4"/>
+  <containedEdges identifier="E62" sources="//@children.39/@ports.0" targets="//@children.37/@ports.4"/>
+  <containedEdges identifier="E63" sources="//@children.40/@ports.1" targets="//@children.37/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/verification_simpletrafficlight_SimpleTrafficLightDECTA.elkg
+++ b/realworld/ptolemy/flattened/verification_simpletrafficlight_SimpleTrafficLightDECTA.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="89.0" text="CarLightNormal"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="0.1666666716337204" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="32.83333206176758" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="131.0" text="PedestrianLightNormal"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.1" targets="//@children.1/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/vertx_pubsub_Publisher.elkg
+++ b/realworld/ptolemy/flattened/vertx_pubsub_Publisher.elkg
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="98.0" text="VertxBusHandler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="93.0" text="DisplayDate+10"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="105.0" text="VertxBusHandler2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="86.0" text="DisplayDate+5"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="70.0" text="CurrentDate"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="ModifyDate"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="71.0" text="DisplayDate"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="DateToEvent"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/vertx_pubsub_Subscriber.elkg
+++ b/realworld/ptolemy/flattened/vertx_pubsub_Subscriber.elkg
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="98.0" text="VertxBusHandler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="105.0" text="VertxBusHandler2"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="93.0" text="DisplayDate+10"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="86.0" text="DisplayDate+5"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="75.0" text="StringToDate"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="99.0" text="ArrayToElements"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="66.0" text="ModifyDate"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="DateToEvent"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_antennapattern_AntennaModel.elkg
+++ b/realworld/ptolemy/flattened/wireless_antennapattern_AntennaModel.elkg
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="281.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="102.0" text="HammingWindow"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="59.0" text="Normalize"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="111.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="107.0" text="PlaneWavePhasor"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="111.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="113.0" text="SumArrayElements"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="101.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="352.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="352.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="41.0" text="Repeat"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="254.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="254.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="49.0" text="Repeat2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="87.0" text="MultiplyDivide2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="411.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="411.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="254.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="254.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="110.0" text="SequenceToArray2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.1" targets="//@children.4/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_antennapattern_ReceiveAntennaPattern.elkg
+++ b/realworld/ptolemy/flattened/wireless_antennapattern_ReceiveAntennaPattern.elkg
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="99.0" text="CartesianToPolar"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="104.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="99.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="83.0" text="AntennaModel"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.3" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.2" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_antennapattern_TransmitAntennaPattern.elkg
+++ b/realworld/ptolemy/flattened/wireless_antennapattern_TransmitAntennaPattern.elkg
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="99.0" text="CartesianToPolar"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="104.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="99.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="81.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.20 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="83.0" text="AntennaModel"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.3" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.2" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.1" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_collisions_Collisions.elkg
+++ b/realworld/ptolemy/flattened/wireless_collisions_Collisions.elkg
@@ -1,0 +1,545 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="96.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="17.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="CollisionDetector"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16 //@containedEdges.25 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19 //@containedEdges.30 //@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="96.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="36.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="37.0" text="Server"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="17.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="42.0" y="36.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37 //@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="216.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.3" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.4" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.4" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.2" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.3" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.3" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.3" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.2" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.3" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.14/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.14/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.15/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.18/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.18/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.19/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.20/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.21/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.22/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.22/@ports.1" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.23/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.25/@ports.1" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.26/@ports.0" targets="//@children.27/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.26/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.27/@ports.0" targets="//@children.29/@ports.2"/>
+  <containedEdges identifier="E41" sources="//@children.28/@ports.0" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E42" sources="//@children.29/@ports.0" targets="//@children.30/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_collisions_CollisionsDeterministic.elkg
+++ b/realworld/ptolemy/flattened/wireless_collisions_CollisionsDeterministic.elkg
@@ -1,0 +1,441 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="96.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="96.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="99.0" text="CollisionDetector"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="15.5" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17 //@containedEdges.26 //@containedEdges.28 //@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20 //@containedEdges.31 //@containedEdges.33 //@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.3" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.3" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.4" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.4" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.2" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.2" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.3" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.14/@ports.3" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.14/@ports.3" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.15/@ports.2" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.15/@ports.3" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E25" sources="//@children.16/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.16/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.18/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.19/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.20/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.20/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.21/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.22/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.23/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.24/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.24/@ports.1" targets="//@children.23/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_evaderandpursuer_EvaderAndPursuer.elkg
+++ b/realworld/ptolemy/flattened/wireless_evaderandpursuer_EvaderAndPursuer.elkg
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="94.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="94.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="48.0" text="Random"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="modal model"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="81.0" text="Accumulator2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="70.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="70.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="48.0" text="Poisson"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="78.0" text="MostRecent2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="68.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="68.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="46.0" text="Pursuer"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="40.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.15/@ports.3" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.17/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_intersections_Intersections.elkg
+++ b/realworld/ptolemy/flattened/wireless_intersections_Intersections.elkg
@@ -1,0 +1,4128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P117" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P123" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P133" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P147" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P174" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P182" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P191" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P192" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N62" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L62" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N63" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.56">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.57">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P205" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P208" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.58">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.59">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L68" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.61">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N69" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L69" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.60">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N70" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L70" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N71" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L71" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.62">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.63">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N72" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P228" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.64">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.65">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P233" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P234" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.66">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.67">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P240" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.68">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.69">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P252" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.71">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.70">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.72">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.73">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P262" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P266" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.74">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P268" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N85" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L85" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P269" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N86" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L86" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.76">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P273" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.77">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P274" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N87" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P275" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P278" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P279" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P280" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N89" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P286" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P287" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.81">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.80">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P291" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L92" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P292" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N93" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L93" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P295" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.82">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P296" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.83">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P297" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N94" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P298" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N95" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L95" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P301" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.84">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P302" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.85">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P303" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N96" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L96" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P304" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N97" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L97" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P307" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.86">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P308" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.87">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P309" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N98" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L98" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P310" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N99" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L99" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P313" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.88">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P314" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.89">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P315" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N100" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.91">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.90">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P327" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.92">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P331" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.93">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P332" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P333" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P336" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.94">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P337" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.95">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P338" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P339" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P343" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.97">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P345" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N110" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L110" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P348" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.98">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P349" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.99">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P350" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N111" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L111" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P356" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N112" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L112" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P357" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.101">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N113" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L113" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.100">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P361" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N114" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L114" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P362" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N115" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L115" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P365" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.102">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P366" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.103">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P367" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N116" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L116" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P368" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N117" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P371" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.104">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P372" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P373" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N118" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L118" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P374" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N119" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L119" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P377" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.106">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P378" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.107">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N120" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L120" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P380" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N121" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L121" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P383" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.108">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P384" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.109">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P385" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N122" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P388" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P390" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P391" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P392" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.111">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N124" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L124" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P395" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.110">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P396" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N125" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L125" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P397" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N126" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L126" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P400" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.112">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P401" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.113">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P402" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N127" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L127" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P403" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P404" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N128" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L128" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P406" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.114">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P407" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.115">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P408" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N129" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P409" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P411" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P412" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.116">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P413" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.117">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P414" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P415" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P416" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P418" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.118">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P419" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.119">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P420" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P424" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P425" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P426" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P427" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.121">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P430" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.120">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P431" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P432" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P433" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N137" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L137" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P435" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.122">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P436" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.123">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P437" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N138" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P438" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P439" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P440" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P441" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.124">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P442" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.125">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P443" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P444" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P445" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P447" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.126">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P448" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.127">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P449" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P450" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P451" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P453" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.128">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P454" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.129">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P455" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P459" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P461" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P462" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.131">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P463" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P465" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.130">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P466" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P467" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N148" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L148" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P469" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P470" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.132">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P471" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.133">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P472" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N149" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L149" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P473" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N150" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L150" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P475" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P476" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.134">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P477" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.135">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P478" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N151" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L151" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P479" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N152" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L152" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P482" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.136">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P483" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.137">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P484" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N153" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L153" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P485" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P486" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N154" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P487" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P488" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.138">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P489" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.139">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P490" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N155" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L155" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P491" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P493" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P494" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P496" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N156" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L156" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P497" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.141">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P498" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N157" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L157" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.140">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P501" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N158" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L158" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P502" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P503" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N159" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L159" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P504" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P505" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.142">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P506" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.143">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P507" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N160" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L160" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P508" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N161" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L161" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P511" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.144">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P512" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.145">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P513" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N162" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L162" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P514" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N163" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L163" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P516" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P517" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.146">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P518" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.147">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P519" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N164" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L164" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P520" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N165" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L165" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P523" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.148">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P524" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.149">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P525" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N166" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L166" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P526" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P528" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P529" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P531" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N167" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L167" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P532" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.151">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P533" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P534" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N168" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L168" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.150">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P536" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N169" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L169" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P537" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P538" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N170" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L170" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P540" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.152">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P541" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.153">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P542" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N171" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L171" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P543" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P544" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N172" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L172" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P546" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.154">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P547" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.155">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P548" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N173" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L173" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P549" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N174" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L174" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P552" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.156">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P553" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.157">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P554" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N175" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L175" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P555" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P556" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N176" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L176" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P558" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.158">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P559" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.159">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P560" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N177" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P562" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P563" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P564" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P565" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P566" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P567" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.161">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P568" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P570" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.160">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P571" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P572" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N181" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L181" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P574" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P575" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.162">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P576" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.163">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P577" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N182" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L182" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P578" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P579" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N183" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L183" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P581" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.164">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P582" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.165">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P583" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N184" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L184" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P584" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P585" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N185" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L185" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P587" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.166">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P588" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.167">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P589" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N186" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L186" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P590" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N187" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L187" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P592" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P593" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.168">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P594" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.169">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P595" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N188" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L188" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P597" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P598" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P600" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P601" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N189" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L189" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P602" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.171">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P604" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N190" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L190" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P605" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.170">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P606" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N191" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L191" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P607" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N192" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L192" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P609" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P610" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.172">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P611" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.173">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P612" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N193" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L193" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P613" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P614" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N194" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L194" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P616" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.174">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P617" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.175">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P618" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N195" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P619" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P620" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N196" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L196" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P622" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.176">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P623" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.177">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P624" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N197" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L197" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P625" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P626" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N198" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L198" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P628" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.178">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P629" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.179">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P630" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N199" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L199" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P631" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P633" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P634" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P636" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N200" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L200" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P637" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.181">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P638" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P639" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N201" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L201" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.180">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P641" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N202" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L202" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P642" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P643" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N203" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L203" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P645" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.182">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P646" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.183">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P647" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N204" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L204" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P648" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P649" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N205" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L205" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P650" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P651" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.184">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P652" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.185">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P653" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N206" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L206" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P654" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P655" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N207" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L207" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P656" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P657" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.186">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P658" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.187">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P659" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N208" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L208" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P660" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P661" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N209" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L209" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P662" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P663" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.188">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P664" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.189">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P665" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N210" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L210" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P666" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P667" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P670" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P671" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N211" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L211" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P672" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.191">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P673" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P674" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N212" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L212" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.190">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P676" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N213" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L213" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P677" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P678" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N214" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L214" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P679" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P680" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.192">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P681" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.193">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P682" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N215" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L215" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P683" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P684" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N216" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L216" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P685" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P686" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.194">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P687" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.195">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P688" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N217" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L217" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P689" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P690" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N218" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L218" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P691" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P692" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.196">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P693" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.197">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P694" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N219" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L219" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P695" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P696" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N220" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L220" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P698" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.198">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P699" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.199">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P700" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.5" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.2" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.2" targets="//@children.11/@ports.4"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.2" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.20/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.21/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.22/@ports.5" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.23/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.25/@ports.0" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.26/@ports.2" targets="//@children.22/@ports.3"/>
+  <containedEdges identifier="E25" sources="//@children.27/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.28/@ports.2" targets="//@children.22/@ports.4"/>
+  <containedEdges identifier="E27" sources="//@children.29/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.30/@ports.2" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.31/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.32/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.33/@ports.5" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.34/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.36/@ports.0" targets="//@children.37/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.37/@ports.2" targets="//@children.33/@ports.3"/>
+  <containedEdges identifier="E35" sources="//@children.38/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.39/@ports.2" targets="//@children.33/@ports.4"/>
+  <containedEdges identifier="E37" sources="//@children.40/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.41/@ports.2" targets="//@children.33/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.42/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E40" sources="//@children.43/@ports.2" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.44/@ports.5" targets="//@children.46/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.45/@ports.0" targets="//@children.44/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.47/@ports.0" targets="//@children.48/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.48/@ports.2" targets="//@children.44/@ports.3"/>
+  <containedEdges identifier="E45" sources="//@children.49/@ports.0" targets="//@children.50/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.50/@ports.2" targets="//@children.44/@ports.4"/>
+  <containedEdges identifier="E47" sources="//@children.51/@ports.0" targets="//@children.52/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.52/@ports.2" targets="//@children.44/@ports.2"/>
+  <containedEdges identifier="E49" sources="//@children.53/@ports.0" targets="//@children.54/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.54/@ports.2" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.55/@ports.5" targets="//@children.57/@ports.0"/>
+  <containedEdges identifier="E52" sources="//@children.56/@ports.0" targets="//@children.55/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.58/@ports.0" targets="//@children.59/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.59/@ports.2" targets="//@children.55/@ports.3"/>
+  <containedEdges identifier="E55" sources="//@children.60/@ports.0" targets="//@children.61/@ports.1"/>
+  <containedEdges identifier="E56" sources="//@children.61/@ports.2" targets="//@children.55/@ports.4"/>
+  <containedEdges identifier="E57" sources="//@children.62/@ports.0" targets="//@children.63/@ports.1"/>
+  <containedEdges identifier="E58" sources="//@children.63/@ports.2" targets="//@children.55/@ports.2"/>
+  <containedEdges identifier="E59" sources="//@children.64/@ports.0" targets="//@children.65/@ports.1"/>
+  <containedEdges identifier="E60" sources="//@children.65/@ports.2" targets="//@children.55/@ports.1"/>
+  <containedEdges identifier="E61" sources="//@children.66/@ports.5" targets="//@children.68/@ports.0"/>
+  <containedEdges identifier="E62" sources="//@children.67/@ports.0" targets="//@children.66/@ports.0"/>
+  <containedEdges identifier="E63" sources="//@children.69/@ports.0" targets="//@children.70/@ports.1"/>
+  <containedEdges identifier="E64" sources="//@children.70/@ports.2" targets="//@children.66/@ports.3"/>
+  <containedEdges identifier="E65" sources="//@children.71/@ports.0" targets="//@children.72/@ports.1"/>
+  <containedEdges identifier="E66" sources="//@children.72/@ports.2" targets="//@children.66/@ports.4"/>
+  <containedEdges identifier="E67" sources="//@children.73/@ports.0" targets="//@children.74/@ports.1"/>
+  <containedEdges identifier="E68" sources="//@children.74/@ports.2" targets="//@children.66/@ports.2"/>
+  <containedEdges identifier="E69" sources="//@children.75/@ports.0" targets="//@children.76/@ports.1"/>
+  <containedEdges identifier="E70" sources="//@children.76/@ports.2" targets="//@children.66/@ports.1"/>
+  <containedEdges identifier="E71" sources="//@children.77/@ports.5" targets="//@children.79/@ports.0"/>
+  <containedEdges identifier="E72" sources="//@children.78/@ports.0" targets="//@children.77/@ports.0"/>
+  <containedEdges identifier="E73" sources="//@children.80/@ports.0" targets="//@children.81/@ports.1"/>
+  <containedEdges identifier="E74" sources="//@children.81/@ports.2" targets="//@children.77/@ports.3"/>
+  <containedEdges identifier="E75" sources="//@children.82/@ports.0" targets="//@children.83/@ports.1"/>
+  <containedEdges identifier="E76" sources="//@children.83/@ports.2" targets="//@children.77/@ports.4"/>
+  <containedEdges identifier="E77" sources="//@children.84/@ports.0" targets="//@children.85/@ports.1"/>
+  <containedEdges identifier="E78" sources="//@children.85/@ports.2" targets="//@children.77/@ports.2"/>
+  <containedEdges identifier="E79" sources="//@children.86/@ports.0" targets="//@children.87/@ports.1"/>
+  <containedEdges identifier="E80" sources="//@children.87/@ports.2" targets="//@children.77/@ports.1"/>
+  <containedEdges identifier="E81" sources="//@children.88/@ports.5" targets="//@children.90/@ports.0"/>
+  <containedEdges identifier="E82" sources="//@children.89/@ports.0" targets="//@children.88/@ports.0"/>
+  <containedEdges identifier="E83" sources="//@children.91/@ports.0" targets="//@children.92/@ports.1"/>
+  <containedEdges identifier="E84" sources="//@children.92/@ports.2" targets="//@children.88/@ports.3"/>
+  <containedEdges identifier="E85" sources="//@children.93/@ports.0" targets="//@children.94/@ports.1"/>
+  <containedEdges identifier="E86" sources="//@children.94/@ports.2" targets="//@children.88/@ports.4"/>
+  <containedEdges identifier="E87" sources="//@children.95/@ports.0" targets="//@children.96/@ports.1"/>
+  <containedEdges identifier="E88" sources="//@children.96/@ports.2" targets="//@children.88/@ports.2"/>
+  <containedEdges identifier="E89" sources="//@children.97/@ports.0" targets="//@children.98/@ports.1"/>
+  <containedEdges identifier="E90" sources="//@children.98/@ports.2" targets="//@children.88/@ports.1"/>
+  <containedEdges identifier="E91" sources="//@children.99/@ports.5" targets="//@children.101/@ports.0"/>
+  <containedEdges identifier="E92" sources="//@children.100/@ports.0" targets="//@children.99/@ports.0"/>
+  <containedEdges identifier="E93" sources="//@children.102/@ports.0" targets="//@children.103/@ports.1"/>
+  <containedEdges identifier="E94" sources="//@children.103/@ports.2" targets="//@children.99/@ports.3"/>
+  <containedEdges identifier="E95" sources="//@children.104/@ports.0" targets="//@children.105/@ports.1"/>
+  <containedEdges identifier="E96" sources="//@children.105/@ports.2" targets="//@children.99/@ports.4"/>
+  <containedEdges identifier="E97" sources="//@children.106/@ports.0" targets="//@children.107/@ports.1"/>
+  <containedEdges identifier="E98" sources="//@children.107/@ports.2" targets="//@children.99/@ports.2"/>
+  <containedEdges identifier="E99" sources="//@children.108/@ports.0" targets="//@children.109/@ports.1"/>
+  <containedEdges identifier="E100" sources="//@children.109/@ports.2" targets="//@children.99/@ports.1"/>
+  <containedEdges identifier="E101" sources="//@children.110/@ports.5" targets="//@children.112/@ports.0"/>
+  <containedEdges identifier="E102" sources="//@children.111/@ports.0" targets="//@children.110/@ports.0"/>
+  <containedEdges identifier="E103" sources="//@children.113/@ports.0" targets="//@children.114/@ports.1"/>
+  <containedEdges identifier="E104" sources="//@children.114/@ports.2" targets="//@children.110/@ports.3"/>
+  <containedEdges identifier="E105" sources="//@children.115/@ports.0" targets="//@children.116/@ports.1"/>
+  <containedEdges identifier="E106" sources="//@children.116/@ports.2" targets="//@children.110/@ports.4"/>
+  <containedEdges identifier="E107" sources="//@children.117/@ports.0" targets="//@children.118/@ports.1"/>
+  <containedEdges identifier="E108" sources="//@children.118/@ports.2" targets="//@children.110/@ports.2"/>
+  <containedEdges identifier="E109" sources="//@children.119/@ports.0" targets="//@children.120/@ports.1"/>
+  <containedEdges identifier="E110" sources="//@children.120/@ports.2" targets="//@children.110/@ports.1"/>
+  <containedEdges identifier="E111" sources="//@children.121/@ports.5" targets="//@children.123/@ports.0"/>
+  <containedEdges identifier="E112" sources="//@children.122/@ports.0" targets="//@children.121/@ports.0"/>
+  <containedEdges identifier="E113" sources="//@children.124/@ports.0" targets="//@children.125/@ports.1"/>
+  <containedEdges identifier="E114" sources="//@children.125/@ports.2" targets="//@children.121/@ports.3"/>
+  <containedEdges identifier="E115" sources="//@children.126/@ports.0" targets="//@children.127/@ports.1"/>
+  <containedEdges identifier="E116" sources="//@children.127/@ports.2" targets="//@children.121/@ports.4"/>
+  <containedEdges identifier="E117" sources="//@children.128/@ports.0" targets="//@children.129/@ports.1"/>
+  <containedEdges identifier="E118" sources="//@children.129/@ports.2" targets="//@children.121/@ports.2"/>
+  <containedEdges identifier="E119" sources="//@children.130/@ports.0" targets="//@children.131/@ports.1"/>
+  <containedEdges identifier="E120" sources="//@children.131/@ports.2" targets="//@children.121/@ports.1"/>
+  <containedEdges identifier="E121" sources="//@children.132/@ports.5" targets="//@children.134/@ports.0"/>
+  <containedEdges identifier="E122" sources="//@children.133/@ports.0" targets="//@children.132/@ports.0"/>
+  <containedEdges identifier="E123" sources="//@children.135/@ports.0" targets="//@children.136/@ports.1"/>
+  <containedEdges identifier="E124" sources="//@children.136/@ports.2" targets="//@children.132/@ports.3"/>
+  <containedEdges identifier="E125" sources="//@children.137/@ports.0" targets="//@children.138/@ports.1"/>
+  <containedEdges identifier="E126" sources="//@children.138/@ports.2" targets="//@children.132/@ports.4"/>
+  <containedEdges identifier="E127" sources="//@children.139/@ports.0" targets="//@children.140/@ports.1"/>
+  <containedEdges identifier="E128" sources="//@children.140/@ports.2" targets="//@children.132/@ports.2"/>
+  <containedEdges identifier="E129" sources="//@children.141/@ports.0" targets="//@children.142/@ports.1"/>
+  <containedEdges identifier="E130" sources="//@children.142/@ports.2" targets="//@children.132/@ports.1"/>
+  <containedEdges identifier="E131" sources="//@children.143/@ports.5" targets="//@children.145/@ports.0"/>
+  <containedEdges identifier="E132" sources="//@children.144/@ports.0" targets="//@children.143/@ports.0"/>
+  <containedEdges identifier="E133" sources="//@children.146/@ports.0" targets="//@children.147/@ports.1"/>
+  <containedEdges identifier="E134" sources="//@children.147/@ports.2" targets="//@children.143/@ports.3"/>
+  <containedEdges identifier="E135" sources="//@children.148/@ports.0" targets="//@children.149/@ports.1"/>
+  <containedEdges identifier="E136" sources="//@children.149/@ports.2" targets="//@children.143/@ports.4"/>
+  <containedEdges identifier="E137" sources="//@children.150/@ports.0" targets="//@children.151/@ports.1"/>
+  <containedEdges identifier="E138" sources="//@children.151/@ports.2" targets="//@children.143/@ports.2"/>
+  <containedEdges identifier="E139" sources="//@children.152/@ports.0" targets="//@children.153/@ports.1"/>
+  <containedEdges identifier="E140" sources="//@children.153/@ports.2" targets="//@children.143/@ports.1"/>
+  <containedEdges identifier="E141" sources="//@children.154/@ports.5" targets="//@children.156/@ports.0"/>
+  <containedEdges identifier="E142" sources="//@children.155/@ports.0" targets="//@children.154/@ports.0"/>
+  <containedEdges identifier="E143" sources="//@children.157/@ports.0" targets="//@children.158/@ports.1"/>
+  <containedEdges identifier="E144" sources="//@children.158/@ports.2" targets="//@children.154/@ports.3"/>
+  <containedEdges identifier="E145" sources="//@children.159/@ports.0" targets="//@children.160/@ports.1"/>
+  <containedEdges identifier="E146" sources="//@children.160/@ports.2" targets="//@children.154/@ports.4"/>
+  <containedEdges identifier="E147" sources="//@children.161/@ports.0" targets="//@children.162/@ports.1"/>
+  <containedEdges identifier="E148" sources="//@children.162/@ports.2" targets="//@children.154/@ports.2"/>
+  <containedEdges identifier="E149" sources="//@children.163/@ports.0" targets="//@children.164/@ports.1"/>
+  <containedEdges identifier="E150" sources="//@children.164/@ports.2" targets="//@children.154/@ports.1"/>
+  <containedEdges identifier="E151" sources="//@children.165/@ports.5" targets="//@children.167/@ports.0"/>
+  <containedEdges identifier="E152" sources="//@children.166/@ports.0" targets="//@children.165/@ports.0"/>
+  <containedEdges identifier="E153" sources="//@children.168/@ports.0" targets="//@children.169/@ports.1"/>
+  <containedEdges identifier="E154" sources="//@children.169/@ports.2" targets="//@children.165/@ports.3"/>
+  <containedEdges identifier="E155" sources="//@children.170/@ports.0" targets="//@children.171/@ports.1"/>
+  <containedEdges identifier="E156" sources="//@children.171/@ports.2" targets="//@children.165/@ports.4"/>
+  <containedEdges identifier="E157" sources="//@children.172/@ports.0" targets="//@children.173/@ports.1"/>
+  <containedEdges identifier="E158" sources="//@children.173/@ports.2" targets="//@children.165/@ports.2"/>
+  <containedEdges identifier="E159" sources="//@children.174/@ports.0" targets="//@children.175/@ports.1"/>
+  <containedEdges identifier="E160" sources="//@children.175/@ports.2" targets="//@children.165/@ports.1"/>
+  <containedEdges identifier="E161" sources="//@children.176/@ports.5" targets="//@children.178/@ports.0"/>
+  <containedEdges identifier="E162" sources="//@children.177/@ports.0" targets="//@children.176/@ports.0"/>
+  <containedEdges identifier="E163" sources="//@children.179/@ports.0" targets="//@children.180/@ports.1"/>
+  <containedEdges identifier="E164" sources="//@children.180/@ports.2" targets="//@children.176/@ports.3"/>
+  <containedEdges identifier="E165" sources="//@children.181/@ports.0" targets="//@children.182/@ports.1"/>
+  <containedEdges identifier="E166" sources="//@children.182/@ports.2" targets="//@children.176/@ports.4"/>
+  <containedEdges identifier="E167" sources="//@children.183/@ports.0" targets="//@children.184/@ports.1"/>
+  <containedEdges identifier="E168" sources="//@children.184/@ports.2" targets="//@children.176/@ports.2"/>
+  <containedEdges identifier="E169" sources="//@children.185/@ports.0" targets="//@children.186/@ports.1"/>
+  <containedEdges identifier="E170" sources="//@children.186/@ports.2" targets="//@children.176/@ports.1"/>
+  <containedEdges identifier="E171" sources="//@children.187/@ports.5" targets="//@children.189/@ports.0"/>
+  <containedEdges identifier="E172" sources="//@children.188/@ports.0" targets="//@children.187/@ports.0"/>
+  <containedEdges identifier="E173" sources="//@children.190/@ports.0" targets="//@children.191/@ports.1"/>
+  <containedEdges identifier="E174" sources="//@children.191/@ports.2" targets="//@children.187/@ports.3"/>
+  <containedEdges identifier="E175" sources="//@children.192/@ports.0" targets="//@children.193/@ports.1"/>
+  <containedEdges identifier="E176" sources="//@children.193/@ports.2" targets="//@children.187/@ports.4"/>
+  <containedEdges identifier="E177" sources="//@children.194/@ports.0" targets="//@children.195/@ports.1"/>
+  <containedEdges identifier="E178" sources="//@children.195/@ports.2" targets="//@children.187/@ports.2"/>
+  <containedEdges identifier="E179" sources="//@children.196/@ports.0" targets="//@children.197/@ports.1"/>
+  <containedEdges identifier="E180" sources="//@children.197/@ports.2" targets="//@children.187/@ports.1"/>
+  <containedEdges identifier="E181" sources="//@children.198/@ports.5" targets="//@children.200/@ports.0"/>
+  <containedEdges identifier="E182" sources="//@children.199/@ports.0" targets="//@children.198/@ports.0"/>
+  <containedEdges identifier="E183" sources="//@children.201/@ports.0" targets="//@children.202/@ports.1"/>
+  <containedEdges identifier="E184" sources="//@children.202/@ports.2" targets="//@children.198/@ports.3"/>
+  <containedEdges identifier="E185" sources="//@children.203/@ports.0" targets="//@children.204/@ports.1"/>
+  <containedEdges identifier="E186" sources="//@children.204/@ports.2" targets="//@children.198/@ports.4"/>
+  <containedEdges identifier="E187" sources="//@children.205/@ports.0" targets="//@children.206/@ports.1"/>
+  <containedEdges identifier="E188" sources="//@children.206/@ports.2" targets="//@children.198/@ports.2"/>
+  <containedEdges identifier="E189" sources="//@children.207/@ports.0" targets="//@children.208/@ports.1"/>
+  <containedEdges identifier="E190" sources="//@children.208/@ports.2" targets="//@children.198/@ports.1"/>
+  <containedEdges identifier="E191" sources="//@children.209/@ports.5" targets="//@children.211/@ports.0"/>
+  <containedEdges identifier="E192" sources="//@children.210/@ports.0" targets="//@children.209/@ports.0"/>
+  <containedEdges identifier="E193" sources="//@children.212/@ports.0" targets="//@children.213/@ports.1"/>
+  <containedEdges identifier="E194" sources="//@children.213/@ports.2" targets="//@children.209/@ports.3"/>
+  <containedEdges identifier="E195" sources="//@children.214/@ports.0" targets="//@children.215/@ports.1"/>
+  <containedEdges identifier="E196" sources="//@children.215/@ports.2" targets="//@children.209/@ports.4"/>
+  <containedEdges identifier="E197" sources="//@children.216/@ports.0" targets="//@children.217/@ports.1"/>
+  <containedEdges identifier="E198" sources="//@children.217/@ports.2" targets="//@children.209/@ports.2"/>
+  <containedEdges identifier="E199" sources="//@children.218/@ports.0" targets="//@children.219/@ports.1"/>
+  <containedEdges identifier="E200" sources="//@children.219/@ports.2" targets="//@children.209/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_intersections_PedestrianLight.elkg
+++ b/realworld/ptolemy/flattened/wireless_intersections_PedestrianLight.elkg
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="139.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="150.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="144.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="135.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="94.0" text="BooleanSwitch4"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.2" targets="//@children.0/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_network_MacReception.elkg
+++ b/realworld/ptolemy/flattened/wireless_network_MacReception.elkg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="79.0" text="ChannelState"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="62.0" text="FilterMpdu"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="79.0" text="ValidateMpdu"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Rxdata"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Rxstart"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="40.0" text="RxEnd"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_network_SimpleModel.elkg
+++ b/realworld/ptolemy/flattened/wireless_network_SimpleModel.elkg
@@ -1,0 +1,568 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="99.0" text="CollisionDetector"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="TimePlotter"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="79.0" text="VariableDelay"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="VariableDelay2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="52.0" text="Uniform2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="112.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="112.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="99.0" text="CollisionDetector"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="79.0" text="VariableDelay"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="87.0" text="VariableDelay2"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="52.0" text="Uniform2"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="112.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="112.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.31 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.4" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.3" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.14/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.16/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.17/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.2" targets="//@children.18/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.4" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.18/@ports.3" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.21/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.23/@ports.0" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.24/@ports.1" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.25/@ports.0" targets="//@children.24/@ports.2"/>
+  <containedEdges identifier="E29" sources="//@children.26/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.27/@ports.2" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.27/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.28/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.28/@ports.2" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.28/@ports.3" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.30/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.30/@ports.0" targets="//@children.23/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_personalareanetwork_Bluetooth2devices.elkg
+++ b/realworld/ptolemy/flattened/wireless_personalareanetwork_Bluetooth2devices.elkg
@@ -1,0 +1,663 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="19.0" text="RD"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="63.0" text="Hold mode"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="75.0" text="Comparator3"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.26 //@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="75.0" text="Comparator4"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18 //@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="75.0" text="Comparator5"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31 //@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="127.0" text="Output if in sniff mode"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="131.0" text="Output if in Data mode"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="73.0" text="Expression4"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.38 //@containedEdges.40 //@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="79.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="79.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="94.0" text="BooleanSwitch5"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.41 //@containedEdges.42 //@containedEdges.43 //@containedEdges.44 //@containedEdges.45 //@containedEdges.46 //@containedEdges.47 //@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="94.0" text="BooleanSwitch6"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="39.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="25.0" width="82.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="82.0" y="8.5" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.2" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.9/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.10/@ports.2" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.11/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.11/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.12/@ports.2" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.14/@ports.2" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.14/@ports.2" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.15/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.16/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.16/@ports.2" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.16/@ports.2" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.18/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.19/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.20/@ports.0" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.20/@ports.0" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.21/@ports.0" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.22/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.23/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.24/@ports.2" targets="//@children.26/@ports.1"/>
+  <containedEdges identifier="E39" sources="//@children.25/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.28/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.29/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.30/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.30/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E44" sources="//@children.30/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.30/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.30/@ports.0" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.30/@ports.0" targets="//@children.28/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.30/@ports.0" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.30/@ports.0" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.30/@ports.0" targets="//@children.34/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.31/@ports.3" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E52" sources="//@children.32/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.33/@ports.0" targets="//@children.35/@ports.0"/>
+  <containedEdges identifier="E54" sources="//@children.34/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E55" sources="//@children.35/@ports.2" targets="//@children.27/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_personalareanetwork_PersonalAreaNetwork.elkg
+++ b/realworld/ptolemy/flattened/wireless_personalareanetwork_PersonalAreaNetwork.elkg
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="98.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="98.0" y="8.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="98.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="98.0" y="8.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_personalareanetwork_PersonalAreaNetwork2.elkg
+++ b/realworld/ptolemy/flattened/wireless_personalareanetwork_PersonalAreaNetwork2.elkg
@@ -1,0 +1,798 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="21.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.23 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.24 //@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.26 //@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29 //@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.35 //@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.35 //@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.36 //@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="40.0" text="Equals"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.40 //@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.45 //@containedEdges.46 //@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.50 //@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.52 //@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="25.0" width="37.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="25.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="21.0" y="8.5" outgoingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.53">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.55">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.0" targets="//@children.15/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.0" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.0" targets="//@children.17/@ports.3"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.2" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.20/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.20/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.21/@ports.2" targets="//@children.22/@ports.2"/>
+  <containedEdges identifier="E27" sources="//@children.22/@ports.0" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.22/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.23/@ports.2" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.24/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.25/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E32" sources="//@children.25/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.25/@ports.3" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.26/@ports.1" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.29/@ports.2" targets="//@children.32/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.30/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E37" sources="//@children.30/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E38" sources="//@children.31/@ports.2" targets="//@children.32/@ports.2"/>
+  <containedEdges identifier="E39" sources="//@children.32/@ports.0" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.33/@ports.2" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E41" sources="//@children.34/@ports.0" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.35/@ports.1" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E43" sources="//@children.35/@ports.2" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.35/@ports.3" targets="//@children.36/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.36/@ports.1" targets="//@children.33/@ports.1"/>
+  <containedEdges identifier="E46" sources="//@children.37/@ports.0" targets="//@children.39/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.37/@ports.0" targets="//@children.40/@ports.1"/>
+  <containedEdges identifier="E48" sources="//@children.37/@ports.0" targets="//@children.44/@ports.1"/>
+  <containedEdges identifier="E49" sources="//@children.39/@ports.0" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E50" sources="//@children.40/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E51" sources="//@children.41/@ports.0" targets="//@children.43/@ports.2"/>
+  <containedEdges identifier="E52" sources="//@children.41/@ports.0" targets="//@children.45/@ports.2"/>
+  <containedEdges identifier="E53" sources="//@children.42/@ports.0" targets="//@children.43/@ports.1"/>
+  <containedEdges identifier="E54" sources="//@children.42/@ports.0" targets="//@children.45/@ports.1"/>
+  <containedEdges identifier="E55" sources="//@children.43/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E56" sources="//@children.44/@ports.0" targets="//@children.45/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_smallworld_SmallWorldRouter.elkg
+++ b/realworld/ptolemy/flattened/wireless_smallworld_SmallWorldRouter.elkg
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="Disassembler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="166.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="48.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="48.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="55.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="52.0" text="Uniform2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23 //@containedEdges.24 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.3" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.12/@ports.3"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.12/@ports.4"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.13/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.13/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.14/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.15/@ports.0" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.16/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.17/@ports.0" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.18/@ports.0" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.19/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.19/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.19/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.19/@ports.1" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.20/@ports.0" targets="//@children.21/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_smallworld_SmallWorldRouter_loss.elkg
+++ b/realworld/ptolemy/flattened/wireless_smallworld_SmallWorldRouter_loss.elkg
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="48.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="48.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="50.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="55.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="80.0" text="Disassembler"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="57.0" text="Previous2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="94.0" text="BooleanSwitch3"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17 //@containedEdges.18 //@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="115.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.15/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.16/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.17/@ports.1" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.18/@ports.0" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_smartparking_LotSensor.elkg
+++ b/realworld/ptolemy/flattened/wireless_smartparking_LotSensor.elkg
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.9 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="187.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="187.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="44.0" text="Merge2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.15 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="21.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="187.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="187.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="111.0" text="RecordAssembler2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="48.0" text="initialize"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="52.0" text="Discard2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.3" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.3" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.14/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_smartparking_SmartParking.elkg
+++ b/realworld/ptolemy/flattened/wireless_smartparking_SmartParking.elkg
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="99.0" text="WirelessToWired"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="dataCollector"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="79.0" text="VariableDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="ParkingClient"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="car arrival"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.3" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_terrainmodel_TerrainModel2.elkg
+++ b/realworld/ptolemy/flattened/wireless_terrainmodel_TerrainModel2.elkg
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="220.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="GetProperties"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="79.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="79.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.10/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_wirelesssounddetection_WirelessSoundDetectionContinuous.elkg
+++ b/realworld/ptolemy/flattened/wireless_wirelesssounddetection_WirelessSoundDetectionContinuous.elkg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="ChangeLocation"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="1:Integrator"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="15.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="15.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="47.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="114.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="114.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Triangulator"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="79.0" text="ArrayElement"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="87.0" text="ArrayElement2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/wireless_zigbee_Zigbee.elkg
+++ b/realworld/ptolemy/flattened/wireless_zigbee_Zigbee.elkg
@@ -1,0 +1,621 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="611.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="611.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="WiredToWireless"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="WirelessToWired"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="106.0" text="WirelessToWired2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="106.0" text="WirelessToWired3"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.22 //@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.32 //@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="83.0" text="MonitorValue2"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.2" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.2" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.20/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.20/@ports.2" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.23/@ports.0" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.24/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.26/@ports.2" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.26/@ports.2" targets="//@children.29/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.26/@ports.1" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.29/@ports.0" targets="//@children.30/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.30/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.32/@ports.2" targets="//@children.33/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.32/@ports.2" targets="//@children.35/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.32/@ports.1" targets="//@children.34/@ports.0"/>
+  <containedEdges identifier="E31" sources="//@children.35/@ports.0" targets="//@children.36/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.36/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.38/@ports.2" targets="//@children.39/@ports.0"/>
+  <containedEdges identifier="E34" sources="//@children.38/@ports.2" targets="//@children.41/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.38/@ports.1" targets="//@children.40/@ports.0"/>
+  <containedEdges identifier="E36" sources="//@children.41/@ports.0" targets="//@children.42/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.42/@ports.0" targets="//@children.43/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_MOMLFileTransformation.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_MOMLFileTransformation.elkg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="177.0" text="Display - Remove Redundancy"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="70.0" width="261.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="31.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="89.0" text="StringReplace2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="89.0" text="StringReplace3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="171.0" text="Display2 - Remove Repetition"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="163.0" text="Display3 - File Combination "/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="80.0" text="StringToXML3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="180.0" text="Display4 - Rearrange Hierarchy"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="98.0" text="XSLTransformer2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="98.0" text="XSLTransformer3"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.3" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.3" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.3" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.1" targets="//@children.16/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformer2.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformer2.elkg
@@ -1,0 +1,385 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="177.0" text="Display - Remove Redundancy"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="70.0" width="261.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="31.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="89.0" text="StringReplace2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="89.0" text="StringReplace3"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="171.0" text="Display2 - Remove Repetition"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="160.0" text="Display3 - File Combination"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="80.0" text="StringToXML3"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="180.0" text="Display4 - Rearrange Hierarchy"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="60.0" text="LineWriter"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="98.0" text="XSLTransformer2"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="98.0" text="XSLTransformer3"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.3" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.3" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.3" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.0" targets="//@children.20/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.20/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.20/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.21/@ports.1" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.21/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.22/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.22/@ports.1" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformer3.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformer3.elkg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="70.0" width="261.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="31.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="89.0" text="StringReplace2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="89.0" text="StringReplace3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="80.0" text="StringToXML3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="60.0" text="LineWriter"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="98.0" text="XSLTransformer2"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="98.0" text="XSLTransformer3"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.20 //@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.3" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.3" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.3" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.19/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.19/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.20/@ports.1" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.20/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.21/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.21/@ports.1" targets="//@children.18/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformerUsingIterateOverArray.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformerUsingIterateOverArray.elkg
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="70.0" width="261.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="31.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="58.0" text="ArraySum"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="89.0" text="StringReplace2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="98.0" text="XSLTransformer2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.3" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.12/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.1" targets="//@children.11/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformerUsingXMLInclusion.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_XMLFileTransformerUsingXMLInclusion.elkg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="52.0" text="OUTPUT"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="220.0" text="XSLTransformer - Rearrange Hierarchy"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="XMLInclusion"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="209.0" text="XSLTransformer - Remove One layer"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Combination"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="224.0" text="XSLTransformer - Remove Redundancy"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="211.0" text="XSLTransformer - Remove Repetition"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="80.0" text="StringToXML3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.3" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLFile1.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLFile1.elkg
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="98.0" text="XSLTransformer2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="60.0" text="LineWriter"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.8/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLFile6.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLFile6.elkg
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="60.0" text="LineWriter"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.9/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLfile4.elkg
+++ b/realworld/ptolemy/flattened/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLfile4.elkg
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="98.0" text="XSLTransformer2"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="89.0" text="StringReplace2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="74.0" text="Accumulator"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="DownSample"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="89.0" text="StringReplace3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="70.0" width="261.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="31.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.3" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.0" targets="//@children.11/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/flattened/xslt_xmlinclusiondemo_XMLInclusionDemo.elkg
+++ b/realworld/ptolemy/flattened/xslt_xmlinclusiondemo_XMLInclusionDemo.elkg
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="145.0" width="324.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="53.0" text="Template"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="324.0" y="68.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="68.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="StringToXML1"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="XMLInclusion"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="80.0" text="StringToXML2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="StringToXML3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="107.0" text="ElementsToArray2"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="85.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="240.0" y="38.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="38.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="85.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="240.0" y="38.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="38.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="85.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="76.0" text="StringConst3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="240.0" y="38.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="38.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="85.0" width="240.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="76.0" text="StringConst4"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="240.0" y="38.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="38.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/algebraic_heateropentank_HeaterOpenTank.elkg
+++ b/realworld/ptolemy/hierarchical/algebraic_heateropentank_HeaterOpenTank.elkg
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="27.0" text="Tank"/>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.3" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.7" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.4 //@children.0/@containedEdges.8" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="15.0" text="dp"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6 //@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="25.0" width="106.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="106.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="185.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="185.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E26" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.0/@ports.7" targets="//@children.0/@children.0/@children.2/@ports.3"/>
+      <containedEdges identifier="E31" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.6"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.3"/>
+    </children>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="35.0" text="Pump"/>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.13" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.9" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.0 //@children.0/@containedEdges.12" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.10" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.11" incomingEdges="//@children.0/@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N8" height="25.0" width="146.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E36" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.1/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.5"/>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="39.0" text="Heater"/>
+      <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.18" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.14" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.2/@containedEdges.0 //@children.0/@containedEdges.17" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.15" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.2/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.16" incomingEdges="//@children.0/@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="25.0" width="149.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="149.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E39" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.2/@ports.5" targets="//@children.0/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.2/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.6"/>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.4" targets="//@children.0/@children.0/@ports.7"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.0/@ports.4" targets="//@children.0/@children.1/@ports.4"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.6" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.7" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@children.2/@ports.3"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.5" targets="//@children.0/@children.2/@ports.5"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.1/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.2/@ports.6" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@children.2/@ports.4"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@ports.2"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="27.0" text="TSet"/>
+    <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="76.0" text="SingleEvent3"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E42" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="83.0" text="QSSIntegrator"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.0/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/algebraic_heateropentank_HeaterOpenTankRefactored.elkg
+++ b/realworld/ptolemy/hierarchical/algebraic_heateropentank_HeaterOpenTankRefactored.elkg
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="27.0" text="TSet"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="76.0" text="SingleEvent3"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="141.0" text="CalculateMassFlowRate"/>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.1/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6" height="25.0" width="156.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="124.0" text="heaterOutletPressure"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="156.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="202.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="120.0" text="pumpOutletPressure"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="15.0" text="dp"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="189.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="massFlowRate"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="189.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.10 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="83.0" text="QSSIntegrator"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="124.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="124.0" y="8.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="106.0" text="MostRecent_mdot"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.0 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="95.0" text="MostRecent_TIn"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13 //@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.2 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="85.0" text="MostRecent_T"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.9 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.7/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.7/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.8/@ports.1" targets="//@children.5/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/algebraic_rlc_RLC.elkg
+++ b/realworld/ptolemy/hierarchical/algebraic_rlc_RLC.elkg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="CapacitorGain"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Capacitor"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="83.0" text="AlgebraicLoop"/>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.2/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="73.0" text="Resistance1"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6 //@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="73.0" text="Resistance2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.2/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@ports.3" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@ports.4"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="85.0" text="VoltageSource"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="92.0" text="VoltageSource2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="47.0" text="Inductor"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="74.0" text="InductorGain"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.4" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/aspect_canbus_CanBusVariousCollisions.elkg
+++ b/realworld/ptolemy/hierarchical/aspect_canbus_CanBusVariousCollisions.elkg
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="19.0" text="DC"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="26.0" text="DC2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="17.0" text="B1"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.4" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.5 //@containedEdges.8 //@containedEdges.10 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="17.0" text="B2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="60.0" text="CanBusPr"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="67.0" text="CanBusPr2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="10.0" text="C"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/aspect_cartrackingattackmodeling_CarTrackingAttackModeling.elkg
+++ b/realworld/ptolemy/hierarchical/aspect_cartrackingattackmodeling_CarTrackingAttackModeling.elkg
@@ -1,0 +1,919 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="48.0" text="Position"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="LeadingCar"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.1/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L3" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@children.1/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@children.1/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N4" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.2 //@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.6 //@children.1/@children.0/@containedEdges.7 //@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.1/@children.0/@children.0/@ports.2" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.1/@children.0/@children.1/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.1/@children.0/@children.1/@ports.2" targets="//@children.1/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E18" sources="//@children.1/@children.0/@children.2/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E19" sources="//@children.1/@children.0/@children.3/@ports.2" targets="//@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E20" sources="//@children.1/@children.0/@children.4/@ports.2" targets="//@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E21" sources="//@children.1/@children.0/@children.4/@ports.2" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E22" sources="//@children.1/@children.0/@children.4/@ports.2" targets="//@children.1/@children.0/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="103.0" text="PeriodicSampler2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.0/@ports.3" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.4 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="114.0" text="Urban Driving Cycle"/>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="75.0" text="FollowingCar"/>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.4/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@children.4/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N17" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.2 //@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.6 //@children.4/@children.0/@containedEdges.7 //@children.4/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E28" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.4/@children.0/@children.0/@ports.2" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.4/@children.0/@children.1/@ports.2" targets="//@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E31" sources="//@children.4/@children.0/@children.1/@ports.2" targets="//@children.4/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.4/@children.0/@children.2/@ports.0" targets="//@children.4/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E33" sources="//@children.4/@children.0/@children.3/@ports.2" targets="//@children.4/@children.0/@ports.3"/>
+      <containedEdges identifier="E34" sources="//@children.4/@children.0/@children.4/@ports.2" targets="//@children.4/@children.0/@ports.2"/>
+      <containedEdges identifier="E35" sources="//@children.4/@children.0/@children.4/@ports.2" targets="//@children.4/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.4/@children.0/@children.4/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.4/@children.0/@ports.2" targets="//@children.4/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N23">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L23" height="15.0" width="132.0" text="ManInTheMiddleAttack"/>
+    <children identifier="N24" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.4 //@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="15.0" y="41.0" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="38.0" y="41.0" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="98.0" text="AttackStartEvent"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="93.0" text="AttackEndEvent"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="49.0" text="Register"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E37" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.5/@children.3/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.3/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.7/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.5/@children.5/@ports.0" targets="//@children.5/@children.4/@ports.2"/>
+    <containedEdges identifier="E44" sources="//@children.5/@children.6/@ports.0" targets="//@children.5/@children.4/@ports.3"/>
+    <containedEdges identifier="E45" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.3/@ports.1"/>
+  </children>
+  <children identifier="N32">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L32" height="15.0" width="102.0" text="FabricationAttack"/>
+    <children identifier="N33" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="49.0" text="Register"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.5 //@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="44.0" text="Uniform"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E46" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.5/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.6/@children.5/@ports.1" targets="//@children.6/@children.3/@ports.2"/>
+    <containedEdges identifier="E52" sources="//@children.6/@children.5/@ports.1" targets="//@children.6/@children.4/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.6/@children.6/@ports.0" targets="//@children.6/@children.7/@ports.1"/>
+    <containedEdges identifier="E54" sources="//@children.6/@children.7/@ports.0" targets="//@children.6/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N41">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L41" height="15.0" width="102.0" text="InterruptionAttack"/>
+    <children identifier="N42" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P101" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="49.0" text="Register"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="98.0" text="AttackStartEvent"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="93.0" text="AttackEndEvent"/>
+      <ports identifier="P108" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.7/@containedEdges.6 //@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="34.0" text="Inhibit"/>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8 //@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="56.0" text="Register2"/>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="54.0" text="TrueGate"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E55" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.2/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.9/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.7/@children.5/@ports.0" targets="//@children.7/@children.9/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.8/@ports.2"/>
+    <containedEdges identifier="E63" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.2/@ports.2"/>
+    <containedEdges identifier="E64" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.3/@ports.2"/>
+    <containedEdges identifier="E65" sources="//@children.7/@children.8/@ports.1" targets="//@children.7/@children.10/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.7/@children.9/@ports.1" targets="//@children.7/@children.8/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.7/@children.10/@ports.1" targets="//@children.7/@children.7/@ports.2"/>
+  </children>
+  <children identifier="N53">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L53" height="15.0" width="78.0" text="ReplayAttack"/>
+    <children identifier="N54" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="86.0" text="RecordingStart"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="93.0" text="AttackEndEvent"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P126" height="8.0" width="8.0" x="9.25" y="41.0" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P130" height="8.0" width="8.0" x="43.75" y="41.0" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="68.0" text="ReplayStart"/>
+      <ports identifier="P131" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E68" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.4/@ports.3"/>
+    <containedEdges identifier="E69" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.4/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.8/@children.3/@ports.0" targets="//@children.8/@children.4/@ports.4"/>
+    <containedEdges identifier="E71" sources="//@children.8/@children.4/@ports.1" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E72" sources="//@children.8/@children.5/@ports.0" targets="//@children.8/@children.4/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/aspect_cartrackingattackmodeling_CarTrackingAttackModelingAllAttacksInOneModel.elkg
+++ b/realworld/ptolemy/hierarchical/aspect_cartrackingattackmodeling_CarTrackingAttackModelingAllAttacksInOneModel.elkg
@@ -1,0 +1,1485 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="66.0" text="LeadingCar"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="103.0" text="PeriodicSampler1"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="103.0" text="PeriodicSampler2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="49.0" text="Subtract"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.0/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.4/@ports.1"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="132.0" text="ManInTheMiddleAttack"/>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="15.0" y="41.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="38.0" y="41.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="98.0" text="AttackStartEvent"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="93.0" text="AttackEndEvent"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="49.0" text="Register"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E28" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.7/@ports.2"/>
+    <containedEdges identifier="E34" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.4/@ports.2"/>
+    <containedEdges identifier="E35" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.4/@ports.3"/>
+    <containedEdges identifier="E36" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="102.0" text="FabricationAttack"/>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="49.0" text="Register"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="44.0" text="Uniform"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E37" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E44" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.7/@ports.1"/>
+    <containedEdges identifier="E45" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N26">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L26" height="15.0" width="102.0" text="InterruptionAttack"/>
+    <children identifier="N27" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="49.0" text="Register"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="98.0" text="AttackStartEvent"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="93.0" text="AttackEndEvent"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.3/@containedEdges.6 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="34.0" text="Inhibit"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.8 //@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="56.0" text="Register2"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="54.0" text="TrueGate"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E46" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.8/@ports.2"/>
+    <containedEdges identifier="E54" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.2/@ports.2"/>
+    <containedEdges identifier="E55" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.3/@ports.2"/>
+    <containedEdges identifier="E56" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.3/@children.10/@ports.1" targets="//@children.3/@children.7/@ports.2"/>
+  </children>
+  <children identifier="N38">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L38" height="15.0" width="114.0" text="Urban Driving Cycle"/>
+    <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.4/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N39" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E59" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  </children>
+  <children identifier="N40">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L40" height="15.0" width="78.0" text="ReplayAttack"/>
+    <children identifier="N41" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="86.0" text="RecordingStart"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="93.0" text="AttackEndEvent"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P90" height="8.0" width="8.0" x="9.25" y="41.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="43.75" y="41.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="68.0" text="ReplayStart"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E60" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.4/@ports.3"/>
+    <containedEdges identifier="E61" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.5/@children.3/@ports.0" targets="//@children.5/@children.4/@ports.4"/>
+    <containedEdges identifier="E63" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.5/@children.5/@ports.0" targets="//@children.5/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N47">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L47" height="15.0" width="75.0" text="FollowingCar"/>
+    <ports identifier="P96" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N48">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L48" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P99" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@children.6/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2" incomingEdges="//@children.6/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N49" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.2 //@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P109" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P111" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.6/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P114" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P115" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.6/@children.0/@containedEdges.6 //@children.6/@children.0/@containedEdges.7 //@children.6/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E69" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E70" sources="//@children.6/@children.0/@children.0/@ports.2" targets="//@children.6/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E71" sources="//@children.6/@children.0/@children.1/@ports.2" targets="//@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E72" sources="//@children.6/@children.0/@children.1/@ports.2" targets="//@children.6/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.6/@children.0/@children.2/@ports.0" targets="//@children.6/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E74" sources="//@children.6/@children.0/@children.3/@ports.2" targets="//@children.6/@children.0/@ports.3"/>
+      <containedEdges identifier="E75" sources="//@children.6/@children.0/@children.4/@ports.2" targets="//@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E76" sources="//@children.6/@children.0/@children.4/@ports.2" targets="//@children.6/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E77" sources="//@children.6/@children.0/@children.4/@ports.2" targets="//@children.6/@children.0/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N54" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E65" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@ports.1"/>
+    <containedEdges identifier="E67" sources="//@children.6/@children.0/@ports.3" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E68" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N55">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L55" height="15.0" width="82.0" text="FollowingCar2"/>
+    <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.7/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.7/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N56">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L56" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P124" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" incomingEdges="//@children.7/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@children.7/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@children.7/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N57" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P133" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@children.0/@containedEdges.2 //@children.7/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P134" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.7/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P136" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.7/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P140" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.7/@children.0/@containedEdges.6 //@children.7/@children.0/@containedEdges.7 //@children.7/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E82" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.7/@children.0/@children.0/@ports.2" targets="//@children.7/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.7/@children.0/@children.1/@ports.2" targets="//@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E85" sources="//@children.7/@children.0/@children.1/@ports.2" targets="//@children.7/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E86" sources="//@children.7/@children.0/@children.2/@ports.0" targets="//@children.7/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E87" sources="//@children.7/@children.0/@children.3/@ports.2" targets="//@children.7/@children.0/@ports.3"/>
+      <containedEdges identifier="E88" sources="//@children.7/@children.0/@children.4/@ports.2" targets="//@children.7/@children.0/@ports.2"/>
+      <containedEdges identifier="E89" sources="//@children.7/@children.0/@children.4/@ports.2" targets="//@children.7/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E90" sources="//@children.7/@children.0/@children.4/@ports.2" targets="//@children.7/@children.0/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N62" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E78" sources="//@children.7/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E79" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@ports.1"/>
+    <containedEdges identifier="E80" sources="//@children.7/@children.0/@ports.3" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E81" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N63">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L63" height="15.0" width="82.0" text="FollowingCar3"/>
+    <ports identifier="P146" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.8/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.8/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N64">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L64" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P149" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.0/@containedEdges.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" incomingEdges="//@children.8/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.1" incomingEdges="//@children.8/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P152" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.2" incomingEdges="//@children.8/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N65" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L65" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P155" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N66" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L66" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P158" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.0/@containedEdges.2 //@children.8/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N67" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L67" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P159" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.8/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N68" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P161" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P163" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.8/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P164" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P165" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P167" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.8/@children.0/@containedEdges.6 //@children.8/@children.0/@containedEdges.7 //@children.8/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P168" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E95" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E96" sources="//@children.8/@children.0/@children.0/@ports.2" targets="//@children.8/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.8/@children.0/@children.1/@ports.2" targets="//@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E98" sources="//@children.8/@children.0/@children.1/@ports.2" targets="//@children.8/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E99" sources="//@children.8/@children.0/@children.2/@ports.0" targets="//@children.8/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E100" sources="//@children.8/@children.0/@children.3/@ports.2" targets="//@children.8/@children.0/@ports.3"/>
+      <containedEdges identifier="E101" sources="//@children.8/@children.0/@children.4/@ports.2" targets="//@children.8/@children.0/@ports.2"/>
+      <containedEdges identifier="E102" sources="//@children.8/@children.0/@children.4/@ports.2" targets="//@children.8/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E103" sources="//@children.8/@children.0/@children.4/@ports.2" targets="//@children.8/@children.0/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N70" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P170" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E91" sources="//@children.8/@ports.0" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E92" sources="//@children.8/@children.0/@ports.2" targets="//@children.8/@ports.1"/>
+    <containedEdges identifier="E93" sources="//@children.8/@children.0/@ports.3" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E94" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N71">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L71" height="15.0" width="82.0" text="FollowingCar4"/>
+    <ports identifier="P171" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.9/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.9/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N72">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L72" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P174" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.0/@containedEdges.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" incomingEdges="//@children.9/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1" incomingEdges="//@children.9/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.2" incomingEdges="//@children.9/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N73" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P180" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N74" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L74" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.0/@containedEdges.2 //@children.9/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N75" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L75" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P184" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.9/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N76" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L76" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P186" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P188" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.9/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P189" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N77" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L77" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P190" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P192" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.9/@children.0/@containedEdges.6 //@children.9/@children.0/@containedEdges.7 //@children.9/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P193" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E108" sources="//@children.9/@children.0/@ports.0" targets="//@children.9/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E109" sources="//@children.9/@children.0/@children.0/@ports.2" targets="//@children.9/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.9/@children.0/@children.1/@ports.2" targets="//@children.9/@children.0/@ports.1"/>
+      <containedEdges identifier="E111" sources="//@children.9/@children.0/@children.1/@ports.2" targets="//@children.9/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E112" sources="//@children.9/@children.0/@children.2/@ports.0" targets="//@children.9/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E113" sources="//@children.9/@children.0/@children.3/@ports.2" targets="//@children.9/@children.0/@ports.3"/>
+      <containedEdges identifier="E114" sources="//@children.9/@children.0/@children.4/@ports.2" targets="//@children.9/@children.0/@ports.2"/>
+      <containedEdges identifier="E115" sources="//@children.9/@children.0/@children.4/@ports.2" targets="//@children.9/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E116" sources="//@children.9/@children.0/@children.4/@ports.2" targets="//@children.9/@children.0/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N78" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L78" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P195" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E104" sources="//@children.9/@ports.0" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E105" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@ports.1"/>
+    <containedEdges identifier="E106" sources="//@children.9/@children.0/@ports.3" targets="//@children.9/@ports.2"/>
+    <containedEdges identifier="E107" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N79">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L79" height="15.0" width="82.0" text="FollowingCar5"/>
+    <ports identifier="P196" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16" incomingEdges="//@children.10/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" outgoingEdges="//@containedEdges.17" incomingEdges="//@children.10/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N80">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L80" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P199" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P200" height="8.0" width="8.0" incomingEdges="//@children.10/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P201" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@children.10/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P202" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.2" incomingEdges="//@children.10/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N81" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P205" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P208" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.2 //@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P209" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.10/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P211" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P213" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P214" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N85" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L85" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P215" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P217" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.6 //@children.10/@children.0/@containedEdges.7 //@children.10/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P218" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E121" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E122" sources="//@children.10/@children.0/@children.0/@ports.2" targets="//@children.10/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E123" sources="//@children.10/@children.0/@children.1/@ports.2" targets="//@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E124" sources="//@children.10/@children.0/@children.1/@ports.2" targets="//@children.10/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E125" sources="//@children.10/@children.0/@children.2/@ports.0" targets="//@children.10/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E126" sources="//@children.10/@children.0/@children.3/@ports.2" targets="//@children.10/@children.0/@ports.3"/>
+      <containedEdges identifier="E127" sources="//@children.10/@children.0/@children.4/@ports.2" targets="//@children.10/@children.0/@ports.2"/>
+      <containedEdges identifier="E128" sources="//@children.10/@children.0/@children.4/@ports.2" targets="//@children.10/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E129" sources="//@children.10/@children.0/@children.4/@ports.2" targets="//@children.10/@children.0/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N86" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P220" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E117" sources="//@children.10/@ports.0" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E118" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@ports.1"/>
+    <containedEdges identifier="E119" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E120" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N87" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L87" height="15.0" width="48.0" text="Position"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.9 //@containedEdges.11 //@containedEdges.13 //@containedEdges.15 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N88" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="38.0" text="Speed"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.8 //@containedEdges.10 //@containedEdges.12 //@containedEdges.14 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.2" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/aspect_compositeqm_CheckExecutionTimeConstraints.elkg
+++ b/realworld/ptolemy/hierarchical/aspect_compositeqm_CheckExecutionTimeConstraints.elkg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="10.0" text="C"/>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="98.0" text="ThrowModelError"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="78.0" text="CurrentTime2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="36.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="39.0" text="Queue"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="28.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.8/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/aspect_compositeqm_CompositeQM.elkg
+++ b/realworld/ptolemy/hierarchical/aspect_compositeqm_CompositeQM.elkg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="9.0" text="B"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="10.0" text="C"/>
+    <children identifier="N8" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="17.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="8.0" text="a"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="8.0" text="b"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="172.0" text="CommunicationResponsePort"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="9.0" text="X"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.4/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.1 //@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N16">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L16" height="15.0" width="9.0" text="Y"/>
+    <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.5/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N17" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/aspect_de_DE2.elkg
+++ b/realworld/ptolemy/hierarchical/aspect_de_DE2.elkg
@@ -1,0 +1,683 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4 //@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.4 //@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E22" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Ramp4"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N26">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L26" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P53" height="8.0" width="8.0" incomingEdges="//@children.10/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" incomingEdges="//@children.10/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0 //@children.10/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N27">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L27" height="15.0" width="67.0" text="1Processor"/>
+        <children identifier="N28" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="18.0" text="in1"/>
+          <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N29" height="36.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="37.0" text="Server"/>
+          <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P60" height="8.0" width="8.0" x="42.0" y="36.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N30" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L30" height="15.0" width="121.0" text="RecordDisassembler"/>
+          <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P62" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N31" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L31" height="15.0" width="18.0" text="out"/>
+          <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N32" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L32" height="15.0" width="18.0" text="in2"/>
+          <ports identifier="P64" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N33" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L33" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.0 //@children.10/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P66" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.4 //@children.10/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E36" sources="//@children.10/@children.0/@children.0/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E37" sources="//@children.10/@children.0/@children.0/@children.1/@ports.1" targets="//@children.10/@children.0/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E38" sources="//@children.10/@children.0/@children.0/@children.2/@ports.1" targets="//@children.10/@children.0/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E39" sources="//@children.10/@children.0/@children.0/@children.4/@ports.0" targets="//@children.10/@children.0/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E40" sources="//@children.10/@children.0/@children.0/@children.5/@ports.1" targets="//@children.10/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E41" sources="//@children.10/@children.0/@children.0/@children.5/@ports.1" targets="//@children.10/@children.0/@children.0/@children.2/@ports.0"/>
+      </children>
+      <children identifier="N34" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="42.0" text="Ramp3"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="42.0" text="Ramp4"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N36">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L36" height="15.0" width="73.0" text="2Processors"/>
+        <children identifier="N37" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L37" height="15.0" width="18.0" text="in1"/>
+          <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.0 //@children.10/@children.0/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N38" height="36.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L38" height="15.0" width="37.0" text="Server"/>
+          <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P75" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P76" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P77" height="8.0" width="8.0" x="42.0" y="36.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N39" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L39" height="15.0" width="121.0" text="RecordDisassembler"/>
+          <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N40" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L40" height="15.0" width="18.0" text="out"/>
+          <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N41" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L41" height="15.0" width="18.0" text="in2"/>
+          <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.4 //@children.10/@children.0/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N42" height="36.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L42" height="15.0" width="44.0" text="Server2"/>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P83" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P85" height="8.0" width="8.0" x="42.0" y="36.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N43" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L43" height="15.0" width="128.0" text="RecordDisassembler2"/>
+          <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P87" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N44" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L44" height="15.0" width="26.0" text="out2"/>
+          <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E42" sources="//@children.10/@children.0/@children.3/@children.0/@ports.0" targets="//@children.10/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E43" sources="//@children.10/@children.0/@children.3/@children.0/@ports.0" targets="//@children.10/@children.0/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E44" sources="//@children.10/@children.0/@children.3/@children.1/@ports.1" targets="//@children.10/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E45" sources="//@children.10/@children.0/@children.3/@children.2/@ports.1" targets="//@children.10/@children.0/@children.3/@children.1/@ports.2"/>
+        <containedEdges identifier="E46" sources="//@children.10/@children.0/@children.3/@children.4/@ports.0" targets="//@children.10/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E47" sources="//@children.10/@children.0/@children.3/@children.4/@ports.0" targets="//@children.10/@children.0/@children.3/@children.6/@ports.0"/>
+        <containedEdges identifier="E48" sources="//@children.10/@children.0/@children.3/@children.5/@ports.1" targets="//@children.10/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E49" sources="//@children.10/@children.0/@children.3/@children.6/@ports.1" targets="//@children.10/@children.0/@children.3/@children.5/@ports.2"/>
+      </children>
+      <children identifier="N45" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E30" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E31" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.10/@children.0/@children.1/@ports.0" targets="//@children.10/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.10/@children.0/@children.2/@ports.0" targets="//@children.10/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.10/@children.0/@children.4/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.10/@children.0/@children.5/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/backtrack_trialmodule_TrialModule.elkg
+++ b/realworld/ptolemy/hierarchical/backtrack_trialmodule_TrialModule.elkg
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="106.0" text="BooleanSelect (B)"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="TrialModule"/>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1 //@children.7/@containedEdges.2" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.7/@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.7/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="97.0" text="StringSubstring1"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const1"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="97.0" text="StringSubstring2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="74.0" text="StringLength"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.6 //@children.7/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="62.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.7/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="56.0" text="Ramp (B)"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="73.0" text="EmptyString"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="31.0" width="81.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="85.0" text="StringFunction"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.16 //@children.7/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.7/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.7/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.12/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.0/@ports.2"/>
+    <containedEdges identifier="E18" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.0/@ports.3"/>
+    <containedEdges identifier="E19" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.3/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.3/@ports.3"/>
+    <containedEdges identifier="E22" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.9/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.7/@children.7/@ports.0" targets="//@children.7/@children.13/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.7/@children.8/@ports.1" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E25" sources="//@children.7/@children.9/@ports.3" targets="//@children.7/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.7/@children.10/@ports.0" targets="//@children.7/@children.13/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.7/@children.11/@ports.0" targets="//@children.7/@children.9/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.7/@children.12/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.7/@children.13/@ports.2" targets="//@children.7/@children.8/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.7/@children.13/@ports.2" targets="//@children.7/@children.9/@ports.2"/>
+  </children>
+  <children identifier="N23" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.5 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/backtrack_trialmodule_TrialModuleNonBacktrack.elkg
+++ b/realworld/ptolemy/hierarchical/backtrack_trialmodule_TrialModuleNonBacktrack.elkg
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="67.0" text="TrialModule"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1 //@children.8/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10" incomingEdges="//@children.8/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.8/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10" height="31.0" width="81.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="85.0" text="StringFunction"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="97.0" text="StringSubstring1"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const1"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="97.0" text="StringSubstring2"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="74.0" text="StringLength"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.3 //@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="62.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.8/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.8/@containedEdges.12 //@children.8/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.8/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="38.0" text="Empty"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.8/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.8/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.8/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.8/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.8/@ports.0" targets="//@children.8/@children.6/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.7/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.1/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.8/@children.3/@ports.0" targets="//@children.8/@children.1/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.4/@ports.1" targets="//@children.8/@children.7/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.8/@children.5/@ports.0" targets="//@children.8/@children.4/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.8/@children.6/@ports.1" targets="//@children.8/@children.4/@ports.3"/>
+    <containedEdges identifier="E23" sources="//@children.8/@children.7/@ports.2" targets="//@children.8/@children.12/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.8/@children.8/@ports.0" targets="//@children.8/@children.9/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.8/@children.9/@ports.2" targets="//@children.8/@children.10/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.8/@children.9/@ports.2" targets="//@children.8/@children.12/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.8/@children.10/@ports.1" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.8/@children.11/@ports.0" targets="//@children.8/@children.12/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.8/@children.12/@ports.3" targets="//@children.8/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.8/@children.13/@ports.0" targets="//@children.8/@children.9/@ports.1"/>
+  </children>
+  <children identifier="N24" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.3/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ca_conway_Conway.elkg
+++ b/realworld/ptolemy/hierarchical/ca_conway_Conway.elkg
@@ -1,0 +1,573 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="101.0" text="CA2DConvolution"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.32 //@children.0/@containedEdges.33 //@children.0/@containedEdges.34 //@children.0/@containedEdges.35 //@children.0/@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.8" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.7" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.9" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.6" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14 //@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.19 //@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="94.0" text="BooleanSwitch3"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="75.0" text="Comparator3"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="75.0" text="Comparator4"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.27 //@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const8"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch4"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const9"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.0/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.0/@ports.8" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@ports.5" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@ports.7" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@ports.10" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@ports.11" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@ports.6" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@ports.4" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@ports.9" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.14/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.5/@ports.3" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.15/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.16/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.11/@ports.3" targets="//@children.0/@children.12/@ports.1"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.13/@ports.1"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.12/@ports.0" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.16/@ports.0" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.17/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N20" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P74" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="25.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.0/@ports.6"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.0/@ports.7"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.0/@ports.8"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.0/@ports.9"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.0/@ports.10"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.0" targets="//@children.0/@ports.11"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ci_router_ComplexRouter.elkg
+++ b/realworld/ptolemy/hierarchical/ci_router_ComplexRouter.elkg
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="53.0" text="channel1"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="72.0" text="Counter - q1"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="53.0" text="channel2"/>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.1/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="Counter - q2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="141.0" text="MonitorValue - q1 length"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="141.0" text="MonitorValue - q2 length"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="98.0" text="DatagramReader"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="79.0" text="QueueControl"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="-1.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="6.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="13.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="0.1666666716337204">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="32.83333206176758" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="82.0" text="Interface - fast"/>
+    <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12" incomingEdges="//@children.10/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="34.0" text="Sleep"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="26.5" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.10/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@ports.1"/>
+  </children>
+  <children identifier="N19">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L19" height="15.0" width="88.0" text="Interface - slow"/>
+    <ports identifier="P49" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14" incomingEdges="//@children.11/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="34.0" text="Sleep"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="26.5" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E26" sources="//@children.11/@ports.0" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.9/@ports.6"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.9/@ports.8"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.9/@ports.7"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.9" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.9" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.10" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.10" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.4" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.3/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ci_router_Router.elkg
+++ b/realworld/ptolemy/hierarchical/ci_router_Router.elkg
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="53.0" text="channel1"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="53.0" text="channel2"/>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="80.0" text="DataReceived"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="141.0" text="MonitorValue - q1 length"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="141.0" text="MonitorValue - q2 length"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="47.0" text="dropped"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="60.0" text="Distributor"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="82.0" text="Interface - fast"/>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.7/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="34.0" text="Sleep"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="26.5" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@ports.1"/>
+  </children>
+  <children identifier="N16">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L16" height="15.0" width="88.0" text="Interface - slow"/>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.8/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="34.0" text="Sleep"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="26.5" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.8/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@ports.1"/>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="46.0" text="Queue1"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="26.5" y="-8.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="46.0" text="Queue2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.6/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.6/@ports.5" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.6/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.7/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ci_router_dropqueuetest1.elkg
+++ b/realworld/ptolemy/hierarchical/ci_router_dropqueuetest1.elkg
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="60.0" text="Consumer"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="80.0" text="VariableSleep"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="87.0" text="randomTime t2"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="82.0" text="LongToDouble"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="49.0" text="Dropped"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="53.0" text="Producer"/>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.2/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="80.0" text="VariableSleep"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="83.0" text="randonTime t1"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="82.0" text="LongToDouble"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.6 //@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.0/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="96.0" text="FrontDropQueue"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.2" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ci_router_queuetest1.elkg
+++ b/realworld/ptolemy/hierarchical/ci_router_queuetest1.elkg
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="39.0" text="Queue"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="60.0" text="Consumer"/>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="80.0" text="VariableSleep"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="87.0" text="randomTime t2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="82.0" text="LongToDouble"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="82.0" text="Queue Length"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="53.0" text="Producer"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="80.0" text="VariableSleep"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="83.0" text="randonTime t1"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="82.0" text="LongToDouble"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.6 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.5/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.2/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.4/@ports.1" targets="//@children.3/@children.3/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.4/@ports.1" targets="//@children.3/@children.3/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/comm_convolutionalcoder_ConvolutionalCoder.elkg
+++ b/realworld/ptolemy/hierarchical/comm_convolutionalcoder_ConvolutionalCoder.elkg
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.1" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.0" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="81.0" text="Count Errors2"/>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.2" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.2/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E33" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.2/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.2/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E37" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.2/@children.4/@ports.2" targets="//@children.2/@ports.3"/>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="60.0" text="Scrambler"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="76.0" text="DeScrambler"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="58.0" text="Bernoulli2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="83.0" text="DeScrambler2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="86.0" text="ViterbiDecoder"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/comm_scrambler_Scrambler.elkg
+++ b/realworld/ptolemy/hierarchical/comm_scrambler_Scrambler.elkg
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="60.0" text="Scrambler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="76.0" text="DeScrambler"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="94.0" text="Scrambled Data"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="131.0" text="Measure Rate of Trues"/>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.4/@children.3/@ports.2" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="77.0" text="Rate of Trues"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="108.0" text="Descrambled Data"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/comm_trellisdecoder_TrellisDecoder.elkg
+++ b/realworld/ptolemy/hierarchical/comm_trellisdecoder_TrellisDecoder.elkg
@@ -1,0 +1,563 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1 //@children.4/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.4/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.4/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.3 //@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.4/@ports.0" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@ports.1" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.4/@children.4/@ports.2" targets="//@children.4/@ports.3"/>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="81.0" text="Count Errors2"/>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1 //@children.7/@containedEdges.2" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.7/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.7/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E28" sources="//@children.7/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.7/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.7/@ports.1" targets="//@children.7/@children.3/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E32" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.4/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.7/@children.4/@ports.2" targets="//@children.7/@ports.3"/>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Slicer"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="59.0" text="LineCoder"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="66.0" text="LineCoder2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="111.0" text="Complex Gaussian"/>
+    <ports identifier="P57" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.14/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.14/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="63.0" text="Gaussian2"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.14/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="25.0" width="92.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.14/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.14/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E37" sources="//@children.14/@children.0/@ports.0" targets="//@children.14/@children.2/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.14/@children.1/@ports.0" targets="//@children.14/@children.2/@ports.2"/>
+    <containedEdges identifier="E39" sources="//@children.14/@children.2/@ports.0" targets="//@children.14/@ports.0"/>
+  </children>
+  <children identifier="N29">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L29" height="15.0" width="118.0" text="Complex Gaussian2"/>
+    <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16" incomingEdges="//@children.15/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N30" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="63.0" text="Gaussian2"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="25.0" width="92.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E40" sources="//@children.15/@children.0/@ports.0" targets="//@children.15/@children.2/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.15/@children.1/@ports.0" targets="//@children.15/@children.2/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.15/@children.2/@ports.0" targets="//@children.15/@ports.0"/>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="83.0" text="TrellisDecoder"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/comm_viterbidecoder_ViterbiDecoder.elkg
+++ b/realworld/ptolemy/hierarchical/comm_viterbidecoder_ViterbiDecoder.elkg
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1 //@children.9/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.9/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.9/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.9/@ports.0" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.9/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.9/@ports.1" targets="//@children.9/@children.3/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.9/@children.3/@ports.0" targets="//@children.9/@children.4/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.9/@children.4/@ports.2" targets="//@children.9/@ports.3"/>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="Count Errors2"/>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.1 //@children.12/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.12/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.12/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.3 //@children.12/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@containedEdges.0 //@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E29" sources="//@children.12/@ports.0" targets="//@children.12/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.12/@ports.1" targets="//@children.12/@children.2/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.12/@ports.1" targets="//@children.12/@children.3/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@children.4/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.12/@children.1/@ports.1" targets="//@children.12/@children.0/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.12/@children.2/@ports.1" targets="//@children.12/@children.1/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.12/@children.3/@ports.0" targets="//@children.12/@children.4/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.12/@children.4/@ports.2" targets="//@children.12/@ports.3"/>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="93.0" text="ViterbiDecoder2"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.3" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_bouncingball_BouncingBall.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_bouncingball_BouncingBall.elkg
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="Animate Ball"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="70.0" text="ViewScreen"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="58.0" text="Sphere3D"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="40.0" text="Box3D"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="84.0" text="Translate3D10"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="75.0" text="Copy1:Const"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="61.0" text="Ball Model"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_bus_2Bus.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_bus_2Bus.elkg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.5/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@ports.1"/>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_cartpendulum_CartPendulum.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_cartpendulum_CartPendulum.elkg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="0.1666666716337204">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="32.83333206176758">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="Positions"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="78.0" text="3D Animation"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N4">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L4" height="15.0" width="93.0" text="PendulumModel"/>
+      <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@children.2/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N5" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="33.0" text="string"/>
+        <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="58.0" text="Sphere3D"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="70.0" text="Translate3D"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="30.399999618530273">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="55.0" text="Rotate3D"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.3 //@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.4/@ports.2"/>
+      <containedEdges identifier="E15" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E18" sources="//@children.2/@children.0/@children.3/@ports.1" targets="//@children.2/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.2/@children.0/@children.4/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="86.0" text="ViewScreen3D"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="50.0" text="Scale3D"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="33.0" text="stage"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="47.0" text="Cone3D"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="77.0" text="Translate3D3"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.6 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="43.0" text="cartbox"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.2/@children.7/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.7/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.3" targets="//@children.2/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_cartracking_CarTracking.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_cartracking_CarTracking.elkg
@@ -1,0 +1,813 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Car Model"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.0/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="49.0" text="Subtract"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="87.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.3/@ports.1"/>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="113.0" text="Grandma Simulator"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="78.0" text="CurrentTime2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="28.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="20.0" text="Sin"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.4 //@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.8 //@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="64.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="31.0" text="Add2"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.12/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.3/@ports.2" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.2/@children.7/@ports.2" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.9/@ports.0" targets="//@children.2/@children.7/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.2/@children.10/@ports.2" targets="//@children.2/@children.12/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.2/@children.12/@ports.2" targets="//@children.2/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N22" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="82.0" text="NetworkModel"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="75.0" text="FollowingCar"/>
+    <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.8/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="79.0" text="FaultDetector"/>
+      <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.0/@containedEdges.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.2 //@children.8/@containedEdges.3" incomingEdges="//@children.8/@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N29" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="10.0" y="1.7999999523162842" outgoingEdges="//@children.8/@children.0/@containedEdges.2 //@children.8/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="10.0" y="11.600000381469727">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="21.399999618530273" outgoingEdges="//@children.8/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="31.200000762939453" outgoingEdges="//@children.8/@children.0/@containedEdges.4 //@children.8/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="21.0" text="Pre"/>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="28.0" text="Pre2"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="55.0" width="194.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="150.0" text="Estimate Current Position"/>
+        <ports identifier="P85" height="8.0" width="8.0" x="194.0" y="23.5" outgoingEdges="//@children.8/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="4.599999904632568" incomingEdges="//@children.8/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="17.200000762939453" incomingEdges="//@children.8/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="29.799999237060547" incomingEdges="//@children.8/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="42.400001525878906" incomingEdges="//@children.8/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="28.0" text="Pre3"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.8/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.8/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.8/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="61.0" text="LogicalNot"/>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.8/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E44" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.8/@children.0/@children.0/@ports.3" targets="//@children.8/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.8/@children.0/@children.0/@ports.1" targets="//@children.8/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.8/@children.0/@children.0/@ports.1" targets="//@children.8/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.8/@children.0/@children.0/@ports.4" targets="//@children.8/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.8/@children.0/@children.0/@ports.4" targets="//@children.8/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.8/@children.0/@children.1/@ports.1" targets="//@children.8/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E51" sources="//@children.8/@children.0/@children.2/@ports.1" targets="//@children.8/@children.0/@children.3/@ports.3"/>
+      <containedEdges identifier="E52" sources="//@children.8/@children.0/@children.3/@ports.0" targets="//@children.8/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.8/@children.0/@children.4/@ports.1" targets="//@children.8/@children.0/@children.3/@ports.4"/>
+      <containedEdges identifier="E54" sources="//@children.8/@children.0/@children.5/@ports.2" targets="//@children.8/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.8/@children.0/@children.6/@ports.1" targets="//@children.8/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N36" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N39">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L39" height="15.0" width="59.0" text="Car Model"/>
+      <ports identifier="P103" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.4/@containedEdges.0" incomingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.6" incomingEdges="//@children.8/@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.7" incomingEdges="//@children.8/@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.8" incomingEdges="//@children.8/@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N40" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="49.0" text="Subtract"/>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="87.0" text="MultiplyDivide4"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.4/@containedEdges.1 //@children.8/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.4/@containedEdges.2 //@children.8/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="25.0" width="62.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P113" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@children.8/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="62.0" text="Integrator2"/>
+        <ports identifier="P115" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.8/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P119" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P121" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.8/@children.4/@containedEdges.6 //@children.8/@children.4/@containedEdges.7 //@children.8/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E56" sources="//@children.8/@children.4/@ports.0" targets="//@children.8/@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.8/@children.4/@children.0/@ports.2" targets="//@children.8/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.8/@children.4/@children.1/@ports.2" targets="//@children.8/@children.4/@ports.1"/>
+      <containedEdges identifier="E59" sources="//@children.8/@children.4/@children.1/@ports.2" targets="//@children.8/@children.4/@children.4/@ports.1"/>
+      <containedEdges identifier="E60" sources="//@children.8/@children.4/@children.2/@ports.0" targets="//@children.8/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.8/@children.4/@children.3/@ports.2" targets="//@children.8/@children.4/@ports.3"/>
+      <containedEdges identifier="E62" sources="//@children.8/@children.4/@children.4/@ports.2" targets="//@children.8/@children.4/@ports.2"/>
+      <containedEdges identifier="E63" sources="//@children.8/@children.4/@children.4/@ports.2" targets="//@children.8/@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E64" sources="//@children.8/@children.4/@children.4/@ports.2" targets="//@children.8/@children.4/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N45" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E34" sources="//@children.8/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.8/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.3/@ports.2"/>
+    <containedEdges identifier="E38" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@children.5/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.8/@children.4/@ports.1" targets="//@children.8/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.8/@children.4/@ports.2" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.8/@children.4/@ports.3" targets="//@children.8/@ports.3"/>
+    <containedEdges identifier="E43" sources="//@children.8/@children.5/@ports.1" targets="//@children.8/@children.4/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.6/@ports.4"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.2" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.3" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_continuousinsidede_ContinuousInsideDE.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_continuousinsidede_ContinuousInsideDE.elkg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="48.0" text="jobDone"/>
+    <ports identifier="P4" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" outgoingEdges="//@containedEdges.4 //@containedEdges.5" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.6 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="91.0" text="ZeroOrderHold3"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="91.0" text="ColtExponential"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_hierarchicalexecution_HierarchicalExecution.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_hierarchicalexecution_HierarchicalExecution.elkg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="62.0" text="Integrator3"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="62.0" text="Integrator2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="80.0" text="AddSubtract3"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="46.0" text="signal 1"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="46.0" text="signal 2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="56.0" text="difference"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.11/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N13" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.11/@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.11/@children.0/@ports.2" targets="//@children.11/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.0" targets="//@children.2/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_pendulum3d_Pendulum3D.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_pendulum3d_Pendulum3D.elkg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="22.625" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="34.875" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="79.0" text="Displacement"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="40.0" text="Angles"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="Angular Velocities"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="57.0" text="animation"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L6" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="33.0" text="string"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="58.0" text="Sphere3D"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="70.0" text="Translate3D"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="30.399999618530273">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="55.0" text="Rotate3D"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.3 //@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E19" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.4/@ports.2"/>
+      <containedEdges identifier="E20" sources="//@children.4/@children.0/@children.0/@ports.0" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.4/@children.0/@children.1/@ports.0" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.4/@children.0/@children.4/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="86.0" text="ViewScreen3D"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.3 //@children.4/@containedEdges.6 //@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="50.0" text="Scale3D"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="55.0" text="Rotate3D"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="33.0" text="stage"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="47.0" text="Cone3D"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.4/@ports.1" targets="//@children.4/@children.3/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.4/@children.5/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.7/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.5" targets="//@children.4/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_sigmadelta_SigmaDelta.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_sigmadelta_SigmaDelta.elkg
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="131.0" text="ContinuousSubsystem"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="75.0" text="Current Time"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="20.0" text="Sin"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="31.0" text="Add1"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="41.0" text="Scale0"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="41.0" text="Scale1"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="41.0" text="Scale3"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="88.0" text="ContinuousPlot"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.5 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="31.0" text="delay"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="54.0" text="FIR Filter"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="57.0" text="Quantizer"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="41.0" text="DEPlot"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="90.0" text="Moving Average"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="117.0" text="Average 50 samples"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_squarewave_SquareWave.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_squarewave_SquareWave.elkg
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="162.0" text="ContinuousTransferFunction"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="63.0" text="InputAdder"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.6 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="74.0" text="OutputAdder"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="62.0" text="Integrator0"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="65.0" text="Feedback0"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="78.0" text="Feedforward0"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="65.0" text="Feedback1"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="78.0" text="Feedforward1"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="98.0" text="ContinuousClock"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_starmac_Starmac.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_starmac_Starmac.elkg
@@ -1,0 +1,4756 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="114.0" text="Graphics Animation"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="20.799999237060547" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="117.0" text="VectorDisassembler"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="86.0" text="ViewScreen3D"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="124.0" text="VectorDisassembler2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="46.0" text="Rotate3"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="46.0" text="Rotate2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="46.0" text="Rotate4"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="49.0" text="Starmac"/>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.12" incomingEdges="//@children.0/@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="40.0" text="Box3D"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="64.0" text="Cylinder3D"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.7/@containedEdges.0 //@children.0/@children.7/@containedEdges.3 //@children.0/@children.7/@containedEdges.4 //@children.0/@children.7/@containedEdges.5 //@children.0/@children.7/@containedEdges.7 //@children.0/@children.7/@containedEdges.9 //@children.0/@children.7/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="70.0" text="Translate3D"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="47.0" text="Box3D2"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="47.0" text="Box3D3"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="71.0" text="Cylinder3D2"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="71.0" text="Cylinder3D3"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="71.0" text="Cylinder3D4"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.7/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.7/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E29" sources="//@children.0/@children.7/@children.0/@ports.0" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.7/@children.1/@ports.0" targets="//@children.0/@children.7/@children.3/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.0/@children.7/@children.2/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.7/@children.3/@ports.1" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.7/@children.4/@ports.0" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.7/@children.5/@ports.0" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.7/@children.6/@ports.0" targets="//@children.0/@children.7/@children.7/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.7/@children.7/@ports.1" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.7/@children.8/@ports.0" targets="//@children.0/@children.7/@children.9/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.7/@children.9/@ports.1" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.7/@children.10/@ports.0" targets="//@children.0/@children.7/@children.11/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.7/@children.11/@ports.1" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N22" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.0/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.5/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N24" height="25.0" width="88.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="80.0" text="Wind Velocity"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="34.0" text="Angle"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="103.0" text="PeriodicSampler2"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L29" height="15.0" width="87.0" text="Vehicle Control"/>
+    <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.6/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1 //@children.6/@containedEdges.2" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="92.0" text="Position Control"/>
+      <ports identifier="P55" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.3" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31" height="25.0" width="102.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="102.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E48" sources="//@children.6/@children.0/@children.0/@ports.0" targets="//@children.6/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N32">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L32" height="15.0" width="89.0" text="Altitude Control"/>
+      <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.4" incomingEdges="//@children.6/@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N33" height="25.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.3 //@children.6/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.4 //@children.6/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="25.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="80.0" text="AddSubtract4"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@children.6/@children.1/@containedEdges.16 //@children.6/@children.1/@containedEdges.17 //@children.6/@children.1/@containedEdges.18 //@children.6/@children.1/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="25.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="72.0" text="TrigFunction"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="25.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="79.0" text="TrigFunction2"/>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.9 //@children.6/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="25.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="49.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="100.0" text="VectorAssembler"/>
+        <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="124.0" text="VectorDisassembler2"/>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.15 //@children.6/@children.1/@containedEdges.16 //@children.6/@children.1/@containedEdges.17 //@children.6/@children.1/@containedEdges.18 //@children.6/@children.1/@containedEdges.19 //@children.6/@children.1/@containedEdges.20 //@children.6/@children.1/@containedEdges.21 //@children.6/@children.1/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E49" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.1/@children.15/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.6/@children.1/@children.0/@ports.0" targets="//@children.6/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.6/@children.1/@children.1/@ports.2" targets="//@children.6/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.6/@children.1/@children.2/@ports.1" targets="//@children.6/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.6/@children.1/@children.3/@ports.2" targets="//@children.6/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.6/@children.1/@children.4/@ports.2" targets="//@children.6/@children.1/@children.14/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.6/@children.1/@children.5/@ports.0" targets="//@children.6/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.6/@children.1/@children.6/@ports.2" targets="//@children.6/@children.1/@children.7/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.6/@children.1/@children.7/@ports.1" targets="//@children.6/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.6/@children.1/@children.9/@ports.1" targets="//@children.6/@children.1/@children.11/@ports.0"/>
+      <containedEdges identifier="E59" sources="//@children.6/@children.1/@children.10/@ports.1" targets="//@children.6/@children.1/@children.11/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.6/@children.1/@children.11/@ports.2" targets="//@children.6/@children.1/@children.12/@ports.1"/>
+      <containedEdges identifier="E61" sources="//@children.6/@children.1/@children.12/@ports.2" targets="//@children.6/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.6/@children.1/@children.13/@ports.0" targets="//@children.6/@children.1/@children.12/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.6/@children.1/@children.14/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E65" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E69" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E70" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E71" sources="//@children.6/@children.1/@children.15/@ports.1" targets="//@children.6/@children.1/@children.10/@ports.0"/>
+    </children>
+    <children identifier="N49">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L49" height="15.0" width="90.0" text="Attitude Control"/>
+      <ports identifier="P98" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.5" incomingEdges="//@children.6/@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N50" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L51" height="15.0" width="100.0" text="VectorAssembler"/>
+        <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.1/@containedEdges.0 //@children.6/@children.2/@children.1/@containedEdges.1" incomingEdges="//@children.6/@children.2/@containedEdges.5 //@children.6/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.3" incomingEdges="//@children.6/@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N52" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L52" height="15.0" width="100.0" text="VectorAssembler"/>
+          <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.1/@containedEdges.3 //@children.6/@children.2/@children.1/@containedEdges.4 //@children.6/@children.2/@children.1/@containedEdges.5 //@children.6/@children.2/@children.1/@containedEdges.6 //@children.6/@children.2/@children.1/@containedEdges.7 //@children.6/@children.2/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P107" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N53" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L53" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P109" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.1/@containedEdges.3 //@children.6/@children.2/@children.1/@containedEdges.4 //@children.6/@children.2/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N54" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L54" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P111" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.1/@containedEdges.6 //@children.6/@children.2/@children.1/@containedEdges.7 //@children.6/@children.2/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E79" sources="//@children.6/@children.2/@children.1/@ports.0" targets="//@children.6/@children.2/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E80" sources="//@children.6/@children.2/@children.1/@ports.0" targets="//@children.6/@children.2/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E81" sources="//@children.6/@children.2/@children.1/@children.0/@ports.1" targets="//@children.6/@children.2/@children.1/@ports.1"/>
+        <containedEdges identifier="E82" sources="//@children.6/@children.2/@children.1/@children.1/@ports.1" targets="//@children.6/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E83" sources="//@children.6/@children.2/@children.1/@children.1/@ports.1" targets="//@children.6/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E84" sources="//@children.6/@children.2/@children.1/@children.1/@ports.1" targets="//@children.6/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E85" sources="//@children.6/@children.2/@children.1/@children.2/@ports.1" targets="//@children.6/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E86" sources="//@children.6/@children.2/@children.1/@children.2/@ports.1" targets="//@children.6/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E87" sources="//@children.6/@children.2/@children.1/@children.2/@ports.1" targets="//@children.6/@children.2/@children.1/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N55" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L55" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N56">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L56" height="15.0" width="117.0" text="VectorDisassembler"/>
+        <ports identifier="P114" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.3/@containedEdges.0" incomingEdges="//@children.6/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.5" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.6" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N57" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L57" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P121" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.3/@containedEdges.1 //@children.6/@children.2/@children.3/@containedEdges.2 //@children.6/@children.2/@children.3/@containedEdges.3 //@children.6/@children.2/@children.3/@containedEdges.4 //@children.6/@children.2/@children.3/@containedEdges.5 //@children.6/@children.2/@children.3/@containedEdges.6 //@children.6/@children.2/@children.3/@containedEdges.7 //@children.6/@children.2/@children.3/@containedEdges.8 //@children.6/@children.2/@children.3/@containedEdges.9 //@children.6/@children.2/@children.3/@containedEdges.10 //@children.6/@children.2/@children.3/@containedEdges.11 //@children.6/@children.2/@children.3/@containedEdges.12 //@children.6/@children.2/@children.3/@containedEdges.13 //@children.6/@children.2/@children.3/@containedEdges.14 //@children.6/@children.2/@children.3/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N58" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L58" height="15.0" width="100.0" text="VectorAssembler"/>
+          <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.1 //@children.6/@children.2/@children.3/@containedEdges.2 //@children.6/@children.2/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P123" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.3/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N59" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="107.0" text="VectorAssembler2"/>
+          <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.13 //@children.6/@children.2/@children.3/@containedEdges.14 //@children.6/@children.2/@children.3/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P125" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.3/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N60" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L60" height="15.0" width="107.0" text="VectorAssembler3"/>
+          <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.10 //@children.6/@children.2/@children.3/@containedEdges.11 //@children.6/@children.2/@children.3/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P127" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.3/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N61" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L61" height="15.0" width="107.0" text="VectorAssembler4"/>
+          <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.7 //@children.6/@children.2/@children.3/@containedEdges.8 //@children.6/@children.2/@children.3/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P129" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.3/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N62" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L62" height="15.0" width="107.0" text="VectorAssembler5"/>
+          <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.3/@containedEdges.4 //@children.6/@children.2/@children.3/@containedEdges.5 //@children.6/@children.2/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P131" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.3/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E88" sources="//@children.6/@children.2/@children.3/@ports.0" targets="//@children.6/@children.2/@children.3/@children.0/@ports.0"/>
+        <containedEdges identifier="E89" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E90" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E91" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E92" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E93" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E94" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E95" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.4/@ports.0"/>
+        <containedEdges identifier="E96" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.4/@ports.0"/>
+        <containedEdges identifier="E97" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.4/@ports.0"/>
+        <containedEdges identifier="E98" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E99" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E100" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E101" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E102" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E103" sources="//@children.6/@children.2/@children.3/@children.0/@ports.1" targets="//@children.6/@children.2/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E104" sources="//@children.6/@children.2/@children.3/@children.1/@ports.1" targets="//@children.6/@children.2/@children.3/@ports.1"/>
+        <containedEdges identifier="E105" sources="//@children.6/@children.2/@children.3/@children.2/@ports.1" targets="//@children.6/@children.2/@children.3/@ports.5"/>
+        <containedEdges identifier="E106" sources="//@children.6/@children.2/@children.3/@children.3/@ports.1" targets="//@children.6/@children.2/@children.3/@ports.4"/>
+        <containedEdges identifier="E107" sources="//@children.6/@children.2/@children.3/@children.4/@ports.1" targets="//@children.6/@children.2/@children.3/@ports.3"/>
+        <containedEdges identifier="E108" sources="//@children.6/@children.2/@children.3/@children.5/@ports.1" targets="//@children.6/@children.2/@children.3/@ports.2"/>
+      </children>
+      <containedEdges identifier="E72" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E73" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E74" sources="//@children.6/@children.2/@children.0/@ports.2" targets="//@children.6/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.6/@children.2/@children.1/@ports.1" targets="//@children.6/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E76" sources="//@children.6/@children.2/@children.2/@ports.1" targets="//@children.6/@children.2/@ports.2"/>
+      <containedEdges identifier="E77" sources="//@children.6/@children.2/@children.3/@ports.3" targets="//@children.6/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.6/@children.2/@children.3/@ports.5" targets="//@children.6/@children.2/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N63" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.4 //@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P134" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E41" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.6/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E43" sources="//@children.6/@ports.1" targets="//@children.6/@children.2/@ports.1"/>
+    <containedEdges identifier="E44" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.6/@children.3/@ports.2" targets="//@children.6/@ports.0"/>
+  </children>
+  <children identifier="N64" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="41.0" text="Control"/>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="48.0" text="Position"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N66" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L66" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N67" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L67" height="15.0" width="103.0" text="PeriodicSampler3"/>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N68">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L68" height="15.0" width="104.0" text="Vehicle Dynamics"/>
+    <ports identifier="P141" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.11/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.11/@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.11/@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N69">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L69" height="15.0" width="95.0" text="Motor Dynamics"/>
+      <ports identifier="P146" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.0" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.2" incomingEdges="//@children.11/@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N70">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L70" height="15.0" width="162.0" text="ContinuousTransferFunction"/>
+        <ports identifier="P148" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.11/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P149" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.1" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N71" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.0 //@children.11/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P155" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N73" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P156" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P158" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.3 //@children.11/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P159" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N74" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P161" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N75" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L75" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P163" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E155" sources="//@children.11/@children.0/@children.0/@ports.0" targets="//@children.11/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E156" sources="//@children.11/@children.0/@children.0/@children.0/@ports.2" targets="//@children.11/@children.0/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E157" sources="//@children.11/@children.0/@children.0/@children.1/@ports.2" targets="//@children.11/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E158" sources="//@children.11/@children.0/@children.0/@children.2/@ports.2" targets="//@children.11/@children.0/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E159" sources="//@children.11/@children.0/@children.0/@children.2/@ports.2" targets="//@children.11/@children.0/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E160" sources="//@children.11/@children.0/@children.0/@children.3/@ports.1" targets="//@children.11/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E161" sources="//@children.11/@children.0/@children.0/@children.4/@ports.1" targets="//@children.11/@children.0/@children.0/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N76" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L76" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P165" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N77" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L77" height="15.0" width="47.0" text="Limiter2"/>
+        <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P167" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N78" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L78" height="15.0" width="47.0" text="Limiter3"/>
+        <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P169" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N79" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="47.0" text="Limiter4"/>
+        <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P171" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@containedEdges.2 //@children.11/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P174" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@containedEdges.3 //@children.11/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P177" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@containedEdges.4 //@children.11/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P180" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="80.0" text="AddSubtract4"/>
+        <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@containedEdges.5 //@children.11/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N84">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L84" height="15.0" width="116.0" text="Motor Noise Source"/>
+        <ports identifier="P184" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.10" incomingEdges="//@children.11/@children.0/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P185" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.11" incomingEdges="//@children.11/@children.0/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P186" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.12" incomingEdges="//@children.11/@children.0/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P187" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.13" incomingEdges="//@children.11/@children.0/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N85" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L85" height="15.0" width="56.0" text="Gaussian"/>
+          <ports identifier="P188" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.9/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="5.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N86" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L86" height="15.0" width="63.0" text="Gaussian2"/>
+          <ports identifier="P192" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.9/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="5.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N87" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L87" height="15.0" width="63.0" text="Gaussian3"/>
+          <ports identifier="P196" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.9/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="5.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N88" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L88" height="15.0" width="63.0" text="Gaussian4"/>
+          <ports identifier="P200" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.9/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="5.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E162" sources="//@children.11/@children.0/@children.9/@children.0/@ports.0" targets="//@children.11/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E163" sources="//@children.11/@children.0/@children.9/@children.1/@ports.0" targets="//@children.11/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E164" sources="//@children.11/@children.0/@children.9/@children.2/@ports.0" targets="//@children.11/@children.0/@children.9/@ports.2"/>
+        <containedEdges identifier="E165" sources="//@children.11/@children.0/@children.9/@children.3/@ports.0" targets="//@children.11/@children.0/@children.9/@ports.3"/>
+      </children>
+      <children identifier="N89">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L89" height="15.0" width="169.0" text="ContinuousTransferFunction5"/>
+        <ports identifier="P204" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@children.10/@containedEdges.0" incomingEdges="//@children.11/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P205" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.14" incomingEdges="//@children.11/@children.0/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N90" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L90" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.10/@containedEdges.0 //@children.11/@children.0/@children.10/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P208" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N91" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L91" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.10/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P211" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N92" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L92" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P212" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P214" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.10/@containedEdges.3 //@children.11/@children.0/@children.10/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P215" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N93" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P217" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.10/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.10/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P219" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.10/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E166" sources="//@children.11/@children.0/@children.10/@ports.0" targets="//@children.11/@children.0/@children.10/@children.0/@ports.0"/>
+        <containedEdges identifier="E167" sources="//@children.11/@children.0/@children.10/@children.0/@ports.2" targets="//@children.11/@children.0/@children.10/@children.2/@ports.1"/>
+        <containedEdges identifier="E168" sources="//@children.11/@children.0/@children.10/@children.1/@ports.2" targets="//@children.11/@children.0/@children.10/@ports.1"/>
+        <containedEdges identifier="E169" sources="//@children.11/@children.0/@children.10/@children.2/@ports.2" targets="//@children.11/@children.0/@children.10/@children.3/@ports.0"/>
+        <containedEdges identifier="E170" sources="//@children.11/@children.0/@children.10/@children.2/@ports.2" targets="//@children.11/@children.0/@children.10/@children.4/@ports.0"/>
+        <containedEdges identifier="E171" sources="//@children.11/@children.0/@children.10/@children.3/@ports.1" targets="//@children.11/@children.0/@children.10/@children.0/@ports.0"/>
+        <containedEdges identifier="E172" sources="//@children.11/@children.0/@children.10/@children.4/@ports.1" targets="//@children.11/@children.0/@children.10/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N95">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L95" height="15.0" width="169.0" text="ContinuousTransferFunction6"/>
+        <ports identifier="P220" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@children.11/@containedEdges.0" incomingEdges="//@children.11/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P221" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.15" incomingEdges="//@children.11/@children.0/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N96" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L96" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.11/@containedEdges.0 //@children.11/@children.0/@children.11/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P224" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.11/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N97" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L97" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.11/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P227" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.11/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N98" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L98" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P228" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.11/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P230" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.11/@containedEdges.3 //@children.11/@children.0/@children.11/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P231" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N99" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L99" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.11/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P233" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.11/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N100" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L100" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.11/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P235" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.11/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E173" sources="//@children.11/@children.0/@children.11/@ports.0" targets="//@children.11/@children.0/@children.11/@children.0/@ports.0"/>
+        <containedEdges identifier="E174" sources="//@children.11/@children.0/@children.11/@children.0/@ports.2" targets="//@children.11/@children.0/@children.11/@children.2/@ports.1"/>
+        <containedEdges identifier="E175" sources="//@children.11/@children.0/@children.11/@children.1/@ports.2" targets="//@children.11/@children.0/@children.11/@ports.1"/>
+        <containedEdges identifier="E176" sources="//@children.11/@children.0/@children.11/@children.2/@ports.2" targets="//@children.11/@children.0/@children.11/@children.3/@ports.0"/>
+        <containedEdges identifier="E177" sources="//@children.11/@children.0/@children.11/@children.2/@ports.2" targets="//@children.11/@children.0/@children.11/@children.4/@ports.0"/>
+        <containedEdges identifier="E178" sources="//@children.11/@children.0/@children.11/@children.3/@ports.1" targets="//@children.11/@children.0/@children.11/@children.0/@ports.0"/>
+        <containedEdges identifier="E179" sources="//@children.11/@children.0/@children.11/@children.4/@ports.1" targets="//@children.11/@children.0/@children.11/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N101">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L101" height="15.0" width="169.0" text="ContinuousTransferFunction7"/>
+        <ports identifier="P236" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@children.12/@containedEdges.0" incomingEdges="//@children.11/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P237" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.16" incomingEdges="//@children.11/@children.0/@children.12/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N102" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L102" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.12/@containedEdges.0 //@children.11/@children.0/@children.12/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P240" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.12/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N103" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L103" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.0/@children.12/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P243" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@children.12/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N104" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L104" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P244" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.12/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P246" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.12/@containedEdges.3 //@children.11/@children.0/@children.12/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P247" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N105" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L105" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.12/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P249" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.12/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N106" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L106" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.12/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P251" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.12/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E180" sources="//@children.11/@children.0/@children.12/@ports.0" targets="//@children.11/@children.0/@children.12/@children.0/@ports.0"/>
+        <containedEdges identifier="E181" sources="//@children.11/@children.0/@children.12/@children.0/@ports.2" targets="//@children.11/@children.0/@children.12/@children.2/@ports.1"/>
+        <containedEdges identifier="E182" sources="//@children.11/@children.0/@children.12/@children.1/@ports.2" targets="//@children.11/@children.0/@children.12/@ports.1"/>
+        <containedEdges identifier="E183" sources="//@children.11/@children.0/@children.12/@children.2/@ports.2" targets="//@children.11/@children.0/@children.12/@children.3/@ports.0"/>
+        <containedEdges identifier="E184" sources="//@children.11/@children.0/@children.12/@children.2/@ports.2" targets="//@children.11/@children.0/@children.12/@children.4/@ports.0"/>
+        <containedEdges identifier="E185" sources="//@children.11/@children.0/@children.12/@children.3/@ports.1" targets="//@children.11/@children.0/@children.12/@children.0/@ports.0"/>
+        <containedEdges identifier="E186" sources="//@children.11/@children.0/@children.12/@children.4/@ports.1" targets="//@children.11/@children.0/@children.12/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N107" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="117.0" text="VectorDisassembler"/>
+        <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P253" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.17 //@children.11/@children.0/@containedEdges.18 //@children.11/@children.0/@containedEdges.19 //@children.11/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="100.0" text="VectorAssembler"/>
+        <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.6 //@children.11/@children.0/@containedEdges.7 //@children.11/@children.0/@containedEdges.8 //@children.11/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P255" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E133" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E134" sources="//@children.11/@children.0/@children.0/@ports.1" targets="//@children.11/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E135" sources="//@children.11/@children.0/@children.1/@ports.1" targets="//@children.11/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.11/@children.0/@children.2/@ports.1" targets="//@children.11/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E137" sources="//@children.11/@children.0/@children.3/@ports.1" targets="//@children.11/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E138" sources="//@children.11/@children.0/@children.4/@ports.1" targets="//@children.11/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E139" sources="//@children.11/@children.0/@children.5/@ports.2" targets="//@children.11/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E140" sources="//@children.11/@children.0/@children.6/@ports.2" targets="//@children.11/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E141" sources="//@children.11/@children.0/@children.7/@ports.2" targets="//@children.11/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E142" sources="//@children.11/@children.0/@children.8/@ports.2" targets="//@children.11/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E143" sources="//@children.11/@children.0/@children.9/@ports.0" targets="//@children.11/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E144" sources="//@children.11/@children.0/@children.9/@ports.1" targets="//@children.11/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E145" sources="//@children.11/@children.0/@children.9/@ports.2" targets="//@children.11/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E146" sources="//@children.11/@children.0/@children.9/@ports.3" targets="//@children.11/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E147" sources="//@children.11/@children.0/@children.10/@ports.1" targets="//@children.11/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E148" sources="//@children.11/@children.0/@children.11/@ports.1" targets="//@children.11/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E149" sources="//@children.11/@children.0/@children.12/@ports.1" targets="//@children.11/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E150" sources="//@children.11/@children.0/@children.13/@ports.1" targets="//@children.11/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E151" sources="//@children.11/@children.0/@children.13/@ports.1" targets="//@children.11/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E152" sources="//@children.11/@children.0/@children.13/@ports.1" targets="//@children.11/@children.0/@children.11/@ports.0"/>
+      <containedEdges identifier="E153" sources="//@children.11/@children.0/@children.13/@ports.1" targets="//@children.11/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E154" sources="//@children.11/@children.0/@children.14/@ports.1" targets="//@children.11/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N109">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L109" height="15.0" width="120.0" text="Aerodynamic Effects"/>
+      <ports identifier="P256" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.0" incomingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P257" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.1 //@children.11/@children.1/@containedEdges.2" incomingEdges="//@children.11/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P258" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.4 //@children.11/@containedEdges.5" incomingEdges="//@children.11/@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P259" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.3" incomingEdges="//@children.11/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N110" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L110" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@containedEdges.0 //@children.11/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P262" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.3 //@children.11/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N111">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L111" height="15.0" width="54.0" text="Moments"/>
+        <ports identifier="P263" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.8 //@children.11/@children.1/@children.1/@containedEdges.9" incomingEdges="//@children.11/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P264" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.0 //@children.11/@children.1/@children.1/@containedEdges.1 //@children.11/@children.1/@children.1/@containedEdges.2 //@children.11/@children.1/@children.1/@containedEdges.3 //@children.11/@children.1/@children.1/@containedEdges.4 //@children.11/@children.1/@children.1/@containedEdges.5 //@children.11/@children.1/@children.1/@containedEdges.6 //@children.11/@children.1/@children.1/@containedEdges.7" incomingEdges="//@children.11/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P265" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.5" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N112" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.0 //@children.11/@children.1/@children.1/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P268" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.1 //@children.11/@children.1/@children.1/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P271" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N114" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L114" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.2 //@children.11/@children.1/@children.1/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P274" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N115" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L115" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.3 //@children.11/@children.1/@children.1/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P277" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N116" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L116" height="15.0" width="87.0" text="MultiplyDivide5"/>
+          <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.4 //@children.11/@children.1/@children.1/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P280" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N117" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="87.0" text="MultiplyDivide6"/>
+          <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.5 //@children.11/@children.1/@children.1/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P283" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N118" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L118" height="15.0" width="87.0" text="MultiplyDivide7"/>
+          <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.6 //@children.11/@children.1/@children.1/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P286" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N119" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="87.0" text="MultiplyDivide8"/>
+          <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.7 //@children.11/@children.1/@children.1/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P289" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N120">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L120" height="15.0" width="131.0" text="Motor Thrust to Torque"/>
+          <ports identifier="P290" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.18" incomingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P291" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.19" incomingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P292" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.20" incomingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P293" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.21" incomingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P294" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <children identifier="N121" height="46.0" width="66.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L121" height="15.0" width="34.0" text="Scale"/>
+            <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P296" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N122" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L122" height="15.0" width="117.0" text="VectorDisassembler"/>
+            <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P298" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.8/@containedEdges.2 //@children.11/@children.1/@children.1/@children.8/@containedEdges.3 //@children.11/@children.1/@children.1/@children.8/@containedEdges.4 //@children.11/@children.1/@children.1/@children.8/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E248" sources="//@children.11/@children.1/@children.1/@children.8/@ports.4" targets="//@children.11/@children.1/@children.1/@children.8/@children.0/@ports.0"/>
+          <containedEdges identifier="E249" sources="//@children.11/@children.1/@children.1/@children.8/@children.0/@ports.1" targets="//@children.11/@children.1/@children.1/@children.8/@children.1/@ports.0"/>
+          <containedEdges identifier="E250" sources="//@children.11/@children.1/@children.1/@children.8/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.8/@ports.0"/>
+          <containedEdges identifier="E251" sources="//@children.11/@children.1/@children.1/@children.8/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.8/@ports.1"/>
+          <containedEdges identifier="E252" sources="//@children.11/@children.1/@children.1/@children.8/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.8/@ports.2"/>
+          <containedEdges identifier="E253" sources="//@children.11/@children.1/@children.1/@children.8/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.8/@ports.3"/>
+        </children>
+        <children identifier="N123" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L123" height="15.0" width="41.0" text="Motor1"/>
+          <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P300" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N124" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L124" height="15.0" width="41.0" text="Motor4"/>
+          <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P302" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N125" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L125" height="15.0" width="41.0" text="Motor2"/>
+          <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P304" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N126" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L126" height="15.0" width="41.0" text="Motor3"/>
+          <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P306" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N127" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L127" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.22 //@children.11/@children.1/@children.1/@containedEdges.23 //@children.11/@children.1/@children.1/@containedEdges.24 //@children.11/@children.1/@children.1/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P309" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N128" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L128" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.26 //@children.11/@children.1/@children.1/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P312" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N129" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L129" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.37 //@children.11/@children.1/@children.1/@containedEdges.38 //@children.11/@children.1/@children.1/@containedEdges.39 //@children.11/@children.1/@children.1/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P315" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N130" height="25.0" width="22.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L130" height="15.0" width="74.0" text="Moment Arm"/>
+          <ports identifier="P316" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N131" height="25.0" width="22.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L131" height="15.0" width="82.0" text="Moment Arm2"/>
+          <ports identifier="P318" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N132" height="25.0" width="22.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L132" height="15.0" width="82.0" text="Moment Arm3"/>
+          <ports identifier="P320" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N133" height="25.0" width="22.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L133" height="15.0" width="82.0" text="Moment Arm4"/>
+          <ports identifier="P322" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N134" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L134" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P325" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.33 //@children.11/@children.1/@children.1/@containedEdges.34 //@children.11/@children.1/@children.1/@containedEdges.35 //@children.11/@children.1/@children.1/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N135">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L135" height="15.0" width="120.0" text="CrossProduct(AXB)3"/>
+          <ports identifier="P326" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P327" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.1" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P328" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.37" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N136" height="25.0" width="313.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L136" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P329" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="-4"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="-5"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="-6"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N137" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L137" height="15.0" width="117.0" text="VectorDisassembler"/>
+            <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P337" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.3 //@children.11/@children.1/@children.1/@children.21/@containedEdges.4 //@children.11/@children.1/@children.1/@children.21/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N138" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L138" height="15.0" width="124.0" text="VectorDisassembler2"/>
+            <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P339" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.21/@containedEdges.6 //@children.11/@children.1/@children.1/@children.21/@containedEdges.7 //@children.11/@children.1/@children.1/@children.21/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E254" sources="//@children.11/@children.1/@children.1/@children.21/@ports.0" targets="//@children.11/@children.1/@children.1/@children.21/@children.1/@ports.0"/>
+          <containedEdges identifier="E255" sources="//@children.11/@children.1/@children.1/@children.21/@ports.1" targets="//@children.11/@children.1/@children.1/@children.21/@children.2/@ports.0"/>
+          <containedEdges identifier="E256" sources="//@children.11/@children.1/@children.1/@children.21/@children.0/@ports.0" targets="//@children.11/@children.1/@children.1/@children.21/@ports.2"/>
+          <containedEdges identifier="E257" sources="//@children.11/@children.1/@children.1/@children.21/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.21/@children.0/@ports.1"/>
+          <containedEdges identifier="E258" sources="//@children.11/@children.1/@children.1/@children.21/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.21/@children.0/@ports.2"/>
+          <containedEdges identifier="E259" sources="//@children.11/@children.1/@children.1/@children.21/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.21/@children.0/@ports.3"/>
+          <containedEdges identifier="E260" sources="//@children.11/@children.1/@children.1/@children.21/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.21/@children.0/@ports.4"/>
+          <containedEdges identifier="E261" sources="//@children.11/@children.1/@children.1/@children.21/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.21/@children.0/@ports.5"/>
+          <containedEdges identifier="E262" sources="//@children.11/@children.1/@children.1/@children.21/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.21/@children.0/@ports.6"/>
+        </children>
+        <children identifier="N139">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L139" height="15.0" width="120.0" text="CrossProduct(AXB)4"/>
+          <ports identifier="P340" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P341" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.1" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P342" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.38" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N140" height="25.0" width="313.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L140" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P343" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="-4"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P348" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="-5"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="-6"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N141" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L141" height="15.0" width="117.0" text="VectorDisassembler"/>
+            <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P351" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.3 //@children.11/@children.1/@children.1/@children.22/@containedEdges.4 //@children.11/@children.1/@children.1/@children.22/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N142" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L142" height="15.0" width="124.0" text="VectorDisassembler2"/>
+            <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P353" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.22/@containedEdges.6 //@children.11/@children.1/@children.1/@children.22/@containedEdges.7 //@children.11/@children.1/@children.1/@children.22/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E263" sources="//@children.11/@children.1/@children.1/@children.22/@ports.0" targets="//@children.11/@children.1/@children.1/@children.22/@children.1/@ports.0"/>
+          <containedEdges identifier="E264" sources="//@children.11/@children.1/@children.1/@children.22/@ports.1" targets="//@children.11/@children.1/@children.1/@children.22/@children.2/@ports.0"/>
+          <containedEdges identifier="E265" sources="//@children.11/@children.1/@children.1/@children.22/@children.0/@ports.0" targets="//@children.11/@children.1/@children.1/@children.22/@ports.2"/>
+          <containedEdges identifier="E266" sources="//@children.11/@children.1/@children.1/@children.22/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.22/@children.0/@ports.1"/>
+          <containedEdges identifier="E267" sources="//@children.11/@children.1/@children.1/@children.22/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.22/@children.0/@ports.2"/>
+          <containedEdges identifier="E268" sources="//@children.11/@children.1/@children.1/@children.22/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.22/@children.0/@ports.3"/>
+          <containedEdges identifier="E269" sources="//@children.11/@children.1/@children.1/@children.22/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.22/@children.0/@ports.4"/>
+          <containedEdges identifier="E270" sources="//@children.11/@children.1/@children.1/@children.22/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.22/@children.0/@ports.5"/>
+          <containedEdges identifier="E271" sources="//@children.11/@children.1/@children.1/@children.22/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.22/@children.0/@ports.6"/>
+        </children>
+        <children identifier="N143">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L143" height="15.0" width="113.0" text="CrossProduct(AXB)"/>
+          <ports identifier="P354" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P355" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.1" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P356" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.39" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N144" height="25.0" width="313.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L144" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P357" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P361" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="-4"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="-5"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="-6"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N145" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L145" height="15.0" width="117.0" text="VectorDisassembler"/>
+            <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P365" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.3 //@children.11/@children.1/@children.1/@children.23/@containedEdges.4 //@children.11/@children.1/@children.1/@children.23/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N146" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L146" height="15.0" width="124.0" text="VectorDisassembler2"/>
+            <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P367" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.23/@containedEdges.6 //@children.11/@children.1/@children.1/@children.23/@containedEdges.7 //@children.11/@children.1/@children.1/@children.23/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E272" sources="//@children.11/@children.1/@children.1/@children.23/@ports.0" targets="//@children.11/@children.1/@children.1/@children.23/@children.1/@ports.0"/>
+          <containedEdges identifier="E273" sources="//@children.11/@children.1/@children.1/@children.23/@ports.1" targets="//@children.11/@children.1/@children.1/@children.23/@children.2/@ports.0"/>
+          <containedEdges identifier="E274" sources="//@children.11/@children.1/@children.1/@children.23/@children.0/@ports.0" targets="//@children.11/@children.1/@children.1/@children.23/@ports.2"/>
+          <containedEdges identifier="E275" sources="//@children.11/@children.1/@children.1/@children.23/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.23/@children.0/@ports.1"/>
+          <containedEdges identifier="E276" sources="//@children.11/@children.1/@children.1/@children.23/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.23/@children.0/@ports.2"/>
+          <containedEdges identifier="E277" sources="//@children.11/@children.1/@children.1/@children.23/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.23/@children.0/@ports.3"/>
+          <containedEdges identifier="E278" sources="//@children.11/@children.1/@children.1/@children.23/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.23/@children.0/@ports.4"/>
+          <containedEdges identifier="E279" sources="//@children.11/@children.1/@children.1/@children.23/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.23/@children.0/@ports.5"/>
+          <containedEdges identifier="E280" sources="//@children.11/@children.1/@children.1/@children.23/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.23/@children.0/@ports.6"/>
+        </children>
+        <children identifier="N147">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L147" height="15.0" width="120.0" text="CrossProduct(AXB)2"/>
+          <ports identifier="P368" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P369" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.1" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P370" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.40" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N148" height="25.0" width="313.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L148" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P371" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P372" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P374" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="-4"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="-5"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P377" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="-6"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N149" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L149" height="15.0" width="117.0" text="VectorDisassembler"/>
+            <ports identifier="P378" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P379" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.3 //@children.11/@children.1/@children.1/@children.24/@containedEdges.4 //@children.11/@children.1/@children.1/@children.24/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N150" height="41.0" width="10.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L150" height="15.0" width="124.0" text="VectorDisassembler2"/>
+            <ports identifier="P380" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P381" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@children.24/@containedEdges.6 //@children.11/@children.1/@children.1/@children.24/@containedEdges.7 //@children.11/@children.1/@children.1/@children.24/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E281" sources="//@children.11/@children.1/@children.1/@children.24/@ports.0" targets="//@children.11/@children.1/@children.1/@children.24/@children.1/@ports.0"/>
+          <containedEdges identifier="E282" sources="//@children.11/@children.1/@children.1/@children.24/@ports.1" targets="//@children.11/@children.1/@children.1/@children.24/@children.2/@ports.0"/>
+          <containedEdges identifier="E283" sources="//@children.11/@children.1/@children.1/@children.24/@children.0/@ports.0" targets="//@children.11/@children.1/@children.1/@children.24/@ports.2"/>
+          <containedEdges identifier="E284" sources="//@children.11/@children.1/@children.1/@children.24/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.24/@children.0/@ports.1"/>
+          <containedEdges identifier="E285" sources="//@children.11/@children.1/@children.1/@children.24/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.24/@children.0/@ports.2"/>
+          <containedEdges identifier="E286" sources="//@children.11/@children.1/@children.1/@children.24/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.24/@children.0/@ports.3"/>
+          <containedEdges identifier="E287" sources="//@children.11/@children.1/@children.1/@children.24/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.24/@children.0/@ports.4"/>
+          <containedEdges identifier="E288" sources="//@children.11/@children.1/@children.1/@children.24/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.24/@children.0/@ports.5"/>
+          <containedEdges identifier="E289" sources="//@children.11/@children.1/@children.1/@children.24/@children.2/@ports.1" targets="//@children.11/@children.1/@children.1/@children.24/@children.0/@ports.6"/>
+        </children>
+        <containedEdges identifier="E207" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E208" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E209" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E210" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E211" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E212" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.5/@ports.0"/>
+        <containedEdges identifier="E213" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E214" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.7/@ports.0"/>
+        <containedEdges identifier="E215" sources="//@children.11/@children.1/@children.1/@ports.0" targets="//@children.11/@children.1/@children.1/@children.8/@ports.4"/>
+        <containedEdges identifier="E216" sources="//@children.11/@children.1/@children.1/@ports.0" targets="//@children.11/@children.1/@children.1/@children.20/@ports.0"/>
+        <containedEdges identifier="E217" sources="//@children.11/@children.1/@children.1/@children.0/@ports.2" targets="//@children.11/@children.1/@children.1/@children.21/@ports.1"/>
+        <containedEdges identifier="E218" sources="//@children.11/@children.1/@children.1/@children.1/@ports.2" targets="//@children.11/@children.1/@children.1/@children.22/@ports.1"/>
+        <containedEdges identifier="E219" sources="//@children.11/@children.1/@children.1/@children.2/@ports.2" targets="//@children.11/@children.1/@children.1/@children.23/@ports.1"/>
+        <containedEdges identifier="E220" sources="//@children.11/@children.1/@children.1/@children.3/@ports.2" targets="//@children.11/@children.1/@children.1/@children.24/@ports.1"/>
+        <containedEdges identifier="E221" sources="//@children.11/@children.1/@children.1/@children.4/@ports.2" targets="//@children.11/@children.1/@children.1/@children.9/@ports.0"/>
+        <containedEdges identifier="E222" sources="//@children.11/@children.1/@children.1/@children.5/@ports.2" targets="//@children.11/@children.1/@children.1/@children.11/@ports.0"/>
+        <containedEdges identifier="E223" sources="//@children.11/@children.1/@children.1/@children.6/@ports.2" targets="//@children.11/@children.1/@children.1/@children.12/@ports.0"/>
+        <containedEdges identifier="E224" sources="//@children.11/@children.1/@children.1/@children.7/@ports.2" targets="//@children.11/@children.1/@children.1/@children.10/@ports.0"/>
+        <containedEdges identifier="E225" sources="//@children.11/@children.1/@children.1/@children.8/@ports.0" targets="//@children.11/@children.1/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E226" sources="//@children.11/@children.1/@children.1/@children.8/@ports.1" targets="//@children.11/@children.1/@children.1/@children.5/@ports.0"/>
+        <containedEdges identifier="E227" sources="//@children.11/@children.1/@children.1/@children.8/@ports.2" targets="//@children.11/@children.1/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E228" sources="//@children.11/@children.1/@children.1/@children.8/@ports.3" targets="//@children.11/@children.1/@children.1/@children.7/@ports.0"/>
+        <containedEdges identifier="E229" sources="//@children.11/@children.1/@children.1/@children.9/@ports.1" targets="//@children.11/@children.1/@children.1/@children.13/@ports.0"/>
+        <containedEdges identifier="E230" sources="//@children.11/@children.1/@children.1/@children.10/@ports.1" targets="//@children.11/@children.1/@children.1/@children.13/@ports.0"/>
+        <containedEdges identifier="E231" sources="//@children.11/@children.1/@children.1/@children.11/@ports.1" targets="//@children.11/@children.1/@children.1/@children.13/@ports.0"/>
+        <containedEdges identifier="E232" sources="//@children.11/@children.1/@children.1/@children.12/@ports.1" targets="//@children.11/@children.1/@children.1/@children.13/@ports.0"/>
+        <containedEdges identifier="E233" sources="//@children.11/@children.1/@children.1/@children.13/@ports.2" targets="//@children.11/@children.1/@children.1/@children.14/@ports.0"/>
+        <containedEdges identifier="E234" sources="//@children.11/@children.1/@children.1/@children.14/@ports.2" targets="//@children.11/@children.1/@children.1/@ports.2"/>
+        <containedEdges identifier="E235" sources="//@children.11/@children.1/@children.1/@children.15/@ports.2" targets="//@children.11/@children.1/@children.1/@children.14/@ports.0"/>
+        <containedEdges identifier="E236" sources="//@children.11/@children.1/@children.1/@children.16/@ports.0" targets="//@children.11/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E237" sources="//@children.11/@children.1/@children.1/@children.17/@ports.0" targets="//@children.11/@children.1/@children.1/@children.22/@ports.0"/>
+        <containedEdges identifier="E238" sources="//@children.11/@children.1/@children.1/@children.18/@ports.0" targets="//@children.11/@children.1/@children.1/@children.23/@ports.0"/>
+        <containedEdges identifier="E239" sources="//@children.11/@children.1/@children.1/@children.19/@ports.0" targets="//@children.11/@children.1/@children.1/@children.24/@ports.0"/>
+        <containedEdges identifier="E240" sources="//@children.11/@children.1/@children.1/@children.20/@ports.1" targets="//@children.11/@children.1/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E241" sources="//@children.11/@children.1/@children.1/@children.20/@ports.1" targets="//@children.11/@children.1/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E242" sources="//@children.11/@children.1/@children.1/@children.20/@ports.1" targets="//@children.11/@children.1/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E243" sources="//@children.11/@children.1/@children.1/@children.20/@ports.1" targets="//@children.11/@children.1/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E244" sources="//@children.11/@children.1/@children.1/@children.21/@ports.2" targets="//@children.11/@children.1/@children.1/@children.15/@ports.0"/>
+        <containedEdges identifier="E245" sources="//@children.11/@children.1/@children.1/@children.22/@ports.2" targets="//@children.11/@children.1/@children.1/@children.15/@ports.0"/>
+        <containedEdges identifier="E246" sources="//@children.11/@children.1/@children.1/@children.23/@ports.2" targets="//@children.11/@children.1/@children.1/@children.15/@ports.0"/>
+        <containedEdges identifier="E247" sources="//@children.11/@children.1/@children.1/@children.24/@ports.2" targets="//@children.11/@children.1/@children.1/@children.15/@ports.0"/>
+      </children>
+      <children identifier="N151" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L151" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@containedEdges.10 //@children.11/@children.1/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P384" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N152" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L152" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P385" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P387" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.7 //@children.11/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N153">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L153" height="15.0" width="111.0" text="Flapping Dynamics"/>
+        <ports identifier="P388" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.0 //@children.11/@children.1/@children.4/@containedEdges.1 //@children.11/@children.1/@children.4/@containedEdges.2" incomingEdges="//@children.11/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P389" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.9 //@children.11/@children.1/@containedEdges.10" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P390" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.11" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N154" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L154" height="15.0" width="65.0" text="DotProduct"/>
+          <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P393" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N155" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L155" height="15.0" width="114.0" text="UnaryMathFunction"/>
+          <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P395" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.4 //@children.11/@children.1/@children.4/@containedEdges.5 //@children.11/@children.1/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N156" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L156" height="15.0" width="93.0" text="Flap Angle Gain"/>
+          <ports identifier="P396" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P397" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.7 //@children.11/@children.1/@children.4/@containedEdges.8 //@children.11/@children.1/@children.4/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N157" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L157" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P399" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N158" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L158" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P401" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N159" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L159" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.9 //@children.11/@children.1/@children.4/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P404" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N160" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L160" height="15.0" width="109.0" text="rotate 90 degrees2"/>
+          <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P406" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N161" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L161" height="15.0" width="28.0" text="Gain"/>
+          <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P408" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N162" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L162" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.10 //@children.11/@children.1/@children.4/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P411" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N163" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L163" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P412" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.15 //@children.11/@children.1/@children.4/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P413" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P414" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N164" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L164" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P415" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.11 //@children.11/@children.1/@children.4/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P416" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P417" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N165" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L165" height="15.0" width="109.0" text="rotate 90 degrees3"/>
+          <ports identifier="P418" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P419" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N166" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L166" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P420" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.5 //@children.11/@children.1/@children.4/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P421" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P422" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N167" height="25.0" width="55.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L167" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P423" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P424" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N168" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L168" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P425" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P426" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P427" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N169" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L169" height="15.0" width="45.0" text="Select2"/>
+          <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.21 //@children.11/@children.1/@children.4/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P429" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.22 //@children.11/@children.1/@children.4/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P430" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N170" height="25.0" width="88.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L170" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P431" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N171" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L171" height="15.0" width="42.0" text="Body Z"/>
+          <ports identifier="P433" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N172" height="25.0" width="137.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L172" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P435" height="8.0" width="8.0" x="137.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.26 //@children.11/@children.1/@children.4/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P436" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N173" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L173" height="15.0" width="87.0" text="MultiplyDivide5"/>
+          <ports identifier="P437" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@children.4/@containedEdges.23 //@children.11/@children.1/@children.4/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P438" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P439" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N174" height="25.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L174" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P440" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.4/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E290" sources="//@children.11/@children.1/@children.4/@ports.0" targets="//@children.11/@children.1/@children.4/@children.14/@ports.0"/>
+        <containedEdges identifier="E291" sources="//@children.11/@children.1/@children.4/@ports.0" targets="//@children.11/@children.1/@children.4/@children.0/@ports.0"/>
+        <containedEdges identifier="E292" sources="//@children.11/@children.1/@children.4/@ports.0" targets="//@children.11/@children.1/@children.4/@children.0/@ports.1"/>
+        <containedEdges identifier="E293" sources="//@children.11/@children.1/@children.4/@children.0/@ports.2" targets="//@children.11/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E294" sources="//@children.11/@children.1/@children.4/@children.1/@ports.1" targets="//@children.11/@children.1/@children.4/@children.2/@ports.0"/>
+        <containedEdges identifier="E295" sources="//@children.11/@children.1/@children.4/@children.1/@ports.1" targets="//@children.11/@children.1/@children.4/@children.12/@ports.0"/>
+        <containedEdges identifier="E296" sources="//@children.11/@children.1/@children.4/@children.1/@ports.1" targets="//@children.11/@children.1/@children.4/@children.18/@ports.1"/>
+        <containedEdges identifier="E297" sources="//@children.11/@children.1/@children.4/@children.2/@ports.1" targets="//@children.11/@children.1/@children.4/@children.3/@ports.0"/>
+        <containedEdges identifier="E298" sources="//@children.11/@children.1/@children.4/@children.2/@ports.1" targets="//@children.11/@children.1/@children.4/@children.4/@ports.0"/>
+        <containedEdges identifier="E299" sources="//@children.11/@children.1/@children.4/@children.2/@ports.1" targets="//@children.11/@children.1/@children.4/@children.5/@ports.0"/>
+        <containedEdges identifier="E300" sources="//@children.11/@children.1/@children.4/@children.3/@ports.1" targets="//@children.11/@children.1/@children.4/@children.8/@ports.0"/>
+        <containedEdges identifier="E301" sources="//@children.11/@children.1/@children.4/@children.4/@ports.1" targets="//@children.11/@children.1/@children.4/@children.10/@ports.0"/>
+        <containedEdges identifier="E302" sources="//@children.11/@children.1/@children.4/@children.5/@ports.2" targets="//@children.11/@children.1/@children.4/@children.6/@ports.0"/>
+        <containedEdges identifier="E303" sources="//@children.11/@children.1/@children.4/@children.6/@ports.1" targets="//@children.11/@children.1/@children.4/@children.7/@ports.0"/>
+        <containedEdges identifier="E304" sources="//@children.11/@children.1/@children.4/@children.7/@ports.1" targets="//@children.11/@children.1/@children.4/@ports.2"/>
+        <containedEdges identifier="E305" sources="//@children.11/@children.1/@children.4/@children.8/@ports.2" targets="//@children.11/@children.1/@children.4/@children.9/@ports.0"/>
+        <containedEdges identifier="E306" sources="//@children.11/@children.1/@children.4/@children.9/@ports.2" targets="//@children.11/@children.1/@children.4/@ports.1"/>
+        <containedEdges identifier="E307" sources="//@children.11/@children.1/@children.4/@children.10/@ports.2" targets="//@children.11/@children.1/@children.4/@children.9/@ports.0"/>
+        <containedEdges identifier="E308" sources="//@children.11/@children.1/@children.4/@children.11/@ports.1" targets="//@children.11/@children.1/@children.4/@children.10/@ports.0"/>
+        <containedEdges identifier="E309" sources="//@children.11/@children.1/@children.4/@children.12/@ports.1" targets="//@children.11/@children.1/@children.4/@children.14/@ports.1"/>
+        <containedEdges identifier="E310" sources="//@children.11/@children.1/@children.4/@children.13/@ports.0" targets="//@children.11/@children.1/@children.4/@children.12/@ports.0"/>
+        <containedEdges identifier="E311" sources="//@children.11/@children.1/@children.4/@children.14/@ports.2" targets="//@children.11/@children.1/@children.4/@children.15/@ports.0"/>
+        <containedEdges identifier="E312" sources="//@children.11/@children.1/@children.4/@children.15/@ports.1" targets="//@children.11/@children.1/@children.4/@children.11/@ports.0"/>
+        <containedEdges identifier="E313" sources="//@children.11/@children.1/@children.4/@children.15/@ports.1" targets="//@children.11/@children.1/@children.4/@children.19/@ports.0"/>
+        <containedEdges identifier="E314" sources="//@children.11/@children.1/@children.4/@children.16/@ports.0" targets="//@children.11/@children.1/@children.4/@children.15/@ports.0"/>
+        <containedEdges identifier="E315" sources="//@children.11/@children.1/@children.4/@children.17/@ports.0" targets="//@children.11/@children.1/@children.4/@children.8/@ports.0"/>
+        <containedEdges identifier="E316" sources="//@children.11/@children.1/@children.4/@children.18/@ports.0" targets="//@children.11/@children.1/@children.4/@children.12/@ports.2"/>
+        <containedEdges identifier="E317" sources="//@children.11/@children.1/@children.4/@children.18/@ports.0" targets="//@children.11/@children.1/@children.4/@children.15/@ports.2"/>
+        <containedEdges identifier="E318" sources="//@children.11/@children.1/@children.4/@children.19/@ports.2" targets="//@children.11/@children.1/@children.4/@children.5/@ports.0"/>
+        <containedEdges identifier="E319" sources="//@children.11/@children.1/@children.4/@children.20/@ports.0" targets="//@children.11/@children.1/@children.4/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N175">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L175" height="15.0" width="142.0" text="Vertical Effect Dynamics"/>
+        <ports identifier="P442" height="8.0" width="8.0" incomingEdges="//@children.11/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P443" height="8.0" width="8.0" incomingEdges="//@children.11/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P444" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.12" incomingEdges="//@children.11/@children.1/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N176" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L176" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P445" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.5/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E320" sources="//@children.11/@children.1/@children.5/@children.0/@ports.0" targets="//@children.11/@children.1/@children.5/@ports.2"/>
+      </children>
+      <children identifier="N177" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L177" height="15.0" width="87.0" text="MultiplyDivide3"/>
+        <ports identifier="P447" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@containedEdges.1 //@children.11/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P448" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P449" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.13 //@children.11/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N178" height="25.0" width="145.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L178" height="15.0" width="126.0" text="Pick First 2 Elements"/>
+        <ports identifier="P450" height="8.0" width="8.0" x="145.0" y="8.5" outgoingEdges="//@children.11/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P451" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N179" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L179" height="15.0" width="117.0" text="VectorDisassembler"/>
+        <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P453" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.16 //@children.11/@children.1/@containedEdges.17 //@children.11/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N180" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L180" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P454" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.1/@containedEdges.16 //@children.11/@children.1/@containedEdges.17 //@children.11/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P456" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N181" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L181" height="15.0" width="21.0" text="flap"/>
+        <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.11/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E187" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E188" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E189" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E190" sources="//@children.11/@children.1/@children.0/@ports.2" targets="//@children.11/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E191" sources="//@children.11/@children.1/@children.0/@ports.2" targets="//@children.11/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E192" sources="//@children.11/@children.1/@children.1/@ports.2" targets="//@children.11/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E193" sources="//@children.11/@children.1/@children.2/@ports.2" targets="//@children.11/@children.1/@ports.2"/>
+      <containedEdges identifier="E194" sources="//@children.11/@children.1/@children.3/@ports.2" targets="//@children.11/@children.1/@ports.3"/>
+      <containedEdges identifier="E195" sources="//@children.11/@children.1/@children.3/@ports.2" targets="//@children.11/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E196" sources="//@children.11/@children.1/@children.4/@ports.1" targets="//@children.11/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E197" sources="//@children.11/@children.1/@children.4/@ports.1" targets="//@children.11/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E198" sources="//@children.11/@children.1/@children.4/@ports.2" targets="//@children.11/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E199" sources="//@children.11/@children.1/@children.5/@ports.2" targets="//@children.11/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E200" sources="//@children.11/@children.1/@children.6/@ports.2" targets="//@children.11/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E201" sources="//@children.11/@children.1/@children.6/@ports.2" targets="//@children.11/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E202" sources="//@children.11/@children.1/@children.7/@ports.0" targets="//@children.11/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E203" sources="//@children.11/@children.1/@children.8/@ports.1" targets="//@children.11/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E204" sources="//@children.11/@children.1/@children.8/@ports.1" targets="//@children.11/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E205" sources="//@children.11/@children.1/@children.8/@ports.1" targets="//@children.11/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E206" sources="//@children.11/@children.1/@children.9/@ports.2" targets="//@children.11/@children.1/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N182">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L182" height="15.0" width="160.0" text="6DOF (Eurler Angles)_CMU"/>
+      <ports identifier="P458" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.0" incomingEdges="//@children.11/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P459" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.1" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P460" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.14" incomingEdges="//@children.11/@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P461" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.10 //@children.11/@containedEdges.11" incomingEdges="//@children.11/@children.2/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P462" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.12 //@children.11/@containedEdges.13" incomingEdges="//@children.11/@children.2/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P463" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.6 //@children.11/@containedEdges.7" incomingEdges="//@children.11/@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P464" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.8" incomingEdges="//@children.11/@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P465" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P466" height="8.0" width="8.0" incomingEdges="//@children.11/@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="8"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P467" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.15" incomingEdges="//@children.11/@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="9"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N183" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L183" height="15.0" width="28.0" text="Gain"/>
+        <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P469" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@containedEdges.2 //@children.11/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N184" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L184" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P471" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.2/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P472" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N185">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L185" height="15.0" width="120.0" text="CrossProduct(AXB)1"/>
+        <ports identifier="P473" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.2/@containedEdges.0" incomingEdges="//@children.11/@children.2/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P474" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.2/@containedEdges.1" incomingEdges="//@children.11/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P475" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.5" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N186" height="25.0" width="313.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L186" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P476" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P478" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P479" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P482" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N187" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L187" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P483" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P484" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.2/@containedEdges.3 //@children.11/@children.2/@children.2/@containedEdges.4 //@children.11/@children.2/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N188" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L188" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P486" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.2/@containedEdges.6 //@children.11/@children.2/@children.2/@containedEdges.7 //@children.11/@children.2/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E350" sources="//@children.11/@children.2/@children.2/@ports.0" targets="//@children.11/@children.2/@children.2/@children.1/@ports.0"/>
+        <containedEdges identifier="E351" sources="//@children.11/@children.2/@children.2/@ports.1" targets="//@children.11/@children.2/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E352" sources="//@children.11/@children.2/@children.2/@children.0/@ports.0" targets="//@children.11/@children.2/@children.2/@ports.2"/>
+        <containedEdges identifier="E353" sources="//@children.11/@children.2/@children.2/@children.1/@ports.1" targets="//@children.11/@children.2/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E354" sources="//@children.11/@children.2/@children.2/@children.1/@ports.1" targets="//@children.11/@children.2/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E355" sources="//@children.11/@children.2/@children.2/@children.1/@ports.1" targets="//@children.11/@children.2/@children.2/@children.0/@ports.3"/>
+        <containedEdges identifier="E356" sources="//@children.11/@children.2/@children.2/@children.2/@ports.1" targets="//@children.11/@children.2/@children.2/@children.0/@ports.4"/>
+        <containedEdges identifier="E357" sources="//@children.11/@children.2/@children.2/@children.2/@ports.1" targets="//@children.11/@children.2/@children.2/@children.0/@ports.5"/>
+        <containedEdges identifier="E358" sources="//@children.11/@children.2/@children.2/@children.2/@ports.1" targets="//@children.11/@children.2/@children.2/@children.0/@ports.6"/>
+      </children>
+      <children identifier="N189">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L189" height="15.0" width="74.0" text="Create_DCM"/>
+        <ports identifier="P487" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.0" incomingEdges="//@children.11/@children.2/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P488" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.6 //@children.11/@children.2/@containedEdges.7" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N190" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L190" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P489" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.52">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P490" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.1 //@children.11/@children.2/@children.3/@containedEdges.2 //@children.11/@children.2/@children.3/@containedEdges.3 //@children.11/@children.2/@children.3/@containedEdges.4 //@children.11/@children.2/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N191" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L191" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P491" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.16 //@children.11/@children.2/@children.3/@containedEdges.17 //@children.11/@children.2/@children.3/@containedEdges.18 //@children.11/@children.2/@children.3/@containedEdges.19 //@children.11/@children.2/@children.3/@containedEdges.20 //@children.11/@children.2/@children.3/@containedEdges.21 //@children.11/@children.2/@children.3/@containedEdges.22 //@children.11/@children.2/@children.3/@containedEdges.23 //@children.11/@children.2/@children.3/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P493" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N192" height="25.0" width="52.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L192" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P494" height="8.0" width="8.0" x="52.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.43">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N193" height="25.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L193" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P497" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P498" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N194" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L194" height="15.0" width="73.0" text="Expression3"/>
+          <ports identifier="P500" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P501" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N195" height="25.0" width="108.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L195" height="15.0" width="73.0" text="Expression4"/>
+          <ports identifier="P502" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P503" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P504" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P505" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P506" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.44">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N196" height="25.0" width="104.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L196" height="15.0" width="73.0" text="Expression5"/>
+          <ports identifier="P507" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P508" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P511" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.45">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P512" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N197" height="25.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L197" height="15.0" width="73.0" text="Expression6"/>
+          <ports identifier="P513" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P514" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N198" height="25.0" width="104.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L198" height="15.0" width="73.0" text="Expression7"/>
+          <ports identifier="P516" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P517" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P518" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P520" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.46">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N199" height="25.0" width="108.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L199" height="15.0" width="73.0" text="Expression8"/>
+          <ports identifier="P522" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P523" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P524" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P525" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P526" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.47">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N200" height="25.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L200" height="15.0" width="73.0" text="Expression9"/>
+          <ports identifier="P528" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P529" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.42">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N201" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L201" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P531" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P532" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N202" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L202" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P533" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P534" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N203" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L203" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P536" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N204" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L204" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P537" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P538" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N205" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L205" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P540" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N206" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L206" height="15.0" width="41.0" text="Scale6"/>
+          <ports identifier="P541" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P542" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N207" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L207" height="15.0" width="41.0" text="Scale7"/>
+          <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P544" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N208" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L208" height="15.0" width="41.0" text="Scale8"/>
+          <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P546" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N209" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L209" height="15.0" width="41.0" text="Scale9"/>
+          <ports identifier="P547" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P548" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N210" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L210" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.48">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P550" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.25 //@children.11/@children.2/@children.3/@containedEdges.26 //@children.11/@children.2/@children.3/@containedEdges.27 //@children.11/@children.2/@children.3/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N211" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L211" height="15.0" width="79.0" text="TrigFunction3"/>
+          <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.50">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P552" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.29 //@children.11/@children.2/@children.3/@containedEdges.30 //@children.11/@children.2/@children.3/@containedEdges.31 //@children.11/@children.2/@children.3/@containedEdges.32 //@children.11/@children.2/@children.3/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N212" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L212" height="15.0" width="79.0" text="TrigFunction4"/>
+          <ports identifier="P553" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.49">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P554" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.34 //@children.11/@children.2/@children.3/@containedEdges.35 //@children.11/@children.2/@children.3/@containedEdges.36 //@children.11/@children.2/@children.3/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N213" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L213" height="15.0" width="79.0" text="TrigFunction5"/>
+          <ports identifier="P555" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.51">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P556" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.38 //@children.11/@children.2/@children.3/@containedEdges.39 //@children.11/@children.2/@children.3/@containedEdges.40 //@children.11/@children.2/@children.3/@containedEdges.41 //@children.11/@children.2/@children.3/@containedEdges.42">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N214" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L214" height="15.0" width="79.0" text="TrigFunction6"/>
+          <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.53">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P558" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.43 //@children.11/@children.2/@children.3/@containedEdges.44 //@children.11/@children.2/@children.3/@containedEdges.45 //@children.11/@children.2/@children.3/@containedEdges.46 //@children.11/@children.2/@children.3/@containedEdges.47">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N215" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L215" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P559" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.3/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P560" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.3/@containedEdges.48 //@children.11/@children.2/@children.3/@containedEdges.49 //@children.11/@children.2/@children.3/@containedEdges.50 //@children.11/@children.2/@children.3/@containedEdges.51 //@children.11/@children.2/@children.3/@containedEdges.52 //@children.11/@children.2/@children.3/@containedEdges.53">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E359" sources="//@children.11/@children.2/@children.3/@ports.0" targets="//@children.11/@children.2/@children.3/@children.25/@ports.0"/>
+        <containedEdges identifier="E360" sources="//@children.11/@children.2/@children.3/@children.0/@ports.1" targets="//@children.11/@children.2/@children.3/@children.3/@ports.2"/>
+        <containedEdges identifier="E361" sources="//@children.11/@children.2/@children.3/@children.0/@ports.1" targets="//@children.11/@children.2/@children.3/@children.5/@ports.3"/>
+        <containedEdges identifier="E362" sources="//@children.11/@children.2/@children.3/@children.0/@ports.1" targets="//@children.11/@children.2/@children.3/@children.6/@ports.3"/>
+        <containedEdges identifier="E363" sources="//@children.11/@children.2/@children.3/@children.0/@ports.1" targets="//@children.11/@children.2/@children.3/@children.8/@ports.4"/>
+        <containedEdges identifier="E364" sources="//@children.11/@children.2/@children.3/@children.0/@ports.1" targets="//@children.11/@children.2/@children.3/@children.9/@ports.3"/>
+        <containedEdges identifier="E365" sources="//@children.11/@children.2/@children.3/@children.1/@ports.2" targets="//@children.11/@children.2/@children.3/@ports.1"/>
+        <containedEdges identifier="E366" sources="//@children.11/@children.2/@children.3/@children.2/@ports.0" targets="//@children.11/@children.2/@children.3/@children.11/@ports.0"/>
+        <containedEdges identifier="E367" sources="//@children.11/@children.2/@children.3/@children.3/@ports.0" targets="//@children.11/@children.2/@children.3/@children.12/@ports.0"/>
+        <containedEdges identifier="E368" sources="//@children.11/@children.2/@children.3/@children.4/@ports.0" targets="//@children.11/@children.2/@children.3/@children.13/@ports.0"/>
+        <containedEdges identifier="E369" sources="//@children.11/@children.2/@children.3/@children.5/@ports.0" targets="//@children.11/@children.2/@children.3/@children.14/@ports.0"/>
+        <containedEdges identifier="E370" sources="//@children.11/@children.2/@children.3/@children.6/@ports.0" targets="//@children.11/@children.2/@children.3/@children.15/@ports.0"/>
+        <containedEdges identifier="E371" sources="//@children.11/@children.2/@children.3/@children.7/@ports.0" targets="//@children.11/@children.2/@children.3/@children.16/@ports.0"/>
+        <containedEdges identifier="E372" sources="//@children.11/@children.2/@children.3/@children.8/@ports.0" targets="//@children.11/@children.2/@children.3/@children.17/@ports.0"/>
+        <containedEdges identifier="E373" sources="//@children.11/@children.2/@children.3/@children.9/@ports.0" targets="//@children.11/@children.2/@children.3/@children.18/@ports.0"/>
+        <containedEdges identifier="E374" sources="//@children.11/@children.2/@children.3/@children.10/@ports.0" targets="//@children.11/@children.2/@children.3/@children.19/@ports.0"/>
+        <containedEdges identifier="E375" sources="//@children.11/@children.2/@children.3/@children.11/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E376" sources="//@children.11/@children.2/@children.3/@children.12/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E377" sources="//@children.11/@children.2/@children.3/@children.13/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E378" sources="//@children.11/@children.2/@children.3/@children.14/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E379" sources="//@children.11/@children.2/@children.3/@children.15/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E380" sources="//@children.11/@children.2/@children.3/@children.16/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E381" sources="//@children.11/@children.2/@children.3/@children.17/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E382" sources="//@children.11/@children.2/@children.3/@children.18/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E383" sources="//@children.11/@children.2/@children.3/@children.19/@ports.1" targets="//@children.11/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E384" sources="//@children.11/@children.2/@children.3/@children.20/@ports.1" targets="//@children.11/@children.2/@children.3/@children.6/@ports.5"/>
+        <containedEdges identifier="E385" sources="//@children.11/@children.2/@children.3/@children.20/@ports.1" targets="//@children.11/@children.2/@children.3/@children.7/@ports.1"/>
+        <containedEdges identifier="E386" sources="//@children.11/@children.2/@children.3/@children.20/@ports.1" targets="//@children.11/@children.2/@children.3/@children.8/@ports.1"/>
+        <containedEdges identifier="E387" sources="//@children.11/@children.2/@children.3/@children.20/@ports.1" targets="//@children.11/@children.2/@children.3/@children.9/@ports.5"/>
+        <containedEdges identifier="E388" sources="//@children.11/@children.2/@children.3/@children.21/@ports.1" targets="//@children.11/@children.2/@children.3/@children.4/@ports.1"/>
+        <containedEdges identifier="E389" sources="//@children.11/@children.2/@children.3/@children.21/@ports.1" targets="//@children.11/@children.2/@children.3/@children.5/@ports.2"/>
+        <containedEdges identifier="E390" sources="//@children.11/@children.2/@children.3/@children.21/@ports.1" targets="//@children.11/@children.2/@children.3/@children.6/@ports.1"/>
+        <containedEdges identifier="E391" sources="//@children.11/@children.2/@children.3/@children.21/@ports.1" targets="//@children.11/@children.2/@children.3/@children.8/@ports.3"/>
+        <containedEdges identifier="E392" sources="//@children.11/@children.2/@children.3/@children.21/@ports.1" targets="//@children.11/@children.2/@children.3/@children.9/@ports.2"/>
+        <containedEdges identifier="E393" sources="//@children.11/@children.2/@children.3/@children.22/@ports.1" targets="//@children.11/@children.2/@children.3/@children.5/@ports.1"/>
+        <containedEdges identifier="E394" sources="//@children.11/@children.2/@children.3/@children.22/@ports.1" targets="//@children.11/@children.2/@children.3/@children.8/@ports.2"/>
+        <containedEdges identifier="E395" sources="//@children.11/@children.2/@children.3/@children.22/@ports.1" targets="//@children.11/@children.2/@children.3/@children.9/@ports.1"/>
+        <containedEdges identifier="E396" sources="//@children.11/@children.2/@children.3/@children.22/@ports.1" targets="//@children.11/@children.2/@children.3/@children.10/@ports.1"/>
+        <containedEdges identifier="E397" sources="//@children.11/@children.2/@children.3/@children.23/@ports.1" targets="//@children.11/@children.2/@children.3/@children.2/@ports.1"/>
+        <containedEdges identifier="E398" sources="//@children.11/@children.2/@children.3/@children.23/@ports.1" targets="//@children.11/@children.2/@children.3/@children.3/@ports.1"/>
+        <containedEdges identifier="E399" sources="//@children.11/@children.2/@children.3/@children.23/@ports.1" targets="//@children.11/@children.2/@children.3/@children.6/@ports.2"/>
+        <containedEdges identifier="E400" sources="//@children.11/@children.2/@children.3/@children.23/@ports.1" targets="//@children.11/@children.2/@children.3/@children.7/@ports.2"/>
+        <containedEdges identifier="E401" sources="//@children.11/@children.2/@children.3/@children.23/@ports.1" targets="//@children.11/@children.2/@children.3/@children.10/@ports.2"/>
+        <containedEdges identifier="E402" sources="//@children.11/@children.2/@children.3/@children.24/@ports.1" targets="//@children.11/@children.2/@children.3/@children.2/@ports.2"/>
+        <containedEdges identifier="E403" sources="//@children.11/@children.2/@children.3/@children.24/@ports.1" targets="//@children.11/@children.2/@children.3/@children.5/@ports.4"/>
+        <containedEdges identifier="E404" sources="//@children.11/@children.2/@children.3/@children.24/@ports.1" targets="//@children.11/@children.2/@children.3/@children.6/@ports.4"/>
+        <containedEdges identifier="E405" sources="//@children.11/@children.2/@children.3/@children.24/@ports.1" targets="//@children.11/@children.2/@children.3/@children.8/@ports.5"/>
+        <containedEdges identifier="E406" sources="//@children.11/@children.2/@children.3/@children.24/@ports.1" targets="//@children.11/@children.2/@children.3/@children.9/@ports.4"/>
+        <containedEdges identifier="E407" sources="//@children.11/@children.2/@children.3/@children.25/@ports.1" targets="//@children.11/@children.2/@children.3/@children.20/@ports.0"/>
+        <containedEdges identifier="E408" sources="//@children.11/@children.2/@children.3/@children.25/@ports.1" targets="//@children.11/@children.2/@children.3/@children.22/@ports.0"/>
+        <containedEdges identifier="E409" sources="//@children.11/@children.2/@children.3/@children.25/@ports.1" targets="//@children.11/@children.2/@children.3/@children.21/@ports.0"/>
+        <containedEdges identifier="E410" sources="//@children.11/@children.2/@children.3/@children.25/@ports.1" targets="//@children.11/@children.2/@children.3/@children.23/@ports.0"/>
+        <containedEdges identifier="E411" sources="//@children.11/@children.2/@children.3/@children.25/@ports.1" targets="//@children.11/@children.2/@children.3/@children.0/@ports.0"/>
+        <containedEdges identifier="E412" sources="//@children.11/@children.2/@children.3/@children.25/@ports.1" targets="//@children.11/@children.2/@children.3/@children.24/@ports.0"/>
+      </children>
+      <children identifier="N216">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L216" height="15.0" width="171.0" text="Body-based-to-ref-fram-based"/>
+        <ports identifier="P561" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.0" incomingEdges="//@children.11/@children.2/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P562" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.1" incomingEdges="//@children.11/@children.2/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P563" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.8" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N217" height="25.0" width="251.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L217" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P564" height="8.0" width="8.0" x="251.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P565" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P567" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P568" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N218" height="25.0" width="135.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L218" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P570" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P571" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N219" height="25.0" width="273.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L219" height="15.0" width="73.0" text="Expression3"/>
+          <ports identifier="P574" height="8.0" width="8.0" x="273.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="-2.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P576" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P578" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P579" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N220" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L220" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P581" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.5 //@children.11/@children.2/@children.4/@containedEdges.6 //@children.11/@children.2/@children.4/@containedEdges.7 //@children.11/@children.2/@children.4/@containedEdges.8 //@children.11/@children.2/@children.4/@containedEdges.9 //@children.11/@children.2/@children.4/@containedEdges.10 //@children.11/@children.2/@children.4/@containedEdges.11 //@children.11/@children.2/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N221" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L221" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P582" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P583" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.13 //@children.11/@children.2/@children.4/@containedEdges.14 //@children.11/@children.2/@children.4/@containedEdges.15 //@children.11/@children.2/@children.4/@containedEdges.16 //@children.11/@children.2/@children.4/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N222" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L222" height="15.0" width="100.0" text="VectorAssembler"/>
+          <ports identifier="P584" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.4/@containedEdges.2 //@children.11/@children.2/@children.4/@containedEdges.3 //@children.11/@children.2/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P585" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.4/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E413" sources="//@children.11/@children.2/@children.4/@ports.0" targets="//@children.11/@children.2/@children.4/@children.3/@ports.0"/>
+        <containedEdges identifier="E414" sources="//@children.11/@children.2/@children.4/@ports.1" targets="//@children.11/@children.2/@children.4/@children.4/@ports.0"/>
+        <containedEdges identifier="E415" sources="//@children.11/@children.2/@children.4/@children.0/@ports.0" targets="//@children.11/@children.2/@children.4/@children.5/@ports.0"/>
+        <containedEdges identifier="E416" sources="//@children.11/@children.2/@children.4/@children.1/@ports.0" targets="//@children.11/@children.2/@children.4/@children.5/@ports.0"/>
+        <containedEdges identifier="E417" sources="//@children.11/@children.2/@children.4/@children.2/@ports.0" targets="//@children.11/@children.2/@children.4/@children.5/@ports.0"/>
+        <containedEdges identifier="E418" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.0/@ports.1"/>
+        <containedEdges identifier="E419" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.2/@ports.1"/>
+        <containedEdges identifier="E420" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.0/@ports.2"/>
+        <containedEdges identifier="E421" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.1/@ports.1"/>
+        <containedEdges identifier="E422" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.2/@ports.2"/>
+        <containedEdges identifier="E423" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.0/@ports.3"/>
+        <containedEdges identifier="E424" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.1/@ports.2"/>
+        <containedEdges identifier="E425" sources="//@children.11/@children.2/@children.4/@children.3/@ports.1" targets="//@children.11/@children.2/@children.4/@children.2/@ports.3"/>
+        <containedEdges identifier="E426" sources="//@children.11/@children.2/@children.4/@children.4/@ports.1" targets="//@children.11/@children.2/@children.4/@children.0/@ports.4"/>
+        <containedEdges identifier="E427" sources="//@children.11/@children.2/@children.4/@children.4/@ports.1" targets="//@children.11/@children.2/@children.4/@children.1/@ports.3"/>
+        <containedEdges identifier="E428" sources="//@children.11/@children.2/@children.4/@children.4/@ports.1" targets="//@children.11/@children.2/@children.4/@children.2/@ports.4"/>
+        <containedEdges identifier="E429" sources="//@children.11/@children.2/@children.4/@children.4/@ports.1" targets="//@children.11/@children.2/@children.4/@children.0/@ports.5"/>
+        <containedEdges identifier="E430" sources="//@children.11/@children.2/@children.4/@children.4/@ports.1" targets="//@children.11/@children.2/@children.4/@children.2/@ports.5"/>
+        <containedEdges identifier="E431" sources="//@children.11/@children.2/@children.4/@children.5/@ports.1" targets="//@children.11/@children.2/@children.4/@ports.2"/>
+      </children>
+      <children identifier="N223" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L223" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P587" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P588" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N224" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L224" height="15.0" width="45.0" text="Product"/>
+        <ports identifier="P589" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@containedEdges.9 //@children.11/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P591" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@containedEdges.10 //@children.11/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N225" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L225" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P592" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@containedEdges.15 //@children.11/@children.2/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P594" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N226" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L226" height="15.0" width="87.0" text="MultiplyDivide3"/>
+        <ports identifier="P595" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@containedEdges.17 //@children.11/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P597" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@containedEdges.13 //@children.11/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N227" height="25.0" width="17.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L227" height="15.0" width="7.0" text="J"/>
+        <ports identifier="P598" height="8.0" width="8.0" x="17.0" y="8.5" outgoingEdges="//@children.11/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N228" height="25.0" width="65.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L228" height="15.0" width="30.0" text="Inv(J)"/>
+        <ports identifier="P600" height="8.0" width="8.0" x="65.0" y="8.5" outgoingEdges="//@children.11/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N229" height="25.0" width="104.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L229" height="15.0" width="15.0" text="uT"/>
+        <ports identifier="P602" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@children.11/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N230">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L230" height="15.0" width="92.0" text="VectorIntegrator"/>
+        <ports identifier="P604" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.12/@containedEdges.0" incomingEdges="//@children.11/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P605" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.18 //@children.11/@children.2/@containedEdges.19 //@children.11/@children.2/@containedEdges.20" incomingEdges="//@children.11/@children.2/@children.12/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N231" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L231" height="15.0" width="55.0" text="Integrator"/>
+          <ports identifier="P606" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P607" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.12/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P608" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.12/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P609" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N232" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L232" height="15.0" width="62.0" text="Integrator2"/>
+          <ports identifier="P610" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.12/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P612" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.12/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P613" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N233" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L233" height="15.0" width="62.0" text="Integrator3"/>
+          <ports identifier="P614" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.12/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P616" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.12/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P617" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N234" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L234" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P618" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.12/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P619" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.12/@containedEdges.4 //@children.11/@children.2/@children.12/@containedEdges.5 //@children.11/@children.2/@children.12/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N235" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L235" height="15.0" width="100.0" text="VectorAssembler"/>
+          <ports identifier="P620" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.12/@containedEdges.1 //@children.11/@children.2/@children.12/@containedEdges.2 //@children.11/@children.2/@children.12/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P621" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.12/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E432" sources="//@children.11/@children.2/@children.12/@ports.0" targets="//@children.11/@children.2/@children.12/@children.3/@ports.0"/>
+        <containedEdges identifier="E433" sources="//@children.11/@children.2/@children.12/@children.0/@ports.2" targets="//@children.11/@children.2/@children.12/@children.4/@ports.0"/>
+        <containedEdges identifier="E434" sources="//@children.11/@children.2/@children.12/@children.1/@ports.2" targets="//@children.11/@children.2/@children.12/@children.4/@ports.0"/>
+        <containedEdges identifier="E435" sources="//@children.11/@children.2/@children.12/@children.2/@ports.2" targets="//@children.11/@children.2/@children.12/@children.4/@ports.0"/>
+        <containedEdges identifier="E436" sources="//@children.11/@children.2/@children.12/@children.3/@ports.1" targets="//@children.11/@children.2/@children.12/@children.0/@ports.1"/>
+        <containedEdges identifier="E437" sources="//@children.11/@children.2/@children.12/@children.3/@ports.1" targets="//@children.11/@children.2/@children.12/@children.1/@ports.1"/>
+        <containedEdges identifier="E438" sources="//@children.11/@children.2/@children.12/@children.3/@ports.1" targets="//@children.11/@children.2/@children.12/@children.2/@ports.1"/>
+        <containedEdges identifier="E439" sources="//@children.11/@children.2/@children.12/@children.4/@ports.1" targets="//@children.11/@children.2/@children.12/@ports.1"/>
+      </children>
+      <children identifier="N236">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L236" height="15.0" width="113.0" text="CrossProduct(AXB)"/>
+        <ports identifier="P622" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P623" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.13/@containedEdges.1" incomingEdges="//@children.11/@children.2/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P624" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.21" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N237" height="25.0" width="313.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L237" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P625" height="8.0" width="8.0" x="313.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.13/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P626" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P628" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P629" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P630" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P631" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N238" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L238" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P633" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.13/@containedEdges.3 //@children.11/@children.2/@children.13/@containedEdges.4 //@children.11/@children.2/@children.13/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N239" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L239" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P634" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.13/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P635" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.13/@containedEdges.6 //@children.11/@children.2/@children.13/@containedEdges.7 //@children.11/@children.2/@children.13/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E440" sources="//@children.11/@children.2/@children.13/@ports.0" targets="//@children.11/@children.2/@children.13/@children.1/@ports.0"/>
+        <containedEdges identifier="E441" sources="//@children.11/@children.2/@children.13/@ports.1" targets="//@children.11/@children.2/@children.13/@children.2/@ports.0"/>
+        <containedEdges identifier="E442" sources="//@children.11/@children.2/@children.13/@children.0/@ports.0" targets="//@children.11/@children.2/@children.13/@ports.2"/>
+        <containedEdges identifier="E443" sources="//@children.11/@children.2/@children.13/@children.1/@ports.1" targets="//@children.11/@children.2/@children.13/@children.0/@ports.1"/>
+        <containedEdges identifier="E444" sources="//@children.11/@children.2/@children.13/@children.1/@ports.1" targets="//@children.11/@children.2/@children.13/@children.0/@ports.2"/>
+        <containedEdges identifier="E445" sources="//@children.11/@children.2/@children.13/@children.1/@ports.1" targets="//@children.11/@children.2/@children.13/@children.0/@ports.3"/>
+        <containedEdges identifier="E446" sources="//@children.11/@children.2/@children.13/@children.2/@ports.1" targets="//@children.11/@children.2/@children.13/@children.0/@ports.4"/>
+        <containedEdges identifier="E447" sources="//@children.11/@children.2/@children.13/@children.2/@ports.1" targets="//@children.11/@children.2/@children.13/@children.0/@ports.5"/>
+        <containedEdges identifier="E448" sources="//@children.11/@children.2/@children.13/@children.2/@ports.1" targets="//@children.11/@children.2/@children.13/@children.0/@ports.6"/>
+      </children>
+      <children identifier="N240">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L240" height="15.0" width="99.0" text="VectorIntegrator2"/>
+        <ports identifier="P636" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.14/@containedEdges.0" incomingEdges="//@children.11/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P637" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.22 //@children.11/@children.2/@containedEdges.23 //@children.11/@children.2/@containedEdges.24" incomingEdges="//@children.11/@children.2/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N241" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L241" height="15.0" width="55.0" text="Integrator"/>
+          <ports identifier="P638" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P639" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P640" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P641" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N242" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L242" height="15.0" width="62.0" text="Integrator2"/>
+          <ports identifier="P642" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P643" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.14/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P644" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P645" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N243" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L243" height="15.0" width="62.0" text="Integrator3"/>
+          <ports identifier="P646" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P647" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P648" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P649" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N244" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L244" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P650" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P651" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.14/@containedEdges.4 //@children.11/@children.2/@children.14/@containedEdges.5 //@children.11/@children.2/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N245" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L245" height="15.0" width="100.0" text="VectorAssembler"/>
+          <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.14/@containedEdges.1 //@children.11/@children.2/@children.14/@containedEdges.2 //@children.11/@children.2/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P653" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.14/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E449" sources="//@children.11/@children.2/@children.14/@ports.0" targets="//@children.11/@children.2/@children.14/@children.3/@ports.0"/>
+        <containedEdges identifier="E450" sources="//@children.11/@children.2/@children.14/@children.0/@ports.2" targets="//@children.11/@children.2/@children.14/@children.4/@ports.0"/>
+        <containedEdges identifier="E451" sources="//@children.11/@children.2/@children.14/@children.1/@ports.2" targets="//@children.11/@children.2/@children.14/@children.4/@ports.0"/>
+        <containedEdges identifier="E452" sources="//@children.11/@children.2/@children.14/@children.2/@ports.2" targets="//@children.11/@children.2/@children.14/@children.4/@ports.0"/>
+        <containedEdges identifier="E453" sources="//@children.11/@children.2/@children.14/@children.3/@ports.1" targets="//@children.11/@children.2/@children.14/@children.0/@ports.1"/>
+        <containedEdges identifier="E454" sources="//@children.11/@children.2/@children.14/@children.3/@ports.1" targets="//@children.11/@children.2/@children.14/@children.1/@ports.1"/>
+        <containedEdges identifier="E455" sources="//@children.11/@children.2/@children.14/@children.3/@ports.1" targets="//@children.11/@children.2/@children.14/@children.2/@ports.1"/>
+        <containedEdges identifier="E456" sources="//@children.11/@children.2/@children.14/@children.4/@ports.1" targets="//@children.11/@children.2/@children.14/@ports.1"/>
+      </children>
+      <children identifier="N246">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L246" height="15.0" width="99.0" text="VectorIntegrator3"/>
+        <ports identifier="P654" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.15/@containedEdges.0" incomingEdges="//@children.11/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P655" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.25 //@children.11/@children.2/@containedEdges.26 //@children.11/@children.2/@containedEdges.27" incomingEdges="//@children.11/@children.2/@children.15/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N247" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L247" height="15.0" width="55.0" text="Integrator"/>
+          <ports identifier="P656" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P657" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.15/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P658" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.15/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P659" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N248" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L248" height="15.0" width="62.0" text="Integrator2"/>
+          <ports identifier="P660" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P661" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.15/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P662" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.15/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P663" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N249" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L249" height="15.0" width="62.0" text="Integrator3"/>
+          <ports identifier="P664" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P665" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.15/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P666" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.15/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P667" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N250" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L250" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.15/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P669" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.15/@containedEdges.4 //@children.11/@children.2/@children.15/@containedEdges.5 //@children.11/@children.2/@children.15/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N251" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L251" height="15.0" width="100.0" text="VectorAssembler"/>
+          <ports identifier="P670" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.15/@containedEdges.1 //@children.11/@children.2/@children.15/@containedEdges.2 //@children.11/@children.2/@children.15/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P671" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.15/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E457" sources="//@children.11/@children.2/@children.15/@ports.0" targets="//@children.11/@children.2/@children.15/@children.3/@ports.0"/>
+        <containedEdges identifier="E458" sources="//@children.11/@children.2/@children.15/@children.0/@ports.2" targets="//@children.11/@children.2/@children.15/@children.4/@ports.0"/>
+        <containedEdges identifier="E459" sources="//@children.11/@children.2/@children.15/@children.1/@ports.2" targets="//@children.11/@children.2/@children.15/@children.4/@ports.0"/>
+        <containedEdges identifier="E460" sources="//@children.11/@children.2/@children.15/@children.2/@ports.2" targets="//@children.11/@children.2/@children.15/@children.4/@ports.0"/>
+        <containedEdges identifier="E461" sources="//@children.11/@children.2/@children.15/@children.3/@ports.1" targets="//@children.11/@children.2/@children.15/@children.0/@ports.1"/>
+        <containedEdges identifier="E462" sources="//@children.11/@children.2/@children.15/@children.3/@ports.1" targets="//@children.11/@children.2/@children.15/@children.1/@ports.1"/>
+        <containedEdges identifier="E463" sources="//@children.11/@children.2/@children.15/@children.3/@ports.1" targets="//@children.11/@children.2/@children.15/@children.2/@ports.1"/>
+        <containedEdges identifier="E464" sources="//@children.11/@children.2/@children.15/@children.4/@ports.1" targets="//@children.11/@children.2/@children.15/@ports.1"/>
+      </children>
+      <children identifier="N252">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L252" height="15.0" width="99.0" text="VectorIntegrator4"/>
+        <ports identifier="P672" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.16/@containedEdges.0" incomingEdges="//@children.11/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P673" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.28" incomingEdges="//@children.11/@children.2/@children.16/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N253" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L253" height="15.0" width="55.0" text="Integrator"/>
+          <ports identifier="P674" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.16/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P676" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.16/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P677" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N254" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L254" height="15.0" width="62.0" text="Integrator2"/>
+          <ports identifier="P678" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P679" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.16/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P680" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.16/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P681" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N255" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L255" height="15.0" width="62.0" text="Integrator3"/>
+          <ports identifier="P682" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P683" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.16/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P684" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.16/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P685" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N256" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L256" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P686" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.16/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P687" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.16/@containedEdges.4 //@children.11/@children.2/@children.16/@containedEdges.5 //@children.11/@children.2/@children.16/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N257" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L257" height="15.0" width="100.0" text="VectorAssembler"/>
+          <ports identifier="P688" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.16/@containedEdges.1 //@children.11/@children.2/@children.16/@containedEdges.2 //@children.11/@children.2/@children.16/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P689" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.16/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E465" sources="//@children.11/@children.2/@children.16/@ports.0" targets="//@children.11/@children.2/@children.16/@children.3/@ports.0"/>
+        <containedEdges identifier="E466" sources="//@children.11/@children.2/@children.16/@children.0/@ports.2" targets="//@children.11/@children.2/@children.16/@children.4/@ports.0"/>
+        <containedEdges identifier="E467" sources="//@children.11/@children.2/@children.16/@children.1/@ports.2" targets="//@children.11/@children.2/@children.16/@children.4/@ports.0"/>
+        <containedEdges identifier="E468" sources="//@children.11/@children.2/@children.16/@children.2/@ports.2" targets="//@children.11/@children.2/@children.16/@children.4/@ports.0"/>
+        <containedEdges identifier="E469" sources="//@children.11/@children.2/@children.16/@children.3/@ports.1" targets="//@children.11/@children.2/@children.16/@children.0/@ports.1"/>
+        <containedEdges identifier="E470" sources="//@children.11/@children.2/@children.16/@children.3/@ports.1" targets="//@children.11/@children.2/@children.16/@children.1/@ports.1"/>
+        <containedEdges identifier="E471" sources="//@children.11/@children.2/@children.16/@children.3/@ports.1" targets="//@children.11/@children.2/@children.16/@children.2/@ports.1"/>
+        <containedEdges identifier="E472" sources="//@children.11/@children.2/@children.16/@children.4/@ports.1" targets="//@children.11/@children.2/@children.16/@ports.1"/>
+      </children>
+      <containedEdges identifier="E321" sources="//@children.11/@children.2/@ports.0" targets="//@children.11/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E322" sources="//@children.11/@children.2/@ports.1" targets="//@children.11/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E323" sources="//@children.11/@children.2/@children.0/@ports.1" targets="//@children.11/@children.2/@ports.9"/>
+      <containedEdges identifier="E324" sources="//@children.11/@children.2/@children.0/@ports.1" targets="//@children.11/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E325" sources="//@children.11/@children.2/@children.1/@ports.2" targets="//@children.11/@children.2/@children.12/@ports.0"/>
+      <containedEdges identifier="E326" sources="//@children.11/@children.2/@children.2/@ports.2" targets="//@children.11/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E327" sources="//@children.11/@children.2/@children.3/@ports.1" targets="//@children.11/@children.2/@ports.5"/>
+      <containedEdges identifier="E328" sources="//@children.11/@children.2/@children.3/@ports.1" targets="//@children.11/@children.2/@children.11/@ports.1"/>
+      <containedEdges identifier="E329" sources="//@children.11/@children.2/@children.4/@ports.2" targets="//@children.11/@children.2/@children.15/@ports.0"/>
+      <containedEdges identifier="E330" sources="//@children.11/@children.2/@children.5/@ports.2" targets="//@children.11/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E331" sources="//@children.11/@children.2/@children.6/@ports.2" targets="//@children.11/@children.2/@ports.8"/>
+      <containedEdges identifier="E332" sources="//@children.11/@children.2/@children.6/@ports.2" targets="//@children.11/@children.2/@children.14/@ports.0"/>
+      <containedEdges identifier="E333" sources="//@children.11/@children.2/@children.7/@ports.2" targets="//@children.11/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E334" sources="//@children.11/@children.2/@children.8/@ports.2" targets="//@children.11/@children.2/@ports.2"/>
+      <containedEdges identifier="E335" sources="//@children.11/@children.2/@children.8/@ports.2" targets="//@children.11/@children.2/@children.16/@ports.0"/>
+      <containedEdges identifier="E336" sources="//@children.11/@children.2/@children.9/@ports.0" targets="//@children.11/@children.2/@children.7/@ports.0"/>
+      <containedEdges identifier="E337" sources="//@children.11/@children.2/@children.10/@ports.0" targets="//@children.11/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E338" sources="//@children.11/@children.2/@children.11/@ports.0" targets="//@children.11/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E339" sources="//@children.11/@children.2/@children.12/@ports.1" targets="//@children.11/@children.2/@ports.6"/>
+      <containedEdges identifier="E340" sources="//@children.11/@children.2/@children.12/@ports.1" targets="//@children.11/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E341" sources="//@children.11/@children.2/@children.12/@ports.1" targets="//@children.11/@children.2/@children.13/@ports.1"/>
+      <containedEdges identifier="E342" sources="//@children.11/@children.2/@children.13/@ports.2" targets="//@children.11/@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E343" sources="//@children.11/@children.2/@children.14/@ports.1" targets="//@children.11/@children.2/@children.7/@ports.0"/>
+      <containedEdges identifier="E344" sources="//@children.11/@children.2/@children.14/@ports.1" targets="//@children.11/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E345" sources="//@children.11/@children.2/@children.14/@ports.1" targets="//@children.11/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E346" sources="//@children.11/@children.2/@children.15/@ports.1" targets="//@children.11/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E347" sources="//@children.11/@children.2/@children.15/@ports.1" targets="//@children.11/@children.2/@ports.4"/>
+      <containedEdges identifier="E348" sources="//@children.11/@children.2/@children.15/@ports.1" targets="//@children.11/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E349" sources="//@children.11/@children.2/@children.16/@ports.1" targets="//@children.11/@children.2/@ports.3"/>
+    </children>
+    <children identifier="N258" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L258" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P690" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.4 //@children.11/@containedEdges.20 //@children.11/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P691" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P692" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N259" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L259" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P693" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P695" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.17 //@children.11/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N260" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L260" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P696" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.1 //@children.11/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P698" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N261" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L261" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P699" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.7 //@children.11/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P701" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N262" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L262" height="15.0" width="79.0" text="Viscous Drag"/>
+      <ports identifier="P702" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P703" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N263" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L263" height="15.0" width="40.0" text="Gravity"/>
+      <ports identifier="P704" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.11/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P705" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N264">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L264" height="15.0" width="100.0" text="VectorAssembler"/>
+      <ports identifier="P706" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.9/@containedEdges.0 //@children.11/@children.9/@containedEdges.1 //@children.11/@children.9/@containedEdges.2 //@children.11/@children.9/@containedEdges.3 //@children.11/@children.9/@containedEdges.4" incomingEdges="//@children.11/@containedEdges.9 //@children.11/@containedEdges.11 //@children.11/@containedEdges.13 //@children.11/@containedEdges.14 //@children.11/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P707" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.23" incomingEdges="//@children.11/@children.9/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N265" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L265" height="15.0" width="117.0" text="VectorDisassembler"/>
+        <ports identifier="P708" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P709" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.9/@containedEdges.5 //@children.11/@children.9/@containedEdges.6 //@children.11/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N266" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L266" height="15.0" width="124.0" text="VectorDisassembler2"/>
+        <ports identifier="P710" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P711" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.9/@containedEdges.8 //@children.11/@children.9/@containedEdges.9 //@children.11/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N267" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L267" height="15.0" width="124.0" text="VectorDisassembler3"/>
+        <ports identifier="P712" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P713" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.9/@containedEdges.11 //@children.11/@children.9/@containedEdges.12 //@children.11/@children.9/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N268" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L268" height="15.0" width="124.0" text="VectorDisassembler4"/>
+        <ports identifier="P714" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P715" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.9/@containedEdges.14 //@children.11/@children.9/@containedEdges.15 //@children.11/@children.9/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N269" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L269" height="15.0" width="124.0" text="VectorDisassembler5"/>
+        <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P717" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.9/@containedEdges.17 //@children.11/@children.9/@containedEdges.18 //@children.11/@children.9/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N270" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L270" height="15.0" width="100.0" text="VectorAssembler"/>
+        <ports identifier="P718" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.9/@containedEdges.5 //@children.11/@children.9/@containedEdges.6 //@children.11/@children.9/@containedEdges.7 //@children.11/@children.9/@containedEdges.8 //@children.11/@children.9/@containedEdges.9 //@children.11/@children.9/@containedEdges.10 //@children.11/@children.9/@containedEdges.11 //@children.11/@children.9/@containedEdges.12 //@children.11/@children.9/@containedEdges.13 //@children.11/@children.9/@containedEdges.14 //@children.11/@children.9/@containedEdges.15 //@children.11/@children.9/@containedEdges.16 //@children.11/@children.9/@containedEdges.17 //@children.11/@children.9/@containedEdges.18 //@children.11/@children.9/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P719" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.11/@children.9/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E473" sources="//@children.11/@children.9/@ports.0" targets="//@children.11/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E474" sources="//@children.11/@children.9/@ports.0" targets="//@children.11/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E475" sources="//@children.11/@children.9/@ports.0" targets="//@children.11/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E476" sources="//@children.11/@children.9/@ports.0" targets="//@children.11/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E477" sources="//@children.11/@children.9/@ports.0" targets="//@children.11/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E478" sources="//@children.11/@children.9/@children.0/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E479" sources="//@children.11/@children.9/@children.0/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E480" sources="//@children.11/@children.9/@children.0/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E481" sources="//@children.11/@children.9/@children.1/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E482" sources="//@children.11/@children.9/@children.1/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E483" sources="//@children.11/@children.9/@children.1/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E484" sources="//@children.11/@children.9/@children.2/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E485" sources="//@children.11/@children.9/@children.2/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E486" sources="//@children.11/@children.9/@children.2/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E487" sources="//@children.11/@children.9/@children.3/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E488" sources="//@children.11/@children.9/@children.3/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E489" sources="//@children.11/@children.9/@children.3/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E490" sources="//@children.11/@children.9/@children.4/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E491" sources="//@children.11/@children.9/@children.4/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E492" sources="//@children.11/@children.9/@children.4/@ports.1" targets="//@children.11/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E493" sources="//@children.11/@children.9/@children.5/@ports.1" targets="//@children.11/@children.9/@ports.1"/>
+    </children>
+    <children identifier="N271" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L271" height="15.0" width="40.0" text="Forces"/>
+      <ports identifier="P720" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E109" sources="//@children.11/@ports.0" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E110" sources="//@children.11/@ports.1" targets="//@children.11/@children.5/@ports.0"/>
+    <containedEdges identifier="E111" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.1/@ports.0"/>
+    <containedEdges identifier="E112" sources="//@children.11/@children.1/@ports.3" targets="//@children.11/@children.2/@ports.1"/>
+    <containedEdges identifier="E113" sources="//@children.11/@children.1/@ports.2" targets="//@children.11/@children.3/@ports.0"/>
+    <containedEdges identifier="E114" sources="//@children.11/@children.1/@ports.2" targets="//@children.11/@children.10/@ports.0"/>
+    <containedEdges identifier="E115" sources="//@children.11/@children.2/@ports.5" targets="//@children.11/@children.5/@ports.0"/>
+    <containedEdges identifier="E116" sources="//@children.11/@children.2/@ports.5" targets="//@children.11/@children.6/@ports.0"/>
+    <containedEdges identifier="E117" sources="//@children.11/@children.2/@ports.6" targets="//@children.11/@children.4/@ports.0"/>
+    <containedEdges identifier="E118" sources="//@children.11/@children.2/@ports.7" targets="//@children.11/@children.9/@ports.0"/>
+    <containedEdges identifier="E119" sources="//@children.11/@children.2/@ports.3" targets="//@children.11/@ports.2"/>
+    <containedEdges identifier="E120" sources="//@children.11/@children.2/@ports.3" targets="//@children.11/@children.9/@ports.0"/>
+    <containedEdges identifier="E121" sources="//@children.11/@children.2/@ports.4" targets="//@children.11/@ports.3"/>
+    <containedEdges identifier="E122" sources="//@children.11/@children.2/@ports.4" targets="//@children.11/@children.9/@ports.0"/>
+    <containedEdges identifier="E123" sources="//@children.11/@children.2/@ports.2" targets="//@children.11/@children.9/@ports.0"/>
+    <containedEdges identifier="E124" sources="//@children.11/@children.2/@ports.9" targets="//@children.11/@children.9/@ports.0"/>
+    <containedEdges identifier="E125" sources="//@children.11/@children.3/@ports.2" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E126" sources="//@children.11/@children.4/@ports.2" targets="//@children.11/@children.1/@ports.1"/>
+    <containedEdges identifier="E127" sources="//@children.11/@children.4/@ports.2" targets="//@children.11/@children.7/@ports.0"/>
+    <containedEdges identifier="E128" sources="//@children.11/@children.5/@ports.2" targets="//@children.11/@children.4/@ports.1"/>
+    <containedEdges identifier="E129" sources="//@children.11/@children.6/@ports.2" targets="//@children.11/@children.3/@ports.0"/>
+    <containedEdges identifier="E130" sources="//@children.11/@children.7/@ports.1" targets="//@children.11/@children.3/@ports.0"/>
+    <containedEdges identifier="E131" sources="//@children.11/@children.8/@ports.0" targets="//@children.11/@children.6/@ports.0"/>
+    <containedEdges identifier="E132" sources="//@children.11/@children.9/@ports.1" targets="//@children.11/@ports.4"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.9/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.4" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_staticunits_StaticUnits.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_staticunits_StaticUnits.elkg
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="60.0" text="population"/>
+    <ports identifier="P2" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="110.0" text="growthAddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="238.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="28.0" text="Limit"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="328.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="39.0" text="growth"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="90.0" text="HeatProduction"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="25.0" width="243.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="181.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="90.0" text="HeatExchanger"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.3/@ports.3" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="23.0" text="flow"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.3/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_staticunits_StaticUnits2.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_staticunits_StaticUnits2.elkg
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="60.0" text="population"/>
+    <ports identifier="P2" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="110.0" text="growthAddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="238.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="28.0" text="Limit"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="328.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="39.0" text="growth"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="90.0" text="HeatProduction"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="25.0" width="243.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="181.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="90.0" text="HeatExchanger"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.3/@ports.3" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="49.0" text="flow rate"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="158.0" text="Convert Population to Joule"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="14.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.3/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_stickymasses_StickyMasses.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_stickymasses_StickyMasses.elkg
@@ -1,0 +1,1299 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="46.0" text="Masses"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="-2.555555582046509" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="2.8888888359069824" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="13.777777671813965" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="19.22222137451172" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="30.11111068725586" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="35.55555725097656" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="85.0" text="Signal Plotters"/>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.6" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.7" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="34.0" text="Force"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="79.0" text="Accelerations"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="56.0" text="Velocities"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="54.0" text="Positions"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.1/@ports.6" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@ports.7" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.3" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.4" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.5" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="60.0" text="3D Viewer"/>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="99.0" text="blue spring-mass"/>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@children.2/@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="55.0" text="Torus3D1"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="55.0" text="Torus3D2"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="77.0" text="Translate3D9"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.5 //@children.2/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="69.0" text="Rotate3D10"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="69.0" text="Rotate3D13"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="69.0" text="Rotate3D14"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="55.0" text="Torus3D3"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="62.0" text="Rotate3D4"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.8 //@children.2/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="62.0" text="Torus3D16"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="69.0" text="Rotate3D17"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="69.0" text="Rotate3D20"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="84.0" text="Translate3D24"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.12 //@children.2/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="62.0" text="Torus3D27"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="69.0" text="Rotate3D28"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="84.0" text="Translate3D33"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.15 //@children.2/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="62.0" text="Torus3D38"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="62.0" text="Torus3D39"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="69.0" text="Rotate3D40"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="69.0" text="Rotate3D41"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="84.0" text="Translate3D42"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.20 //@children.2/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="69.0" text="Rotate3D43"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="84.0" text="Translate3D52"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.22 //@children.2/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.24 //@children.2/@children.0/@containedEdges.25 //@children.2/@children.0/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="65.0" text="Sphere3D1"/>
+        <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.3 //@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="85.0" text="Compute Twist"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.30 //@children.2/@children.0/@containedEdges.31 //@children.2/@children.0/@containedEdges.32 //@children.2/@children.0/@containedEdges.33 //@children.2/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="25.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.35 //@children.2/@children.0/@containedEdges.36 //@children.2/@children.0/@containedEdges.37 //@children.2/@children.0/@containedEdges.38 //@children.2/@children.0/@containedEdges.39 //@children.2/@children.0/@containedEdges.40 //@children.2/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E40" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.28/@ports.1"/>
+      <containedEdges identifier="E41" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.26/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.2/@children.0/@children.3/@ports.1" targets="//@children.2/@children.0/@children.26/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.2/@children.0/@children.4/@ports.1" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.2/@children.0/@children.5/@ports.1" targets="//@children.2/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.2/@children.0/@children.6/@ports.0" targets="//@children.2/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.2/@children.0/@children.7/@ports.1" targets="//@children.2/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.2/@children.0/@children.8/@ports.1" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.2/@children.0/@children.9/@ports.0" targets="//@children.2/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.2/@children.0/@children.10/@ports.1" targets="//@children.2/@children.0/@children.11/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.2/@children.0/@children.11/@ports.1" targets="//@children.2/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.2/@children.0/@children.12/@ports.1" targets="//@children.2/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.2/@children.0/@children.13/@ports.0" targets="//@children.2/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.2/@children.0/@children.14/@ports.1" targets="//@children.2/@children.0/@children.15/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.2/@children.0/@children.15/@ports.1" targets="//@children.2/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.2/@children.0/@children.16/@ports.0" targets="//@children.2/@children.0/@children.18/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.2/@children.0/@children.17/@ports.0" targets="//@children.2/@children.0/@children.21/@ports.0"/>
+      <containedEdges identifier="E59" sources="//@children.2/@children.0/@children.18/@ports.1" targets="//@children.2/@children.0/@children.19/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.2/@children.0/@children.19/@ports.1" targets="//@children.2/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.2/@children.0/@children.20/@ports.1" targets="//@children.2/@children.0/@children.15/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.2/@children.0/@children.21/@ports.1" targets="//@children.2/@children.0/@children.22/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.2/@children.0/@children.22/@ports.1" targets="//@children.2/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.2/@children.0/@children.23/@ports.1" targets="//@children.2/@children.0/@children.4/@ports.2"/>
+      <containedEdges identifier="E65" sources="//@children.2/@children.0/@children.23/@ports.1" targets="//@children.2/@children.0/@children.11/@ports.2"/>
+      <containedEdges identifier="E66" sources="//@children.2/@children.0/@children.23/@ports.1" targets="//@children.2/@children.0/@children.19/@ports.2"/>
+      <containedEdges identifier="E67" sources="//@children.2/@children.0/@children.24/@ports.0" targets="//@children.2/@children.0/@children.25/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.2/@children.0/@children.25/@ports.1" targets="//@children.2/@children.0/@children.22/@ports.0"/>
+      <containedEdges identifier="E69" sources="//@children.2/@children.0/@children.26/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E70" sources="//@children.2/@children.0/@children.27/@ports.0" targets="//@children.2/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E71" sources="//@children.2/@children.0/@children.27/@ports.0" targets="//@children.2/@children.0/@children.7/@ports.2"/>
+      <containedEdges identifier="E72" sources="//@children.2/@children.0/@children.27/@ports.0" targets="//@children.2/@children.0/@children.14/@ports.2"/>
+      <containedEdges identifier="E73" sources="//@children.2/@children.0/@children.27/@ports.0" targets="//@children.2/@children.0/@children.21/@ports.2"/>
+      <containedEdges identifier="E74" sources="//@children.2/@children.0/@children.27/@ports.0" targets="//@children.2/@children.0/@children.23/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.2/@children.0/@children.28/@ports.0" targets="//@children.2/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E76" sources="//@children.2/@children.0/@children.28/@ports.0" targets="//@children.2/@children.0/@children.8/@ports.2"/>
+      <containedEdges identifier="E77" sources="//@children.2/@children.0/@children.28/@ports.0" targets="//@children.2/@children.0/@children.12/@ports.2"/>
+      <containedEdges identifier="E78" sources="//@children.2/@children.0/@children.28/@ports.0" targets="//@children.2/@children.0/@children.15/@ports.2"/>
+      <containedEdges identifier="E79" sources="//@children.2/@children.0/@children.28/@ports.0" targets="//@children.2/@children.0/@children.20/@ports.2"/>
+      <containedEdges identifier="E80" sources="//@children.2/@children.0/@children.28/@ports.0" targets="//@children.2/@children.0/@children.22/@ports.2"/>
+      <containedEdges identifier="E81" sources="//@children.2/@children.0/@children.28/@ports.0" targets="//@children.2/@children.0/@children.27/@ports.1"/>
+    </children>
+    <children identifier="N39" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="57.0" text="Scale3D3"/>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="43.0" text="left wall"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="84.0" text="Translate3D26"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.8 //@children.2/@containedEdges.10 //@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="62.0" text="Rotate3D1"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="25.0" text="floor"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="77.0" text="Translate3D3"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="70.0" text="ViewScreen"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="51.0" text="right wall"/>
+      <ports identifier="P101" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="55.0" text="Rotate3D"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="77.0" text="Translate3D4"/>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L51" height="15.0" width="93.0" text="red spring-mass"/>
+      <ports identifier="P110" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.13/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.14" incomingEdges="//@children.2/@children.13/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N52" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="55.0" text="Torus3D1"/>
+        <ports identifier="P112" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="55.0" text="Torus3D2"/>
+        <ports identifier="P113" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N54" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L54" height="15.0" width="77.0" text="Translate3D9"/>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.5 //@children.2/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N55" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L55" height="15.0" width="69.0" text="Rotate3D10"/>
+        <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N56" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L56" height="15.0" width="69.0" text="Rotate3D13"/>
+        <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N57" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="69.0" text="Rotate3D14"/>
+        <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="55.0" text="Torus3D3"/>
+        <ports identifier="P125" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="62.0" text="Rotate3D4"/>
+        <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P127" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.8 //@children.2/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="62.0" text="Torus3D16"/>
+        <ports identifier="P132" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N62" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L62" height="15.0" width="69.0" text="Rotate3D17"/>
+        <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P134" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N63" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L63" height="15.0" width="69.0" text="Rotate3D20"/>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P136" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N64" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L64" height="15.0" width="84.0" text="Translate3D24"/>
+        <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.12 //@children.2/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N65" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L65" height="15.0" width="62.0" text="Torus3D27"/>
+        <ports identifier="P141" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N66" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L66" height="15.0" width="69.0" text="Rotate3D28"/>
+        <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N67" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L67" height="15.0" width="84.0" text="Translate3D33"/>
+        <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.15 //@children.2/@children.13/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N68" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="62.0" text="Torus3D38"/>
+        <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="62.0" text="Torus3D39"/>
+        <ports identifier="P149" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N70" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L70" height="15.0" width="69.0" text="Rotate3D40"/>
+        <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P151" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N71" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L71" height="15.0" width="69.0" text="Rotate3D41"/>
+        <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P153" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N72" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="84.0" text="Translate3D42"/>
+        <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.20 //@children.2/@children.13/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N73" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="69.0" text="Rotate3D43"/>
+        <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P159" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N74" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L74" height="15.0" width="84.0" text="Translate3D52"/>
+        <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@children.13/@containedEdges.22 //@children.2/@children.13/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P162" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.13/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N75" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L75" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.13/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P165" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.13/@containedEdges.24 //@children.2/@children.13/@containedEdges.25 //@children.2/@children.13/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N76" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L76" height="15.0" width="65.0" text="Sphere3D1"/>
+        <ports identifier="P166" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N77" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L77" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P168" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N78" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L78" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.3 //@children.2/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P170" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N79" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="85.0" text="Compute Twist"/>
+        <ports identifier="P171" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.2/@children.13/@containedEdges.30 //@children.2/@children.13/@containedEdges.31 //@children.2/@children.13/@containedEdges.32 //@children.2/@children.13/@containedEdges.33 //@children.2/@children.13/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.13/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="25.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P173" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@children.2/@children.13/@containedEdges.35 //@children.2/@children.13/@containedEdges.36 //@children.2/@children.13/@containedEdges.37 //@children.2/@children.13/@containedEdges.38 //@children.2/@children.13/@containedEdges.39 //@children.2/@children.13/@containedEdges.40 //@children.2/@children.13/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E82" sources="//@children.2/@children.13/@ports.0" targets="//@children.2/@children.13/@children.28/@ports.1"/>
+      <containedEdges identifier="E83" sources="//@children.2/@children.13/@children.0/@ports.0" targets="//@children.2/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.2/@children.13/@children.1/@ports.0" targets="//@children.2/@children.13/@children.5/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.2/@children.13/@children.2/@ports.1" targets="//@children.2/@children.13/@children.26/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.2/@children.13/@children.3/@ports.1" targets="//@children.2/@children.13/@children.26/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.2/@children.13/@children.4/@ports.1" targets="//@children.2/@children.13/@children.2/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.2/@children.13/@children.5/@ports.1" targets="//@children.2/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.2/@children.13/@children.6/@ports.0" targets="//@children.2/@children.13/@children.7/@ports.0"/>
+      <containedEdges identifier="E90" sources="//@children.2/@children.13/@children.7/@ports.1" targets="//@children.2/@children.13/@children.8/@ports.0"/>
+      <containedEdges identifier="E91" sources="//@children.2/@children.13/@children.8/@ports.1" targets="//@children.2/@children.13/@children.2/@ports.0"/>
+      <containedEdges identifier="E92" sources="//@children.2/@children.13/@children.9/@ports.0" targets="//@children.2/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.2/@children.13/@children.10/@ports.1" targets="//@children.2/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E94" sources="//@children.2/@children.13/@children.11/@ports.1" targets="//@children.2/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E95" sources="//@children.2/@children.13/@children.12/@ports.1" targets="//@children.2/@children.13/@children.8/@ports.0"/>
+      <containedEdges identifier="E96" sources="//@children.2/@children.13/@children.13/@ports.0" targets="//@children.2/@children.13/@children.14/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.2/@children.13/@children.14/@ports.1" targets="//@children.2/@children.13/@children.15/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.2/@children.13/@children.15/@ports.1" targets="//@children.2/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.2/@children.13/@children.16/@ports.0" targets="//@children.2/@children.13/@children.18/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.2/@children.13/@children.17/@ports.0" targets="//@children.2/@children.13/@children.21/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.2/@children.13/@children.18/@ports.1" targets="//@children.2/@children.13/@children.19/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.2/@children.13/@children.19/@ports.1" targets="//@children.2/@children.13/@children.20/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.2/@children.13/@children.20/@ports.1" targets="//@children.2/@children.13/@children.15/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.2/@children.13/@children.21/@ports.1" targets="//@children.2/@children.13/@children.22/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.2/@children.13/@children.22/@ports.1" targets="//@children.2/@children.13/@children.20/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.2/@children.13/@children.23/@ports.1" targets="//@children.2/@children.13/@children.4/@ports.2"/>
+      <containedEdges identifier="E107" sources="//@children.2/@children.13/@children.23/@ports.1" targets="//@children.2/@children.13/@children.11/@ports.2"/>
+      <containedEdges identifier="E108" sources="//@children.2/@children.13/@children.23/@ports.1" targets="//@children.2/@children.13/@children.19/@ports.2"/>
+      <containedEdges identifier="E109" sources="//@children.2/@children.13/@children.24/@ports.0" targets="//@children.2/@children.13/@children.25/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.2/@children.13/@children.25/@ports.1" targets="//@children.2/@children.13/@children.22/@ports.0"/>
+      <containedEdges identifier="E111" sources="//@children.2/@children.13/@children.26/@ports.1" targets="//@children.2/@children.13/@ports.1"/>
+      <containedEdges identifier="E112" sources="//@children.2/@children.13/@children.27/@ports.0" targets="//@children.2/@children.13/@children.3/@ports.2"/>
+      <containedEdges identifier="E113" sources="//@children.2/@children.13/@children.27/@ports.0" targets="//@children.2/@children.13/@children.7/@ports.2"/>
+      <containedEdges identifier="E114" sources="//@children.2/@children.13/@children.27/@ports.0" targets="//@children.2/@children.13/@children.14/@ports.2"/>
+      <containedEdges identifier="E115" sources="//@children.2/@children.13/@children.27/@ports.0" targets="//@children.2/@children.13/@children.21/@ports.2"/>
+      <containedEdges identifier="E116" sources="//@children.2/@children.13/@children.27/@ports.0" targets="//@children.2/@children.13/@children.23/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.2/@children.13/@children.28/@ports.0" targets="//@children.2/@children.13/@children.2/@ports.2"/>
+      <containedEdges identifier="E118" sources="//@children.2/@children.13/@children.28/@ports.0" targets="//@children.2/@children.13/@children.8/@ports.2"/>
+      <containedEdges identifier="E119" sources="//@children.2/@children.13/@children.28/@ports.0" targets="//@children.2/@children.13/@children.12/@ports.2"/>
+      <containedEdges identifier="E120" sources="//@children.2/@children.13/@children.28/@ports.0" targets="//@children.2/@children.13/@children.15/@ports.2"/>
+      <containedEdges identifier="E121" sources="//@children.2/@children.13/@children.28/@ports.0" targets="//@children.2/@children.13/@children.20/@ports.2"/>
+      <containedEdges identifier="E122" sources="//@children.2/@children.13/@children.28/@ports.0" targets="//@children.2/@children.13/@children.22/@ports.2"/>
+      <containedEdges identifier="E123" sources="//@children.2/@children.13/@children.28/@ports.0" targets="//@children.2/@children.13/@children.27/@ports.1"/>
+    </children>
+    <children identifier="N81" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L81" height="15.0" width="77.0" text="Translate3D5"/>
+      <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N82" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L82" height="15.0" width="77.0" text="Translate3D6"/>
+      <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P178" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N83" height="25.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L83" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P179" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E22" sources="//@children.2/@ports.1" targets="//@children.2/@children.16/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.2/@ports.0" targets="//@children.2/@children.13/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.11/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.14/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.11/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.15/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.2/@children.11/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.2/@children.12/@ports.1" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.2/@children.13/@ports.1" targets="//@children.2/@children.12/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.2/@children.14/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.2/@children.15/@ports.1" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.2/@children.16/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N84" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P182" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.4" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.6" targets="//@children.1/@ports.6"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.7" targets="//@children.1/@ports.7"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.0/@ports.5" targets="//@children.1/@ports.5"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/continuous_v2v_V2V.elkg
+++ b/realworld/ptolemy/hierarchical/continuous_v2v_V2V.elkg
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="102.0" text="MeasureDistance"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.1" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="99.0" text="FollowingPlatoon"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3" incomingEdges="//@children.1/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="46.0" text="Velocity"/>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3" incomingEdges="//@children.1/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E17" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E18" sources="//@children.1/@children.0/@children.0/@ports.2" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.1/@children.0/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="56.0" text="Controller"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@ports.1" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="56.0" text="Velocities"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="90.0" text="LeadingPlatoon"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="40.0" text="Limiter"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="51.0" text="1:Limiter"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="120.0" text="ContinuousSinewave"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.1/@ports.2" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.3/@ports.2" targets="//@children.3/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="52.0" text="Distance"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ddf_LoopSyntacticC.elkg
+++ b/realworld/ptolemy/hierarchical/ddf_LoopSyntacticC.elkg
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="138.0" text="Outside-the-loop Plotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="127.0" text="Inside-the-loop Plotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" incomingEdges="//@children.9/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.2 //@containedEdges.14" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.9/@containedEdges.4 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="87.0" text="MovingAverage"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.1 //@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.9/@ports.0" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.9/@ports.2" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.9/@children.1/@ports.2" targets="//@children.9/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.9/@children.2/@ports.0" targets="//@children.9/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N14" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.2" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.3" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.10/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ddf_eratosthenes_Eratosthenes.elkg
+++ b/realworld/ptolemy/hierarchical/ddf_eratosthenes_Eratosthenes.elkg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="123.0" text="Prime_Number_Filter"/>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.2/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.8 //@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="90.0" text="ActorRecursion"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="140.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="140.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.2/@children.0/@ports.3" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.2/@children.0/@ports.3" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.7/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.5/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.5/@ports.3" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.5/@ports.3" targets="//@children.2/@children.7/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.6/@ports.3" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.6/@ports.2" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ddf_factorial_Factorial.elkg
+++ b/realworld/ptolemy/hierarchical/ddf_factorial_Factorial.elkg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="115.0" text="Factorial_Generator"/>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="90.0" text="ActorRecursion"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.1/@children.0/@ports.3" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.0/@ports.3" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.2/@ports.3" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ddf_ifthenelse_IfThenElseFSM.elkg
+++ b/realworld/ptolemy/hierarchical/ddf_ifthenelse_IfThenElseFSM.elkg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="92.0" text="DDF +1/-1 Gain"/>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.2" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.2/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.0/@ports.3" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.3/@ports.3" targets="//@children.2/@ports.2"/>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="168.0" text="FSM ModalModel +1/-1 Gain"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.2" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ddf_randomwalk_RandomWalk.elkg
+++ b/realworld/ptolemy/hierarchical/ddf_randomwalk_RandomWalk.elkg
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="52.0" text="Uniform2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="79.0" text="TrigFunction2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="54.0" text="DrawLine"/>
+    <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="49.0" text="Repeat2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="68.0" text="DisplayLine"/>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.2/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.2/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N8" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="81.0" text="Accumulator2"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="55.0" text="XYPlotter"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E13" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.3/@children.2/@children.0/@ports.1" targets="//@children.3/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.3/@children.2/@children.1/@ports.1" targets="//@children.3/@children.2/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.3/@ports.2" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N11" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="99.0" text="CartesianToPolar"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="72.0" text="TrigFunction"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="22.0" text="Ceil"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ddf_rijndaelencryption_RijndaelEncryption.elkg
+++ b/realworld/ptolemy/hierarchical/ddf_rijndaelencryption_RijndaelEncryption.elkg
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="rijndael"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="118.0" text="RoundKeyGenerator"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P4" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="25.0" width="508.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="508.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="203.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="85.0" text="SampleDelay2"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="203.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="103.0" text="ArrayToSequence"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.6 //@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="74.0" text="modal model"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E18" sources="//@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="96.0" text="RoundSequence"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="89.0" text="convertToString"/>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.3/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5" incomingEdges="//@children.0/@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="25.0" width="115.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.3/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="77.0" text="DownSample"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.3 //@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="61.0" text="UpSample"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="227.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="92.0" text="PadToTwoChars"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E19" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.0/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.0/@children.3/@children.0/@ports.0" targets="//@children.0/@children.3/@children.6/@ports.1"/>
+      <containedEdges identifier="E21" sources="//@children.0/@children.3/@children.1/@ports.1" targets="//@children.0/@children.3/@children.2/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.0/@children.3/@children.2/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.3/@children.2/@ports.1" targets="//@children.0/@children.3/@children.4/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.3/@children.3/@ports.1" targets="//@children.0/@children.3/@children.5/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.3/@children.4/@ports.0" targets="//@children.0/@children.3/@children.3/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.3/@children.5/@ports.1" targets="//@children.0/@children.3/@children.1/@ports.2"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.3/@children.6/@ports.0" targets="//@children.0/@children.3/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@children.1/@ports.3"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N20" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L22" height="15.0" width="89.0" text="convertToString"/>
+    <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N23" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="77.0" text="DownSample"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="61.0" text="UpSample"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="25.0" width="227.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="92.0" text="PadToTwoChars"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E28" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.1/@ports.2"/>
+    <containedEdges identifier="E36" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_CommunicationAnomalyDetectionAOM.elkg
+++ b/realworld/ptolemy/hierarchical/de_CommunicationAnomalyDetectionAOM.elkg
@@ -1,0 +1,757 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="Sensor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="93.0" text="OutgoingPacket"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.1/@ports.3"/>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="99.0" text="Application Node"/>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N8" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="14.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="107.0" text="AnomalyDetection"/>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="11.0" text="in"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0 //@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="18.0" text="out"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="99.0" text="LatencyEstimate"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L14" height="15.0" width="109.0" text="Learning/Detection"/>
+        <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.1" incomingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.2" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.0" incomingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N15" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="103.0" text="ArrayToSequence"/>
+          <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.3 //@children.1/@children.1/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="110.0" text="ArrayToSequence2"/>
+          <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.5 //@children.1/@children.1/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="90.0" text="CompareLabels"/>
+          <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="66.0" text="CountTrues"/>
+          <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N19" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L19" height="15.0" width="47.0" text="Average"/>
+          <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N20" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L20" height="15.0" width="54.0" text="Average2"/>
+          <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N21" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L21" height="15.0" width="54.0" text="Average3"/>
+          <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N22" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L22" height="15.0" width="104.0" text="SequencePlotter2"/>
+          <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N23" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L23" height="15.0" width="172.0" text="ParameterEstimatorGaussian"/>
+          <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="1.600000023841858" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="11.199999809265137">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="4"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N24" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L24" height="15.0" width="140.0" text="HMMGaussianClassifier"/>
+          <ports identifier="P53" height="8.0" width="8.0" x="-8.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N25" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="97.0" text="SequencePlotter"/>
+          <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.4 //@children.1/@children.1/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N26" height="25.0" width="79.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P60" height="8.0" width="8.0" x="79.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E29" sources="//@children.1/@children.1/@children.4/@ports.2" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E30" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.4/@children.8/@ports.0"/>
+        <containedEdges identifier="E31" sources="//@children.1/@children.1/@children.4/@ports.1" targets="//@children.1/@children.1/@children.4/@children.9/@ports.2"/>
+        <containedEdges identifier="E32" sources="//@children.1/@children.1/@children.4/@children.0/@ports.1" targets="//@children.1/@children.1/@children.4/@children.2/@ports.1"/>
+        <containedEdges identifier="E33" sources="//@children.1/@children.1/@children.4/@children.0/@ports.1" targets="//@children.1/@children.1/@children.4/@children.10/@ports.0"/>
+        <containedEdges identifier="E34" sources="//@children.1/@children.1/@children.4/@children.1/@ports.1" targets="//@children.1/@children.1/@children.4/@children.2/@ports.0"/>
+        <containedEdges identifier="E35" sources="//@children.1/@children.1/@children.4/@children.1/@ports.1" targets="//@children.1/@children.1/@children.4/@children.10/@ports.0"/>
+        <containedEdges identifier="E36" sources="//@children.1/@children.1/@children.4/@children.2/@ports.2" targets="//@children.1/@children.1/@children.4/@children.3/@ports.0"/>
+        <containedEdges identifier="E37" sources="//@children.1/@children.1/@children.4/@children.3/@ports.1" targets="//@children.1/@children.1/@children.4/@children.11/@ports.1"/>
+        <containedEdges identifier="E38" sources="//@children.1/@children.1/@children.4/@children.4/@ports.1" targets="//@children.1/@children.1/@children.4/@children.9/@ports.4"/>
+        <containedEdges identifier="E39" sources="//@children.1/@children.1/@children.4/@children.5/@ports.1" targets="//@children.1/@children.1/@children.4/@children.9/@ports.5"/>
+        <containedEdges identifier="E40" sources="//@children.1/@children.1/@children.4/@children.6/@ports.1" targets="//@children.1/@children.1/@children.4/@children.9/@ports.1"/>
+        <containedEdges identifier="E41" sources="//@children.1/@children.1/@children.4/@children.8/@ports.1" targets="//@children.1/@children.1/@children.4/@children.6/@ports.0"/>
+        <containedEdges identifier="E42" sources="//@children.1/@children.1/@children.4/@children.8/@ports.3" targets="//@children.1/@children.1/@children.4/@children.4/@ports.0"/>
+        <containedEdges identifier="E43" sources="//@children.1/@children.1/@children.4/@children.8/@ports.4" targets="//@children.1/@children.1/@children.4/@children.5/@ports.0"/>
+        <containedEdges identifier="E44" sources="//@children.1/@children.1/@children.4/@children.9/@ports.3" targets="//@children.1/@children.1/@children.4/@children.0/@ports.0"/>
+        <containedEdges identifier="E45" sources="//@children.1/@children.1/@children.4/@children.11/@ports.0" targets="//@children.1/@children.1/@children.4/@children.7/@ports.0"/>
+      </children>
+      <children identifier="N27" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="102.0" text="SequenceToArray"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.4 //@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="74.0" text="TrainOrTest?"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="81.0" text="TrainOrTest?2"/>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="110.0" text="SequenceToArray2"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="46.0" text="Counter"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="28.75">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P81" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.12 //@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="79.0" text="UpdateLabels"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="56.0" text="GetToken"/>
+        <ports identifier="P85" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.1/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="10.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.1/@children.1/@containedEdges.16 //@children.1/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.1/@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.1/@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@children.13/@ports.1"/>
+      <containedEdges identifier="E12" sources="//@children.1/@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.1/@children.1/@children.5/@ports.1" targets="//@children.1/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.1/@children.1/@children.5/@ports.1" targets="//@children.1/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.1/@children.1/@children.6/@ports.3" targets="//@children.1/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.1/@children.1/@children.6/@ports.2" targets="//@children.1/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E18" sources="//@children.1/@children.1/@children.7/@ports.2" targets="//@children.1/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.1/@children.1/@children.7/@ports.3" targets="//@children.1/@children.1/@children.4/@ports.2"/>
+      <containedEdges identifier="E20" sources="//@children.1/@children.1/@children.8/@ports.1" targets="//@children.1/@children.1/@children.7/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.1/@children.1/@children.10/@ports.2" targets="//@children.1/@children.1/@children.11/@ports.1"/>
+      <containedEdges identifier="E22" sources="//@children.1/@children.1/@children.11/@ports.0" targets="//@children.1/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E23" sources="//@children.1/@children.1/@children.11/@ports.0" targets="//@children.1/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.1/@children.1/@children.12/@ports.0" targets="//@children.1/@children.1/@children.14/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.1/@children.1/@children.13/@ports.0" targets="//@children.1/@children.1/@children.12/@ports.1"/>
+      <containedEdges identifier="E26" sources="//@children.1/@children.1/@children.14/@ports.3" targets="//@children.1/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.1/@children.1/@children.14/@ports.3" targets="//@children.1/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E28" sources="//@children.1/@children.1/@children.14/@ports.1" targets="//@children.1/@children.1/@children.8/@ports.0"/>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N37">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L37" height="15.0" width="89.0" text="ServiceChannel"/>
+    <children identifier="N38" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="123.0" text="CommunicationDelay"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="79.0" text="UpdateLabels"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="25.0" width="75.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="106.0" text="UpdateCQMToken"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="112.0" text="LatencyDistribution"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E46" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E48" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.8/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E55" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E56" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_CommunicationAnomalyDetectionCQM.elkg
+++ b/realworld/ptolemy/hierarchical/de_CommunicationAnomalyDetectionCQM.elkg
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="66.0" text="Transmitter"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="93.0" text="OutgoingPacket"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.1/@ports.3"/>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="99.0" text="LatencyEstimate"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="109.0" text="Learning/Detection"/>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N10" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="103.0" text="ArrayToSequence"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.2/@containedEdges.3 //@children.1/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="97.0" text="SequencePlotter"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.3 //@children.1/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="110.0" text="ArrayToSequence2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.2/@containedEdges.5 //@children.1/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="90.0" text="CompareLabels"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="66.0" text="CountTrues"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.8 //@children.1/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="40.0" text="priors2"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="47.0" text="Average"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="54.0" text="Average2"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="54.0" text="Average3"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="104.0" text="SequencePlotter2"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="172.0" text="ParameterEstimatorGaussian"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="1.600000023841858" outgoingEdges="//@children.1/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="11.199999809265137" outgoingEdges="//@children.1/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@children.1/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@children.1/@children.2/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="140.0" text="HMMGaussianClassifier"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" incomingEdges="//@children.1/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E24" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.2/@children.12/@ports.2"/>
+      <containedEdges identifier="E27" sources="//@children.1/@children.2/@children.0/@ports.1" targets="//@children.1/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.1/@children.2/@children.0/@ports.1" targets="//@children.1/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E29" sources="//@children.1/@children.2/@children.2/@ports.1" targets="//@children.1/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.2/@children.2/@ports.1" targets="//@children.1/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.1/@children.2/@children.3/@ports.2" targets="//@children.1/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.2/@children.4/@ports.1" targets="//@children.1/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.2/@children.4/@ports.1" targets="//@children.1/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.2/@children.5/@ports.2" targets="//@children.1/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.2/@children.6/@ports.0" targets="//@children.1/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.2/@children.7/@ports.1" targets="//@children.1/@children.2/@children.12/@ports.4"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.2/@children.8/@ports.1" targets="//@children.1/@children.2/@children.12/@ports.5"/>
+      <containedEdges identifier="E38" sources="//@children.1/@children.2/@children.9/@ports.1" targets="//@children.1/@children.2/@children.12/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.2/@children.11/@ports.2" targets="//@children.1/@children.2/@children.12/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.2/@children.11/@ports.1" targets="//@children.1/@children.2/@children.9/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.2/@children.11/@ports.3" targets="//@children.1/@children.2/@children.7/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.2/@children.11/@ports.4" targets="//@children.1/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.2/@children.12/@ports.3" targets="//@children.1/@children.2/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N23" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="81.0" text="TrainOrTest?2"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="74.0" text="TrainOrTest?"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="110.0" text="SequenceToArray2"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="93.0" text="IncomingPacket"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="10.0" y="28.75">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="25.0" width="87.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.14 //@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.4/@ports.3" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.5/@ports.3" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.10/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+  </children>
+  <children identifier="N31">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L31" height="15.0" width="89.0" text="ServiceChannel"/>
+    <children identifier="N32" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="123.0" text="CommunicationDelay"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="79.0" text="UpdateLabels"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="25.0" width="75.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="106.0" text="UpdateCQMToken"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="112.0" text="LatencyDistribution"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E44" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E46" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E47" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E48" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.8/@ports.2"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E54" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_afdx_AFDX.elkg
+++ b/realworld/ptolemy/hierarchical/de_afdx_AFDX.elkg
@@ -1,0 +1,315 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="17.0" text="N1"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="17.0" text="N2"/>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="17.0" text="N3"/>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="17.0" text="N4"/>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11" incomingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E25" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@ports.3"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.4 //@containedEdges.6 //@containedEdges.8 //@containedEdges.10 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="17.0" text="D2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="24.0" text="D41"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="24.0" text="D42"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="17.0" text="D3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="78.0" text="CurrentTime4"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.1" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.3/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.3/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.3/@ports.3" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.9/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.10/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.0" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_afdx_AFDXMulticastSimple.elkg
+++ b/realworld/ptolemy/hierarchical/de_afdx_AFDXMulticastSimple.elkg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="17.0" text="N1"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="17.0" text="N2"/>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.1/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="57.0" text="AFDX_VL"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="17.0" text="D2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="17.0" text="N3"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="17.0" text="D3"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="78.0" text="CurrentTime4"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_bus_2Bus.elkg
+++ b/realworld/ptolemy/hierarchical/de_bus_2Bus.elkg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.5/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@ports.1"/>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_canbus_CanBusVariousCollisions.elkg
+++ b/realworld/ptolemy/hierarchical/de_canbus_CanBusVariousCollisions.elkg
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="19.0" text="DC"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="26.0" text="DC2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="17.0" text="B1"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.4" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.5 //@containedEdges.8 //@containedEdges.10 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="17.0" text="B2"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="60.0" text="CanBusPr"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="67.0" text="CanBusPr2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="10.0" text="C"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_clock_Clock.elkg
+++ b/realworld/ptolemy/hierarchical/de_clock_Clock.elkg
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="31.0" text="clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="40.0" text="Box3D"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="55.0" text="Rotate3D"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="81.0" text="Copy2:Box3D"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="111.0" text="Copy3:Translate3D"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="64.0" text="Cylinder3D"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="77.0" text="ViewScreen2"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.5 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.3"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.3"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.4/@ports.4" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.1/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="60.0" text="ClipPlayer"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="39.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="75.0" text="Comparator2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.2" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_clock_ClockTest.elkg
+++ b/realworld/ptolemy/hierarchical/de_clock_ClockTest.elkg
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="31.0" text="clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="40.0" text="Box3D"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="55.0" text="Rotate3D"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="81.0" text="Copy2:Box3D"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="111.0" text="Copy3:Translate3D"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="64.0" text="Cylinder3D"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="77.0" text="ViewScreen2"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.5 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.0/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.3"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.3"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.4/@ports.4" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.1/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="52.0" text="Play Bell"/>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="126.0" text="Copy1:Lowpass Filter"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="118.0" text="Copy1:Allpass Filter"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="206.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="74.0" text="Copy1:Delay"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="206.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="75.0" text="Copy1:Scale"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="112.0" text="Copy1:AudioPlayer"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.4 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.5 //@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="61.0" text="UpSample"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.5/@ports.2" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.5/@ports.2" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N21" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="43.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="59.0" text="LineCoder"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="102.0" text="Copy1:UpSample"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_clockdrift_ClockDrift.elkg
+++ b/realworld/ptolemy/hierarchical/de_clockdrift_ClockDrift.elkg
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P20" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.6/@ports.2" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@ports.3"/>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_clockdrift_ClockDriftHierarchy.elkg
+++ b/realworld/ptolemy/hierarchical/de_clockdrift_ClockDriftHierarchy.elkg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L3" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N4" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.1/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@ports.2"/>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="89.0" text="DiscreteClock4"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_clockdrift_ClockDrifts.elkg
+++ b/realworld/ptolemy/hierarchical/de_clockdrift_ClockDrifts.elkg
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="120.0" text="ContinuousSinewave"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P34" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.11/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.11/@ports.1" targets="//@children.11/@children.0/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@ports.2"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P39" height="8.0" width="8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16" incomingEdges="//@children.12/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.12/@ports.1" targets="//@children.12/@children.0/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.12/@children.0/@ports.0" targets="//@children.12/@ports.2"/>
+  </children>
+  <children identifier="N16">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L16" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P44" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@containedEdges.17" incomingEdges="//@children.13/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N17" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.13/@children.0/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.13/@children.0/@ports.0" targets="//@children.13/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.13/@ports.2" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_clockdrift_SetClockDriftViaParameterOrPortParameter.elkg
+++ b/realworld/ptolemy/hierarchical/de_clockdrift_SetClockDriftViaParameterOrPortParameter.elkg
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="60.0" text="portParam"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.2"/>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.5 //@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="46.0" text="delayed"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.4/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="RateChange"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="66.0" text="notDelayed"/>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.7/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@ports.1"/>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="114.0" text="SetVariableDelayed"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_compositeqm_CheckExecutionTimeConstraints.elkg
+++ b/realworld/ptolemy/hierarchical/de_compositeqm_CheckExecutionTimeConstraints.elkg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="10.0" text="C"/>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="98.0" text="ThrowModelError"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="78.0" text="CurrentTime2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="36.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="39.0" text="Queue"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="28.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.8/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="44.0" text="Uniform"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_compositeqm_CompositeQM.elkg
+++ b/realworld/ptolemy/hierarchical/de_compositeqm_CompositeQM.elkg
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="9.0" text="B"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="10.0" text="C"/>
+    <children identifier="N8" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="17.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="8.0" text="a"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="8.0" text="b"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="93.0" text="CQMOutputPort"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="9.0" text="X"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.4/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.1 //@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N16">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L16" height="15.0" width="9.0" text="Y"/>
+    <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.5/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N17" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_de_DE2.elkg
+++ b/realworld/ptolemy/hierarchical/de_de_DE2.elkg
@@ -1,0 +1,683 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4 //@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="167.0" text="ResourceMappingOutputPort"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.4 //@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="167.0" text="ResourceMappingOutputPort"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="175.0" text="ResourceMappingOutputPort2"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E22" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="42.0" text="Ramp3"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Ramp4"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N26">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L26" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P53" height="8.0" width="8.0" incomingEdges="//@children.10/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" incomingEdges="//@children.10/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0 //@children.10/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N27">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L27" height="15.0" width="67.0" text="1Processor"/>
+        <children identifier="N28" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="18.0" text="in1"/>
+          <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N29" height="36.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="37.0" text="Server"/>
+          <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P60" height="8.0" width="8.0" x="42.0" y="36.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N30" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L30" height="15.0" width="121.0" text="RecordDisassembler"/>
+          <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P62" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N31" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L31" height="15.0" width="18.0" text="out"/>
+          <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N32" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L32" height="15.0" width="18.0" text="in2"/>
+          <ports identifier="P64" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N33" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L33" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.0 //@children.10/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P66" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.4 //@children.10/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E36" sources="//@children.10/@children.0/@children.0/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E37" sources="//@children.10/@children.0/@children.0/@children.1/@ports.1" targets="//@children.10/@children.0/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E38" sources="//@children.10/@children.0/@children.0/@children.2/@ports.1" targets="//@children.10/@children.0/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E39" sources="//@children.10/@children.0/@children.0/@children.4/@ports.0" targets="//@children.10/@children.0/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E40" sources="//@children.10/@children.0/@children.0/@children.5/@ports.1" targets="//@children.10/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E41" sources="//@children.10/@children.0/@children.0/@children.5/@ports.1" targets="//@children.10/@children.0/@children.0/@children.2/@ports.0"/>
+      </children>
+      <children identifier="N34" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="42.0" text="Ramp3"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="42.0" text="Ramp4"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N36">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L36" height="15.0" width="73.0" text="2Processors"/>
+        <children identifier="N37" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L37" height="15.0" width="18.0" text="in1"/>
+          <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.0 //@children.10/@children.0/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N38" height="36.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L38" height="15.0" width="37.0" text="Server"/>
+          <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P75" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P76" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P77" height="8.0" width="8.0" x="42.0" y="36.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N39" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L39" height="15.0" width="121.0" text="RecordDisassembler"/>
+          <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N40" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L40" height="15.0" width="18.0" text="out"/>
+          <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N41" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L41" height="15.0" width="18.0" text="in2"/>
+          <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.4 //@children.10/@children.0/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N42" height="36.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L42" height="15.0" width="44.0" text="Server2"/>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P83" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P85" height="8.0" width="8.0" x="42.0" y="36.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N43" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L43" height="15.0" width="128.0" text="RecordDisassembler2"/>
+          <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P87" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N44" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L44" height="15.0" width="26.0" text="out2"/>
+          <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@children.0/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E42" sources="//@children.10/@children.0/@children.3/@children.0/@ports.0" targets="//@children.10/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E43" sources="//@children.10/@children.0/@children.3/@children.0/@ports.0" targets="//@children.10/@children.0/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E44" sources="//@children.10/@children.0/@children.3/@children.1/@ports.1" targets="//@children.10/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E45" sources="//@children.10/@children.0/@children.3/@children.2/@ports.1" targets="//@children.10/@children.0/@children.3/@children.1/@ports.2"/>
+        <containedEdges identifier="E46" sources="//@children.10/@children.0/@children.3/@children.4/@ports.0" targets="//@children.10/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E47" sources="//@children.10/@children.0/@children.3/@children.4/@ports.0" targets="//@children.10/@children.0/@children.3/@children.6/@ports.0"/>
+        <containedEdges identifier="E48" sources="//@children.10/@children.0/@children.3/@children.5/@ports.1" targets="//@children.10/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E49" sources="//@children.10/@children.0/@children.3/@children.6/@ports.1" targets="//@children.10/@children.0/@children.3/@children.5/@ports.2"/>
+      </children>
+      <children identifier="N45" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E30" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E31" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.10/@children.0/@children.1/@ports.0" targets="//@children.10/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.10/@children.0/@children.2/@ports.0" targets="//@children.10/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.10/@children.0/@children.4/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.10/@children.0/@children.5/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.10/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_inspection_Inspection.elkg
+++ b/realworld/ptolemy/hierarchical/de_inspection_Inspection.elkg
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="119.0" text="Poisson Bus Arrivals"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="107.0" text="Passenger Arrivals"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="128.0" text="Poisson Waiting Time"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="Timed Plotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="59.0" text="Histogram"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="116.0" text="Regular Bus Arrivals"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="Regular Waiting Time"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="139.0" text="Report Poisson Average"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1 //@children.7/@containedEdges.2" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.7/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="47.0" text="Average"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.4 //@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.7/@ports.1" targets="//@children.7/@children.1/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.7/@ports.1" targets="//@children.7/@children.3/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.7/@children.2/@ports.2" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="179.0" text="Display Average Waiting Times"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="76.0" text="SingleEvent0"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="136.0" text="Report Regular Average"/>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1 //@children.10/@containedEdges.2" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.10/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="47.0" text="Average"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.4 //@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.10/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.10/@ports.1" targets="//@children.10/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.10/@ports.1" targets="//@children.10/@children.3/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.10/@children.3/@ports.0" targets="//@children.10/@children.2/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.2" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_linefault_LineFault.elkg
+++ b/realworld/ptolemy/hierarchical/de_linefault_LineFault.elkg
@@ -1,0 +1,1688 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="111.0" text="LineFaultGenerator"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="135.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="121.0" text="Discrete TimeDelay2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="135.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.2"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="71.0" text="SubstationA"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.1/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.1/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@children.1/@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@children.1/@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0 //@children.1/@children.0/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N9" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="63.0" text="IsPresent2"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="25.0" width="22.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="82.0" text="LogicFunction"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.2 //@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.6 //@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.3 //@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.8 //@children.1/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.10 //@children.1/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.11 //@children.1/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="77.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.13 //@children.1/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.14 //@children.1/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L19" height="15.0" width="94.0" text="CompositeActor"/>
+        <ports identifier="P52" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.10/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.16" incomingEdges="//@children.1/@children.0/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N20" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L20" height="15.0" width="73.0" text="LookupTable"/>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N21" height="46.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L21" height="15.0" width="44.0" text="Uniform"/>
+          <ports identifier="P56" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.1/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.1/@children.0/@children.10/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N22" height="34.0" width="34.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L22" height="15.0" width="38.0" text="Round"/>
+          <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.1/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P61" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@children.1/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E65" sources="//@children.1/@children.0/@children.10/@ports.0" targets="//@children.1/@children.0/@children.10/@children.1/@ports.1"/>
+        <containedEdges identifier="E66" sources="//@children.1/@children.0/@children.10/@children.0/@ports.1" targets="//@children.1/@children.0/@children.10/@ports.1"/>
+        <containedEdges identifier="E67" sources="//@children.1/@children.0/@children.10/@children.1/@ports.0" targets="//@children.1/@children.0/@children.10/@children.2/@ports.0"/>
+        <containedEdges identifier="E68" sources="//@children.1/@children.0/@children.10/@children.2/@ports.1" targets="//@children.1/@children.0/@children.10/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N23" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="89.0" text="DiscreteClock2"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.17 //@children.1/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.20 //@children.1/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.1/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N26">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L26" height="15.0" width="101.0" text="CompositeActor2"/>
+        <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.14/@containedEdges.0 //@children.1/@children.0/@children.14/@containedEdges.1" incomingEdges="//@children.1/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.21 //@children.1/@children.0/@containedEdges.22 //@children.1/@children.0/@containedEdges.23" incomingEdges="//@children.1/@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N27" height="25.0" width="219.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P75" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P78" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P79" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N29" height="25.0" width="223.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="42.0" text="Const5"/>
+          <ports identifier="P80" height="8.0" width="8.0" x="223.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N30" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L30" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@children.14/@containedEdges.2 //@children.1/@children.0/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P83" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.14/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E69" sources="//@children.1/@children.0/@children.14/@ports.0" targets="//@children.1/@children.0/@children.14/@children.0/@ports.1"/>
+        <containedEdges identifier="E70" sources="//@children.1/@children.0/@children.14/@ports.0" targets="//@children.1/@children.0/@children.14/@children.1/@ports.0"/>
+        <containedEdges identifier="E71" sources="//@children.1/@children.0/@children.14/@children.0/@ports.0" targets="//@children.1/@children.0/@children.14/@children.3/@ports.0"/>
+        <containedEdges identifier="E72" sources="//@children.1/@children.0/@children.14/@children.1/@ports.1" targets="//@children.1/@children.0/@children.14/@children.2/@ports.1"/>
+        <containedEdges identifier="E73" sources="//@children.1/@children.0/@children.14/@children.2/@ports.0" targets="//@children.1/@children.0/@children.14/@children.3/@ports.0"/>
+        <containedEdges identifier="E74" sources="//@children.1/@children.0/@children.14/@children.3/@ports.1" targets="//@children.1/@children.0/@children.14/@ports.1"/>
+      </children>
+      <children identifier="N31" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P84" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="80.0" text="AddSubtract4"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L33" height="15.0" width="101.0" text="CompositeActor3"/>
+        <ports identifier="P92" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.17/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.27" incomingEdges="//@children.1/@children.0/@children.17/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.17/@containedEdges.1" incomingEdges="//@children.1/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.26" incomingEdges="//@children.1/@children.0/@children.17/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N34" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L34" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P97" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.17/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@children.17/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N35" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L35" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P99" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.17/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@children.17/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E75" sources="//@children.1/@children.0/@children.17/@ports.1" targets="//@children.1/@children.0/@children.17/@children.0/@ports.1"/>
+        <containedEdges identifier="E76" sources="//@children.1/@children.0/@children.17/@ports.3" targets="//@children.1/@children.0/@children.17/@children.1/@ports.1"/>
+        <containedEdges identifier="E77" sources="//@children.1/@children.0/@children.17/@children.0/@ports.0" targets="//@children.1/@children.0/@children.17/@ports.2"/>
+        <containedEdges identifier="E78" sources="//@children.1/@children.0/@children.17/@children.1/@ports.0" targets="//@children.1/@children.0/@children.17/@ports.4"/>
+      </children>
+      <children identifier="N36" height="28.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="90.0" text="MicrostepDelay"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.1/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="22.0" text="PID"/>
+        <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.30 //@children.1/@children.0/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E33" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.0/@children.16/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.0/@children.17/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.0/@children.0/@ports.1" targets="//@children.1/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.0/@children.1/@ports.1" targets="//@children.1/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.0/@children.2/@ports.1" targets="//@children.1/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.1/@children.0/@children.3/@ports.1" targets="//@children.1/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.0/@children.4/@ports.1" targets="//@children.1/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.0/@children.4/@ports.1" targets="//@children.1/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.0/@children.5/@ports.2" targets="//@children.1/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.0/@children.5/@ports.2" targets="//@children.1/@children.0/@children.19/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.0/@children.6/@ports.0" targets="//@children.1/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.0/@children.7/@ports.2" targets="//@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.1/@children.0/@children.7/@ports.2" targets="//@children.1/@children.0/@children.18/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.1/@children.0/@children.8/@ports.0" targets="//@children.1/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.1/@children.0/@children.9/@ports.2" targets="//@children.1/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.1/@children.0/@children.9/@ports.2" targets="//@children.1/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.1/@children.0/@children.10/@ports.1" targets="//@children.1/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.1/@children.0/@children.11/@ports.0" targets="//@children.1/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.1/@children.0/@children.11/@ports.0" targets="//@children.1/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.1/@children.0/@children.12/@ports.2" targets="//@children.1/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.1/@children.0/@children.13/@ports.1" targets="//@children.1/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.1/@children.0/@children.14/@ports.1" targets="//@children.1/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E55" sources="//@children.1/@children.0/@children.14/@ports.1" targets="//@children.1/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.1/@children.0/@children.14/@ports.1" targets="//@children.1/@children.0/@children.13/@ports.2"/>
+      <containedEdges identifier="E57" sources="//@children.1/@children.0/@children.15/@ports.0" targets="//@children.1/@children.0/@children.17/@ports.3"/>
+      <containedEdges identifier="E58" sources="//@children.1/@children.0/@children.16/@ports.2" targets="//@children.1/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E59" sources="//@children.1/@children.0/@children.17/@ports.4" targets="//@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E60" sources="//@children.1/@children.0/@children.17/@ports.2" targets="//@children.1/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E61" sources="//@children.1/@children.0/@children.18/@ports.1" targets="//@children.1/@children.0/@children.17/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.1/@children.0/@children.19/@ports.1" targets="//@children.1/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.1/@children.0/@children.20/@ports.1" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.1/@children.0/@children.20/@ports.1" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N39">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L39" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P108" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.6" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N40" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P113" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="78.0" text="CurrentTime2"/>
+        <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E79" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E80" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E81" sources="//@children.1/@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.2"/>
+      <containedEdges identifier="E82" sources="//@children.1/@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@ports.4"/>
+    </children>
+    <containedEdges identifier="E26" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.1/@ports.1" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.1/@ports.4" targets="//@children.1/@children.1/@ports.3"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.1/@ports.4" targets="//@children.1/@ports.5"/>
+  </children>
+  <children identifier="N42">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L42" height="15.0" width="71.0" text="SubstationB"/>
+    <ports identifier="P117" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.2/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.2/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N43">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L43" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.3" incomingEdges="//@children.2/@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.4" incomingEdges="//@children.2/@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0 //@children.2/@children.0/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N44" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P127" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P129" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P133" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="63.0" text="IsPresent2"/>
+        <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P135" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="25.0" width="22.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="82.0" text="LogicFunction"/>
+        <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.2 //@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.6 //@children.2/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.3 //@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.8 //@children.2/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P141" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.10 //@children.2/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P145" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.11 //@children.2/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="25.0" width="77.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P146" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.13 //@children.2/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P150" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.14 //@children.2/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N54">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L54" height="15.0" width="94.0" text="CompositeActor"/>
+        <ports identifier="P151" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.10/@containedEdges.0" incomingEdges="//@children.2/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P152" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.16" incomingEdges="//@children.2/@children.0/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N55" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L55" height="15.0" width="73.0" text="LookupTable"/>
+          <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P154" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N56" height="46.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L56" height="15.0" width="44.0" text="Uniform"/>
+          <ports identifier="P155" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.2/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.2/@children.0/@children.10/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N57" height="34.0" width="34.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L57" height="15.0" width="38.0" text="Round"/>
+          <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.2/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P160" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@children.2/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E122" sources="//@children.2/@children.0/@children.10/@ports.0" targets="//@children.2/@children.0/@children.10/@children.1/@ports.1"/>
+        <containedEdges identifier="E123" sources="//@children.2/@children.0/@children.10/@children.0/@ports.1" targets="//@children.2/@children.0/@children.10/@ports.1"/>
+        <containedEdges identifier="E124" sources="//@children.2/@children.0/@children.10/@children.1/@ports.0" targets="//@children.2/@children.0/@children.10/@children.2/@ports.0"/>
+        <containedEdges identifier="E125" sources="//@children.2/@children.0/@children.10/@children.2/@ports.1" targets="//@children.2/@children.0/@children.10/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N58" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="89.0" text="DiscreteClock2"/>
+        <ports identifier="P161" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.17 //@children.2/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P164" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P165" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.20 //@children.2/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P168" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P170" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P171" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N61">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L61" height="15.0" width="101.0" text="CompositeActor2"/>
+        <ports identifier="P172" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.14/@containedEdges.0 //@children.2/@children.0/@children.14/@containedEdges.1" incomingEdges="//@children.2/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P173" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.21 //@children.2/@children.0/@containedEdges.22 //@children.2/@children.0/@containedEdges.23" incomingEdges="//@children.2/@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N62" height="25.0" width="219.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L62" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P174" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N63" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L63" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P177" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P178" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N64" height="25.0" width="223.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L64" height="15.0" width="42.0" text="Const5"/>
+          <ports identifier="P179" height="8.0" width="8.0" x="223.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N65" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L65" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@children.14/@containedEdges.2 //@children.2/@children.0/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P182" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.14/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E126" sources="//@children.2/@children.0/@children.14/@ports.0" targets="//@children.2/@children.0/@children.14/@children.0/@ports.1"/>
+        <containedEdges identifier="E127" sources="//@children.2/@children.0/@children.14/@ports.0" targets="//@children.2/@children.0/@children.14/@children.1/@ports.0"/>
+        <containedEdges identifier="E128" sources="//@children.2/@children.0/@children.14/@children.0/@ports.0" targets="//@children.2/@children.0/@children.14/@children.3/@ports.0"/>
+        <containedEdges identifier="E129" sources="//@children.2/@children.0/@children.14/@children.1/@ports.1" targets="//@children.2/@children.0/@children.14/@children.2/@ports.1"/>
+        <containedEdges identifier="E130" sources="//@children.2/@children.0/@children.14/@children.2/@ports.0" targets="//@children.2/@children.0/@children.14/@children.3/@ports.0"/>
+        <containedEdges identifier="E131" sources="//@children.2/@children.0/@children.14/@children.3/@ports.1" targets="//@children.2/@children.0/@children.14/@ports.1"/>
+      </children>
+      <children identifier="N66" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L66" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P183" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P186" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P187" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N67" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L67" height="15.0" width="80.0" text="AddSubtract4"/>
+        <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P190" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N68">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L68" height="15.0" width="101.0" text="CompositeActor3"/>
+        <ports identifier="P191" height="8.0" width="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P192" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.17/@containedEdges.0" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P193" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.27" incomingEdges="//@children.2/@children.0/@children.17/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P194" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.17/@containedEdges.1" incomingEdges="//@children.2/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P195" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.26" incomingEdges="//@children.2/@children.0/@children.17/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N69" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P196" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.17/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@children.17/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P198" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.17/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@children.17/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E132" sources="//@children.2/@children.0/@children.17/@ports.1" targets="//@children.2/@children.0/@children.17/@children.0/@ports.1"/>
+        <containedEdges identifier="E133" sources="//@children.2/@children.0/@children.17/@ports.3" targets="//@children.2/@children.0/@children.17/@children.1/@ports.1"/>
+        <containedEdges identifier="E134" sources="//@children.2/@children.0/@children.17/@children.0/@ports.0" targets="//@children.2/@children.0/@children.17/@ports.2"/>
+        <containedEdges identifier="E135" sources="//@children.2/@children.0/@children.17/@children.1/@ports.0" targets="//@children.2/@children.0/@children.17/@ports.4"/>
+      </children>
+      <children identifier="N71" height="28.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L71" height="15.0" width="90.0" text="MicrostepDelay"/>
+        <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.2/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P201" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.2/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N72" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P203" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N73" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="22.0" text="PID"/>
+        <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P205" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.30 //@children.2/@children.0/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E90" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.0/@children.16/@ports.0"/>
+      <containedEdges identifier="E91" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.0/@children.17/@ports.1"/>
+      <containedEdges identifier="E92" sources="//@children.2/@children.0/@children.0/@ports.1" targets="//@children.2/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.2/@children.0/@children.1/@ports.1" targets="//@children.2/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E94" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E95" sources="//@children.2/@children.0/@children.3/@ports.1" targets="//@children.2/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E96" sources="//@children.2/@children.0/@children.4/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E97" sources="//@children.2/@children.0/@children.4/@ports.1" targets="//@children.2/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E98" sources="//@children.2/@children.0/@children.5/@ports.2" targets="//@children.2/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E99" sources="//@children.2/@children.0/@children.5/@ports.2" targets="//@children.2/@children.0/@children.19/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.2/@children.0/@children.6/@ports.0" targets="//@children.2/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.2/@children.0/@children.7/@ports.2" targets="//@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.2/@children.0/@children.7/@ports.2" targets="//@children.2/@children.0/@children.18/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.2/@children.0/@children.8/@ports.0" targets="//@children.2/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.2/@children.0/@children.9/@ports.2" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.2/@children.0/@children.9/@ports.2" targets="//@children.2/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.2/@children.0/@children.10/@ports.1" targets="//@children.2/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E107" sources="//@children.2/@children.0/@children.11/@ports.0" targets="//@children.2/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E108" sources="//@children.2/@children.0/@children.11/@ports.0" targets="//@children.2/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E109" sources="//@children.2/@children.0/@children.12/@ports.2" targets="//@children.2/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.2/@children.0/@children.13/@ports.1" targets="//@children.2/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E111" sources="//@children.2/@children.0/@children.14/@ports.1" targets="//@children.2/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E112" sources="//@children.2/@children.0/@children.14/@ports.1" targets="//@children.2/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E113" sources="//@children.2/@children.0/@children.14/@ports.1" targets="//@children.2/@children.0/@children.13/@ports.2"/>
+      <containedEdges identifier="E114" sources="//@children.2/@children.0/@children.15/@ports.0" targets="//@children.2/@children.0/@children.17/@ports.3"/>
+      <containedEdges identifier="E115" sources="//@children.2/@children.0/@children.16/@ports.2" targets="//@children.2/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E116" sources="//@children.2/@children.0/@children.17/@ports.4" targets="//@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E117" sources="//@children.2/@children.0/@children.17/@ports.2" targets="//@children.2/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E118" sources="//@children.2/@children.0/@children.18/@ports.1" targets="//@children.2/@children.0/@children.17/@ports.0"/>
+      <containedEdges identifier="E119" sources="//@children.2/@children.0/@children.19/@ports.1" targets="//@children.2/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.2/@children.0/@children.20/@ports.1" targets="//@children.2/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E121" sources="//@children.2/@children.0/@children.20/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N74">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L74" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P207" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P208" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P209" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.5" incomingEdges="//@children.2/@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P210" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P211" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.6" incomingEdges="//@children.2/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N75" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L75" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P212" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N76" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L76" height="15.0" width="78.0" text="CurrentTime2"/>
+        <ports identifier="P214" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E136" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E137" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E138" sources="//@children.2/@children.1/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.2"/>
+      <containedEdges identifier="E139" sources="//@children.2/@children.1/@children.1/@ports.0" targets="//@children.2/@children.1/@ports.4"/>
+    </children>
+    <containedEdges identifier="E83" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.2"/>
+    <containedEdges identifier="E84" sources="//@children.2/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E85" sources="//@children.2/@ports.4" targets="//@children.2/@children.1/@ports.3"/>
+    <containedEdges identifier="E86" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E87" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E88" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E89" sources="//@children.2/@children.1/@ports.4" targets="//@children.2/@ports.5"/>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="77.0" text="FullClockPlot"/>
+    <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P229" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P231" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P233" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N84">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L84" height="15.0" width="143.0" text="ComputeLocationOfFault"/>
+    <ports identifier="P234" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0 //@children.10/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.2 //@children.10/@containedEdges.3" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16" incomingEdges="//@children.10/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N85" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P239" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P241" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@containedEdges.5 //@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L87" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.5 //@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P244" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N88" height="25.0" width="57.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L88" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P245" height="8.0" width="8.0" x="57.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N89" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L89" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P248" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N90" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L90" height="15.0" width="78.0" text="MostRecent3"/>
+      <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P250" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P251" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N91" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L91" height="15.0" width="78.0" text="MostRecent4"/>
+      <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P253" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P254" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N92" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L92" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.1 //@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P256" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N93" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L93" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P258" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.13 //@children.10/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E140" sources="//@children.10/@ports.0" targets="//@children.10/@children.5/@ports.0"/>
+    <containedEdges identifier="E141" sources="//@children.10/@ports.0" targets="//@children.10/@children.7/@ports.0"/>
+    <containedEdges identifier="E142" sources="//@children.10/@ports.1" targets="//@children.10/@children.6/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.10/@ports.1" targets="//@children.10/@children.7/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E145" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E146" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.3/@ports.1"/>
+    <containedEdges identifier="E147" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@children.4/@ports.0"/>
+    <containedEdges identifier="E148" sources="//@children.10/@children.3/@ports.0" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E149" sources="//@children.10/@children.4/@ports.1" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E150" sources="//@children.10/@children.5/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E151" sources="//@children.10/@children.6/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+    <containedEdges identifier="E152" sources="//@children.10/@children.7/@ports.1" targets="//@children.10/@children.8/@ports.0"/>
+    <containedEdges identifier="E153" sources="//@children.10/@children.8/@ports.1" targets="//@children.10/@children.5/@ports.2"/>
+    <containedEdges identifier="E154" sources="//@children.10/@children.8/@ports.1" targets="//@children.10/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N94" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L94" height="15.0" width="79.0" text="FaultLocation"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.5" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.0" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.10/@ports.2" targets="//@children.11/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_printingpress_PrintingPress-Validation.elkg
+++ b/realworld/ptolemy/hierarchical/de_printingpress_PrintingPress-Validation.elkg
@@ -1,0 +1,6206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="58.0" text="feedRoller"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.0/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="40.0" text="omega"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="78.0" text="Paper Radius"/>
+      <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.21 //@children.0/@containedEdges.22 //@children.0/@containedEdges.23" incomingEdges="//@children.0/@children.14/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N17" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.2 //@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="407.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="119.0" text="initialRadiusSquared"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.6 //@children.0/@children.14/@containedEdges.7 //@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="65.0" text="coreRadius"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.9 //@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="37.0" text="Select"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.14/@containedEdges.8 //@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E80" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.14/@children.0/@ports.2" targets="//@children.0/@children.14/@children.4/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.14/@children.1/@ports.1" targets="//@children.0/@children.14/@children.0/@ports.1"/>
+      <containedEdges identifier="E83" sources="//@children.0/@children.14/@children.1/@ports.1" targets="//@children.0/@children.14/@children.2/@ports.1"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.14/@children.2/@ports.0" targets="//@children.0/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.14/@children.3/@ports.1" targets="//@children.0/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.14/@children.4/@ports.1" targets="//@children.0/@children.14/@children.5/@ports.1"/>
+      <containedEdges identifier="E87" sources="//@children.0/@children.14/@children.4/@ports.1" targets="//@children.0/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.14/@children.4/@ports.1" targets="//@children.0/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.0/@children.14/@children.5/@ports.0" targets="//@children.0/@children.14/@children.6/@ports.1"/>
+      <containedEdges identifier="E90" sources="//@children.0/@children.14/@children.5/@ports.0" targets="//@children.0/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E91" sources="//@children.0/@children.14/@children.6/@ports.2" targets="//@children.0/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E92" sources="//@children.0/@children.14/@children.7/@ports.1" targets="//@children.0/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.0/@children.14/@children.8/@ports.1" targets="//@children.0/@children.14/@children.9/@ports.2"/>
+      <containedEdges identifier="E94" sources="//@children.0/@children.14/@children.9/@ports.1" targets="//@children.0/@children.14/@ports.1"/>
+    </children>
+    <children identifier="N27">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L27" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.15/@containedEdges.0 //@children.0/@children.15/@containedEdges.1 //@children.0/@children.15/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.24 //@children.0/@containedEdges.25 //@children.0/@containedEdges.26 //@children.0/@containedEdges.27" incomingEdges="//@children.0/@children.15/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N28" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.15/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.5 //@children.0/@children.15/@containedEdges.6 //@children.0/@children.15/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.15/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="25.0" width="88.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P85" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.15/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.15/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.15/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.4 //@children.0/@children.15/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="91.0" text="coreMassScale"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.15/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.15/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E95" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.4/@ports.1"/>
+      <containedEdges identifier="E96" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.5/@ports.1"/>
+      <containedEdges identifier="E97" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.6/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.0/@children.15/@children.0/@ports.1" targets="//@children.0/@children.15/@children.3/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.0/@children.15/@children.1/@ports.2" targets="//@children.0/@children.15/@children.11/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.0/@children.15/@children.2/@ports.1" targets="//@children.0/@children.15/@children.3/@ports.1"/>
+      <containedEdges identifier="E101" sources="//@children.0/@children.15/@children.2/@ports.1" targets="//@children.0/@children.15/@children.8/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.0/@children.15/@children.2/@ports.1" targets="//@children.0/@children.15/@children.12/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.0/@children.15/@children.3/@ports.2" targets="//@children.0/@children.15/@children.1/@ports.1"/>
+      <containedEdges identifier="E104" sources="//@children.0/@children.15/@children.4/@ports.0" targets="//@children.0/@children.15/@children.2/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.0/@children.15/@children.5/@ports.0" targets="//@children.0/@children.15/@children.0/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.0/@children.15/@children.6/@ports.1" targets="//@children.0/@children.15/@children.9/@ports.0"/>
+      <containedEdges identifier="E107" sources="//@children.0/@children.15/@children.7/@ports.1" targets="//@children.0/@children.15/@children.1/@ports.0"/>
+      <containedEdges identifier="E108" sources="//@children.0/@children.15/@children.8/@ports.1" targets="//@children.0/@children.15/@children.10/@ports.1"/>
+      <containedEdges identifier="E109" sources="//@children.0/@children.15/@children.9/@ports.1" targets="//@children.0/@children.15/@children.10/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.0/@children.15/@children.10/@ports.2" targets="//@children.0/@children.15/@children.7/@ports.0"/>
+      <containedEdges identifier="E111" sources="//@children.0/@children.15/@children.11/@ports.2" targets="//@children.0/@children.15/@ports.1"/>
+      <containedEdges identifier="E112" sources="//@children.0/@children.15/@children.12/@ports.1" targets="//@children.0/@children.15/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N41" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E51" sources="//@children.0/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E55" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E57" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E65" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E66" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E67" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.0/@children.12/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E71" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E72" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E73" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E74" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E75" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E76" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E77" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E78" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.13/@ports.1"/>
+    <containedEdges identifier="E79" sources="//@children.0/@children.16/@ports.2" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N42">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L42" height="15.0" width="60.0" text="driveRoller"/>
+    <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.1/@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N43" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P110" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3 //@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P114" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.13 //@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.15 //@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P136" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P138" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.16 //@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P142" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N56">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L56" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P146" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.13/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.21 //@children.1/@containedEdges.22 //@children.1/@containedEdges.23 //@children.1/@containedEdges.24" incomingEdges="//@children.1/@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N57" height="25.0" width="219.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P148" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@children.1/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E140" sources="//@children.1/@children.13/@ports.0" targets="//@children.1/@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E141" sources="//@children.1/@children.13/@children.0/@ports.0" targets="//@children.1/@children.13/@ports.1"/>
+    </children>
+    <children identifier="N58" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="25.0" width="75.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P153" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E113" sources="//@children.1/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E114" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E115" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E116" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E117" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.15/@ports.1"/>
+    <containedEdges identifier="E118" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E119" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E120" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E121" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E122" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.12/@ports.0"/>
+    <containedEdges identifier="E123" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E124" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E125" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.13/@ports.0"/>
+    <containedEdges identifier="E126" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E127" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E128" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.10/@ports.1"/>
+    <containedEdges identifier="E129" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E130" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E131" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E132" sources="//@children.1/@children.11/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E133" sources="//@children.1/@children.12/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E134" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E135" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E136" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E137" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.12/@ports.1"/>
+    <containedEdges identifier="E138" sources="//@children.1/@children.14/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E139" sources="//@children.1/@children.15/@ports.0" targets="//@children.1/@children.14/@ports.0"/>
+  </children>
+  <children identifier="N60">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L60" height="15.0" width="84.0" text="DriveController"/>
+    <ports identifier="P155" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.3" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.2/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.2/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N61" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.4 //@children.2/@containedEdges.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N62">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L62" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P161" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P162" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.8" incomingEdges="//@children.2/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N63" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L63" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P164" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P165" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N64" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L64" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P166" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P169" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P170" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E155" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E156" sources="//@children.2/@children.1/@children.0/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E157" sources="//@children.2/@children.1/@children.1/@ports.0" targets="//@children.2/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N65" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P172" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.9" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N66">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L66" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P173" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P174" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N67">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L67" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P177" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.0 //@children.2/@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P178" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P179" height="8.0" width="8.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P180" height="8.0" width="8.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N68" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P182" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P186" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.4 //@children.2/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P188" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P189" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N71" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P191" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P192" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P194" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P195" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E158" sources="//@children.2/@children.3/@children.0/@ports.0" targets="//@children.2/@children.3/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E159" sources="//@children.2/@children.3/@children.0/@ports.0" targets="//@children.2/@children.3/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E160" sources="//@children.2/@children.3/@children.0/@ports.1" targets="//@children.2/@children.3/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E161" sources="//@children.2/@children.3/@children.0/@children.0/@ports.1" targets="//@children.2/@children.3/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E162" sources="//@children.2/@children.3/@children.0/@children.1/@ports.2" targets="//@children.2/@children.3/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E163" sources="//@children.2/@children.3/@children.0/@children.1/@ports.2" targets="//@children.2/@children.3/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E164" sources="//@children.2/@children.3/@children.0/@children.2/@ports.1" targets="//@children.2/@children.3/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E165" sources="//@children.2/@children.3/@children.0/@children.3/@ports.1" targets="//@children.2/@children.3/@children.0/@ports.2"/>
+        <containedEdges identifier="E166" sources="//@children.2/@children.3/@children.0/@children.4/@ports.1" targets="//@children.2/@children.3/@children.0/@ports.3"/>
+      </children>
+    </children>
+    <children identifier="N73" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="81.0" text="TimedPlotter2"/>
+      <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E142" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.2/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E145" sources="//@children.2/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E146" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E147" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E148" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E149" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E150" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E151" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E152" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E153" sources="//@children.2/@children.3/@ports.2" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E154" sources="//@children.2/@children.3/@ports.3" targets="//@children.2/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N75" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P199" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="97.0" text="driveToFeedError"/>
+    <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L77" height="15.0" width="133.0" text="DtoFTrackingController"/>
+    <ports identifier="P201" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.5/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.5/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N78">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L78" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P205" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P206" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.2" incomingEdges="//@children.5/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N79" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P208" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P209" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P210" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P213" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P214" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E175" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E176" sources="//@children.5/@children.0/@children.0/@ports.1" targets="//@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E177" sources="//@children.5/@children.0/@children.1/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N81">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L81" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P215" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@containedEdges.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P216" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.3" incomingEdges="//@children.5/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N82" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P218" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P219" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.5/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P220" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P223" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P224" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E178" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E179" sources="//@children.5/@children.1/@children.0/@ports.1" targets="//@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E180" sources="//@children.5/@children.1/@children.1/@ports.0" targets="//@children.5/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N84" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L84" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.5" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P226" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.4" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N85">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L85" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P227" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P228" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P229" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P230" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N86">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L86" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P231" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P232" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P233" height="8.0" width="8.0" incomingEdges="//@children.5/@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P234" height="8.0" width="8.0" incomingEdges="//@children.5/@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N87" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L87" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.3/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.3/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P237" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.3/@children.0/@containedEdges.2 //@children.5/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N88" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L88" height="15.0" width="68.0" text="TimedDelay"/>
+          <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P239" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.3/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N89" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L89" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P241" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E181" sources="//@children.5/@children.3/@children.0/@ports.0" targets="//@children.5/@children.3/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E182" sources="//@children.5/@children.3/@children.0/@ports.1" targets="//@children.5/@children.3/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E183" sources="//@children.5/@children.3/@children.0/@children.0/@ports.2" targets="//@children.5/@children.3/@children.0/@ports.3"/>
+        <containedEdges identifier="E184" sources="//@children.5/@children.3/@children.0/@children.0/@ports.2" targets="//@children.5/@children.3/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E185" sources="//@children.5/@children.3/@children.0/@children.1/@ports.1" targets="//@children.5/@children.3/@children.0/@ports.2"/>
+        <containedEdges identifier="E186" sources="//@children.5/@children.3/@children.0/@children.2/@ports.1" targets="//@children.5/@children.3/@children.0/@children.1/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E167" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E168" sources="//@children.5/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E169" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E170" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.3/@ports.1"/>
+    <containedEdges identifier="E171" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E172" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E173" sources="//@children.5/@children.3/@ports.3" targets="//@children.5/@ports.2"/>
+    <containedEdges identifier="E174" sources="//@children.5/@children.3/@ports.2" targets="//@children.5/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N90">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L90" height="15.0" width="104.0" text="reserveFeedRoller"/>
+    <ports identifier="P243" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18" incomingEdges="//@children.6/@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" outgoingEdges="//@containedEdges.19" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.6/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P248" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N91" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L91" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P249" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P251" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3 //@children.6/@containedEdges.4 //@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P252" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N92" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L92" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P253" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P255" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.6 //@children.6/@containedEdges.7 //@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P256" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N93" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L93" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.13 //@children.6/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P259" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N94" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L94" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P261" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N95" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L95" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P263" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N96" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L96" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P265" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N97" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L97" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P268" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N98" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L98" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.8 //@children.6/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P271" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N99" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L99" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P274" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.15 //@children.6/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N100" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L100" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P275" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N101" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L101" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P277" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N102" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L102" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.16 //@children.6/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P281" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N103" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L103" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P284" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N104">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L104" height="15.0" width="78.0" text="Paper Radius"/>
+      <ports identifier="P285" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.21 //@children.6/@containedEdges.22 //@children.6/@containedEdges.23" incomingEdges="//@children.6/@children.13/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P286" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.13/@containedEdges.2" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P287" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.13/@containedEdges.0 //@children.6/@children.13/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N105" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L105" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P290" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N106" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L106" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P292" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.13/@containedEdges.4 //@children.6/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N107" height="25.0" width="407.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="119.0" text="initialRadiusSquared"/>
+        <ports identifier="P293" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@children.6/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P296" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.6/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N109" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L109" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P298" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.13/@containedEdges.8 //@children.6/@children.13/@containedEdges.9 //@children.6/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N110" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L110" height="15.0" width="58.0" text="constzero"/>
+        <ports identifier="P299" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.6/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N111" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L111" height="15.0" width="40.0" text="omega"/>
+        <ports identifier="P301" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P303" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.6/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P304" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N112" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L112" height="15.0" width="65.0" text="constzero2"/>
+        <ports identifier="P305" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.6/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N113" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L113" height="15.0" width="65.0" text="coreRadius"/>
+        <ports identifier="P307" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.6/@children.13/@containedEdges.14 //@children.6/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N114" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L114" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.6/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.6/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P311" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.6/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N115" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L115" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P313" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.6/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N116" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L116" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.6/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P315" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.6/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N117" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L117" height="15.0" width="37.0" text="Select"/>
+        <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.6/@children.13/@containedEdges.1 //@children.6/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P317" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.6/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P318" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.6/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N118" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L118" height="15.0" width="45.0" text="Select2"/>
+        <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.6/@children.13/@containedEdges.10 //@children.6/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P320" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.6/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P321" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.6/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E216" sources="//@children.6/@children.13/@ports.2" targets="//@children.6/@children.13/@children.5/@ports.1"/>
+      <containedEdges identifier="E217" sources="//@children.6/@children.13/@ports.2" targets="//@children.6/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E218" sources="//@children.6/@children.13/@ports.1" targets="//@children.6/@children.13/@children.7/@ports.1"/>
+      <containedEdges identifier="E219" sources="//@children.6/@children.13/@children.0/@ports.2" targets="//@children.6/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E220" sources="//@children.6/@children.13/@children.1/@ports.1" targets="//@children.6/@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E221" sources="//@children.6/@children.13/@children.1/@ports.1" targets="//@children.6/@children.13/@children.2/@ports.1"/>
+      <containedEdges identifier="E222" sources="//@children.6/@children.13/@children.2/@ports.0" targets="//@children.6/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E223" sources="//@children.6/@children.13/@children.3/@ports.1" targets="//@children.6/@children.13/@children.0/@ports.0"/>
+      <containedEdges identifier="E224" sources="//@children.6/@children.13/@children.4/@ports.1" targets="//@children.6/@children.13/@children.8/@ports.1"/>
+      <containedEdges identifier="E225" sources="//@children.6/@children.13/@children.4/@ports.1" targets="//@children.6/@children.13/@children.9/@ports.0"/>
+      <containedEdges identifier="E226" sources="//@children.6/@children.13/@children.4/@ports.1" targets="//@children.6/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E227" sources="//@children.6/@children.13/@children.5/@ports.0" targets="//@children.6/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E228" sources="//@children.6/@children.13/@children.6/@ports.2" targets="//@children.6/@children.13/@children.1/@ports.0"/>
+      <containedEdges identifier="E229" sources="//@children.6/@children.13/@children.7/@ports.0" targets="//@children.6/@children.13/@children.12/@ports.2"/>
+      <containedEdges identifier="E230" sources="//@children.6/@children.13/@children.8/@ports.0" targets="//@children.6/@children.13/@children.9/@ports.1"/>
+      <containedEdges identifier="E231" sources="//@children.6/@children.13/@children.8/@ports.0" targets="//@children.6/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E232" sources="//@children.6/@children.13/@children.9/@ports.2" targets="//@children.6/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E233" sources="//@children.6/@children.13/@children.10/@ports.1" targets="//@children.6/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E234" sources="//@children.6/@children.13/@children.11/@ports.1" targets="//@children.6/@children.13/@children.13/@ports.2"/>
+      <containedEdges identifier="E235" sources="//@children.6/@children.13/@children.12/@ports.1" targets="//@children.6/@children.13/@children.6/@ports.1"/>
+      <containedEdges identifier="E236" sources="//@children.6/@children.13/@children.13/@ports.1" targets="//@children.6/@children.13/@ports.0"/>
+    </children>
+    <children identifier="N119">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L119" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P322" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.14/@containedEdges.0 //@children.6/@children.14/@containedEdges.1 //@children.6/@children.14/@containedEdges.2" incomingEdges="//@children.6/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P323" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.24 //@children.6/@containedEdges.25 //@children.6/@containedEdges.26 //@children.6/@containedEdges.27" incomingEdges="//@children.6/@children.14/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N120" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L120" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P325" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.6/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N121" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L121" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P328" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N122" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L122" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P330" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.6/@children.14/@containedEdges.5 //@children.6/@children.14/@containedEdges.6 //@children.6/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N123" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L123" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P333" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N124" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L124" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P334" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.6/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N125" height="25.0" width="88.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L125" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P336" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.6/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N126" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L126" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P339" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.6/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N127" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L127" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+        <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P341" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N128" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L128" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+        <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P343" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.6/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N129" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L129" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+        <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P345" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.6/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N130" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L130" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P348" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N131" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L131" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.14/@containedEdges.4 //@children.6/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P351" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N132" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L132" height="15.0" width="91.0" text="coreMassScale"/>
+        <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E237" sources="//@children.6/@children.14/@ports.0" targets="//@children.6/@children.14/@children.4/@ports.1"/>
+      <containedEdges identifier="E238" sources="//@children.6/@children.14/@ports.0" targets="//@children.6/@children.14/@children.5/@ports.1"/>
+      <containedEdges identifier="E239" sources="//@children.6/@children.14/@ports.0" targets="//@children.6/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E240" sources="//@children.6/@children.14/@children.0/@ports.1" targets="//@children.6/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E241" sources="//@children.6/@children.14/@children.1/@ports.2" targets="//@children.6/@children.14/@children.11/@ports.0"/>
+      <containedEdges identifier="E242" sources="//@children.6/@children.14/@children.2/@ports.1" targets="//@children.6/@children.14/@children.3/@ports.1"/>
+      <containedEdges identifier="E243" sources="//@children.6/@children.14/@children.2/@ports.1" targets="//@children.6/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E244" sources="//@children.6/@children.14/@children.2/@ports.1" targets="//@children.6/@children.14/@children.12/@ports.0"/>
+      <containedEdges identifier="E245" sources="//@children.6/@children.14/@children.3/@ports.2" targets="//@children.6/@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E246" sources="//@children.6/@children.14/@children.4/@ports.0" targets="//@children.6/@children.14/@children.2/@ports.0"/>
+      <containedEdges identifier="E247" sources="//@children.6/@children.14/@children.5/@ports.0" targets="//@children.6/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E248" sources="//@children.6/@children.14/@children.6/@ports.1" targets="//@children.6/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E249" sources="//@children.6/@children.14/@children.7/@ports.1" targets="//@children.6/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E250" sources="//@children.6/@children.14/@children.8/@ports.1" targets="//@children.6/@children.14/@children.10/@ports.1"/>
+      <containedEdges identifier="E251" sources="//@children.6/@children.14/@children.9/@ports.1" targets="//@children.6/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E252" sources="//@children.6/@children.14/@children.10/@ports.2" targets="//@children.6/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E253" sources="//@children.6/@children.14/@children.11/@ports.2" targets="//@children.6/@children.14/@ports.1"/>
+      <containedEdges identifier="E254" sources="//@children.6/@children.14/@children.12/@ports.1" targets="//@children.6/@children.14/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N133" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L133" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.5 //@children.6/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P356" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E187" sources="//@children.6/@ports.1" targets="//@children.6/@children.5/@ports.0"/>
+    <containedEdges identifier="E188" sources="//@children.6/@ports.5" targets="//@children.6/@children.13/@ports.1"/>
+    <containedEdges identifier="E189" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E190" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E191" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.13/@ports.2"/>
+    <containedEdges identifier="E192" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.15/@ports.0"/>
+    <containedEdges identifier="E193" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@ports.3"/>
+    <containedEdges identifier="E194" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E195" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.7/@ports.0"/>
+    <containedEdges identifier="E196" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E197" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@children.12/@ports.0"/>
+    <containedEdges identifier="E198" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.6/@ports.0"/>
+    <containedEdges identifier="E199" sources="//@children.6/@children.5/@ports.1" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E200" sources="//@children.6/@children.6/@ports.2" targets="//@children.6/@children.2/@ports.1"/>
+    <containedEdges identifier="E201" sources="//@children.6/@children.7/@ports.2" targets="//@children.6/@children.2/@ports.1"/>
+    <containedEdges identifier="E202" sources="//@children.6/@children.8/@ports.2" targets="//@children.6/@children.10/@ports.1"/>
+    <containedEdges identifier="E203" sources="//@children.6/@children.8/@ports.2" targets="//@children.6/@children.11/@ports.0"/>
+    <containedEdges identifier="E204" sources="//@children.6/@children.9/@ports.0" targets="//@children.6/@children.8/@ports.0"/>
+    <containedEdges identifier="E205" sources="//@children.6/@children.10/@ports.0" targets="//@children.6/@children.11/@ports.0"/>
+    <containedEdges identifier="E206" sources="//@children.6/@children.11/@ports.2" targets="//@children.6/@children.7/@ports.0"/>
+    <containedEdges identifier="E207" sources="//@children.6/@children.12/@ports.2" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E208" sources="//@children.6/@children.13/@ports.0" targets="//@children.6/@ports.4"/>
+    <containedEdges identifier="E209" sources="//@children.6/@children.13/@ports.0" targets="//@children.6/@children.14/@ports.0"/>
+    <containedEdges identifier="E210" sources="//@children.6/@children.13/@ports.0" targets="//@children.6/@children.15/@ports.0"/>
+    <containedEdges identifier="E211" sources="//@children.6/@children.14/@ports.1" targets="//@children.6/@children.6/@ports.1"/>
+    <containedEdges identifier="E212" sources="//@children.6/@children.14/@ports.1" targets="//@children.6/@children.8/@ports.1"/>
+    <containedEdges identifier="E213" sources="//@children.6/@children.14/@ports.1" targets="//@children.6/@children.9/@ports.1"/>
+    <containedEdges identifier="E214" sources="//@children.6/@children.14/@ports.1" targets="//@children.6/@children.12/@ports.1"/>
+    <containedEdges identifier="E215" sources="//@children.6/@children.15/@ports.2" targets="//@children.6/@ports.0"/>
+  </children>
+  <children identifier="N134" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L134" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N135" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L135" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P359" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N136" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L136" height="15.0" width="114.0" text="driveToReserveError"/>
+    <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N137">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L137" height="15.0" width="134.0" text="DtoRTrackingController"/>
+    <ports identifier="P361" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P362" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P363" height="8.0" width="8.0" outgoingEdges="//@containedEdges.21" incomingEdges="//@children.10/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P364" height="8.0" width="8.0" outgoingEdges="//@containedEdges.22" incomingEdges="//@children.10/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P365" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.2" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N138">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L138" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P366" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P367" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.3" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N139" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L139" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P368" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P369" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P370" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N140" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L140" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P371" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P372" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P374" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P375" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E266" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E267" sources="//@children.10/@children.0/@children.0/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E268" sources="//@children.10/@children.0/@children.1/@ports.0" targets="//@children.10/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N141">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L141" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P376" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.1/@containedEdges.0" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P377" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.4" incomingEdges="//@children.10/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N142" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L142" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P378" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P379" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P380" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N143" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P381" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P384" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P385" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E269" sources="//@children.10/@children.1/@ports.0" targets="//@children.10/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E270" sources="//@children.10/@children.1/@children.0/@ports.1" targets="//@children.10/@children.1/@ports.1"/>
+      <containedEdges identifier="E271" sources="//@children.10/@children.1/@children.1/@ports.0" targets="//@children.10/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N144" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L144" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.6" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P387" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.5" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N145" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L145" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P388" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.8" incomingEdges="//@children.10/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P389" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.7" incomingEdges="//@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N146">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L146" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P390" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P391" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P392" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P393" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P394" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N147">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L147" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P395" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P396" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P397" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P398" height="8.0" width="8.0" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P399" height="8.0" width="8.0" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N148" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L148" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P401" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P402" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.3 //@children.10/@children.4/@children.0/@containedEdges.4 //@children.10/@children.4/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N149" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L149" height="15.0" width="68.0" text="TimedDelay"/>
+          <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P404" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N150" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L150" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P406" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N151" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L151" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P408" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N152" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L152" height="15.0" width="112.0" text="BooleanToAnything"/>
+          <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P411" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N153" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L153" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P412" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.5 //@children.10/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P413" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.10/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P414" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.10/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E272" sources="//@children.10/@children.4/@children.0/@ports.0" targets="//@children.10/@children.4/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E273" sources="//@children.10/@children.4/@children.0/@ports.1" targets="//@children.10/@children.4/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E274" sources="//@children.10/@children.4/@children.0/@ports.2" targets="//@children.10/@children.4/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E275" sources="//@children.10/@children.4/@children.0/@children.0/@ports.2" targets="//@children.10/@children.4/@children.0/@ports.3"/>
+        <containedEdges identifier="E276" sources="//@children.10/@children.4/@children.0/@children.0/@ports.2" targets="//@children.10/@children.4/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E277" sources="//@children.10/@children.4/@children.0/@children.0/@ports.2" targets="//@children.10/@children.4/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E278" sources="//@children.10/@children.4/@children.0/@children.1/@ports.1" targets="//@children.10/@children.4/@children.0/@ports.4"/>
+        <containedEdges identifier="E279" sources="//@children.10/@children.4/@children.0/@children.2/@ports.1" targets="//@children.10/@children.4/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E280" sources="//@children.10/@children.4/@children.0/@children.3/@ports.0" targets="//@children.10/@children.4/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E281" sources="//@children.10/@children.4/@children.0/@children.4/@ports.1" targets="//@children.10/@children.4/@children.0/@children.5/@ports.2"/>
+        <containedEdges identifier="E282" sources="//@children.10/@children.4/@children.0/@children.5/@ports.1" targets="//@children.10/@children.4/@children.0/@children.2/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E255" sources="//@children.10/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E256" sources="//@children.10/@ports.1" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E257" sources="//@children.10/@ports.4" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E258" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.4/@ports.0"/>
+    <containedEdges identifier="E259" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.4/@ports.1"/>
+    <containedEdges identifier="E260" sources="//@children.10/@children.2/@ports.1" targets="//@children.10/@children.4/@ports.2"/>
+    <containedEdges identifier="E261" sources="//@children.10/@children.2/@ports.0" targets="//@children.10/@children.2/@ports.1"/>
+    <containedEdges identifier="E262" sources="//@children.10/@children.3/@ports.1" targets="//@children.10/@ports.3"/>
+    <containedEdges identifier="E263" sources="//@children.10/@children.3/@ports.0" targets="//@children.10/@children.3/@ports.1"/>
+    <containedEdges identifier="E264" sources="//@children.10/@children.4/@ports.3" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E265" sources="//@children.10/@children.4/@ports.4" targets="//@children.10/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N154">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L154" height="15.0" width="118.0" text="ReserveTargetProfile"/>
+    <ports identifier="P415" height="8.0" width="8.0" outgoingEdges="//@containedEdges.23 //@containedEdges.24" incomingEdges="//@children.11/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P416" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N155" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L155" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.2" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P418" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.1" incomingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N156" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L156" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.4" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P420" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.3" incomingEdges="//@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N157">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L157" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P421" height="8.0" width="8.0" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P422" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N158">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L158" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P423" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.0 //@children.11/@children.2/@children.0/@containedEdges.1 //@children.11/@children.2/@children.0/@containedEdges.2 //@children.11/@children.2/@children.0/@containedEdges.3 //@children.11/@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P424" height="8.0" width="8.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N159" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L159" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P425" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P426" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P427" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P428" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P429" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N160" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L160" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P430" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.6 //@children.11/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P431" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N161" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L161" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P433" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.8 //@children.11/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N162" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L162" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P435" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N163" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L163" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P436" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P437" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N164" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L164" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P438" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P439" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P440" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N165" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L165" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P442" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N166" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L166" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P443" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P444" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.14 //@children.11/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N167" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L167" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P445" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P446" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N168" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L168" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P447" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P448" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N169" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L169" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.16 //@children.11/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P450" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P451" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N170" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L170" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P453" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N171" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L171" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P454" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P455" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N172" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L172" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P457" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P458" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P459" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N173" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L173" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.0 //@children.11/@children.2/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P461" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N174" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L174" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P462" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P463" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P464" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P465" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N175" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L175" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.1 //@children.11/@children.2/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P467" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N176" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L176" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.13 //@children.11/@children.2/@children.0/@containedEdges.19 //@children.11/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P469" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N177" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L177" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P471" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P472" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N178" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L178" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P473" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P474" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P475" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P476" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N179" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L179" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.20 //@children.11/@children.2/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P478" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N180" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L180" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P479" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N181" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L181" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P482" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N182" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L182" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P483" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P484" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N183" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L183" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P486" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P487" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N184" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L184" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P489" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P490" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N185" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L185" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P491" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P492" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P493" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N186" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L186" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P494" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P495" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.38 //@children.11/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N187" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L187" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P497" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E289" sources="//@children.11/@children.2/@children.0/@ports.0" targets="//@children.11/@children.2/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E290" sources="//@children.11/@children.2/@children.0/@ports.0" targets="//@children.11/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E291" sources="//@children.11/@children.2/@children.0/@ports.0" targets="//@children.11/@children.2/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E292" sources="//@children.11/@children.2/@children.0/@ports.0" targets="//@children.11/@children.2/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E293" sources="//@children.11/@children.2/@children.0/@ports.0" targets="//@children.11/@children.2/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E294" sources="//@children.11/@children.2/@children.0/@children.0/@ports.0" targets="//@children.11/@children.2/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E295" sources="//@children.11/@children.2/@children.0/@children.1/@ports.0" targets="//@children.11/@children.2/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E296" sources="//@children.11/@children.2/@children.0/@children.1/@ports.0" targets="//@children.11/@children.2/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E297" sources="//@children.11/@children.2/@children.0/@children.2/@ports.1" targets="//@children.11/@children.2/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E298" sources="//@children.11/@children.2/@children.0/@children.2/@ports.1" targets="//@children.11/@children.2/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E299" sources="//@children.11/@children.2/@children.0/@children.3/@ports.1" targets="//@children.11/@children.2/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E300" sources="//@children.11/@children.2/@children.0/@children.4/@ports.0" targets="//@children.11/@children.2/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E301" sources="//@children.11/@children.2/@children.0/@children.5/@ports.2" targets="//@children.11/@children.2/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E302" sources="//@children.11/@children.2/@children.0/@children.6/@ports.1" targets="//@children.11/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E303" sources="//@children.11/@children.2/@children.0/@children.7/@ports.1" targets="//@children.11/@children.2/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E304" sources="//@children.11/@children.2/@children.0/@children.7/@ports.1" targets="//@children.11/@children.2/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E305" sources="//@children.11/@children.2/@children.0/@children.8/@ports.1" targets="//@children.11/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E306" sources="//@children.11/@children.2/@children.0/@children.9/@ports.0" targets="//@children.11/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E307" sources="//@children.11/@children.2/@children.0/@children.10/@ports.2" targets="//@children.11/@children.2/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E308" sources="//@children.11/@children.2/@children.0/@children.11/@ports.1" targets="//@children.11/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E309" sources="//@children.11/@children.2/@children.0/@children.12/@ports.1" targets="//@children.11/@children.2/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E310" sources="//@children.11/@children.2/@children.0/@children.13/@ports.2" targets="//@children.11/@children.2/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E311" sources="//@children.11/@children.2/@children.0/@children.13/@ports.3" targets="//@children.11/@children.2/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E312" sources="//@children.11/@children.2/@children.0/@children.14/@ports.1" targets="//@children.11/@children.2/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E313" sources="//@children.11/@children.2/@children.0/@children.15/@ports.2" targets="//@children.11/@children.2/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E314" sources="//@children.11/@children.2/@children.0/@children.15/@ports.3" targets="//@children.11/@children.2/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E315" sources="//@children.11/@children.2/@children.0/@children.16/@ports.1" targets="//@children.11/@children.2/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E316" sources="//@children.11/@children.2/@children.0/@children.17/@ports.1" targets="//@children.11/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E317" sources="//@children.11/@children.2/@children.0/@children.18/@ports.2" targets="//@children.11/@children.2/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E318" sources="//@children.11/@children.2/@children.0/@children.19/@ports.2" targets="//@children.11/@children.2/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E319" sources="//@children.11/@children.2/@children.0/@children.19/@ports.3" targets="//@children.11/@children.2/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E320" sources="//@children.11/@children.2/@children.0/@children.20/@ports.1" targets="//@children.11/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E321" sources="//@children.11/@children.2/@children.0/@children.21/@ports.0" targets="//@children.11/@children.2/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E322" sources="//@children.11/@children.2/@children.0/@children.22/@ports.1" targets="//@children.11/@children.2/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E323" sources="//@children.11/@children.2/@children.0/@children.23/@ports.0" targets="//@children.11/@children.2/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E324" sources="//@children.11/@children.2/@children.0/@children.24/@ports.1" targets="//@children.11/@children.2/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E325" sources="//@children.11/@children.2/@children.0/@children.25/@ports.1" targets="//@children.11/@children.2/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E326" sources="//@children.11/@children.2/@children.0/@children.26/@ports.1" targets="//@children.11/@children.2/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E327" sources="//@children.11/@children.2/@children.0/@children.27/@ports.1" targets="//@children.11/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E328" sources="//@children.11/@children.2/@children.0/@children.27/@ports.1" targets="//@children.11/@children.2/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E329" sources="//@children.11/@children.2/@children.0/@children.28/@ports.1" targets="//@children.11/@children.2/@children.0/@children.14/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E283" sources="//@children.11/@ports.1" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E284" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E285" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@children.0/@ports.1"/>
+    <containedEdges identifier="E286" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@ports.0"/>
+    <containedEdges identifier="E287" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.1/@ports.1"/>
+    <containedEdges identifier="E288" sources="//@children.11/@children.2/@ports.1" targets="//@children.11/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N188">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L188" height="15.0" width="100.0" text="DriveTargetProfile"/>
+    <ports identifier="P498" height="8.0" width="8.0" outgoingEdges="//@containedEdges.25 //@containedEdges.26" incomingEdges="//@children.12/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P499" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N189" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L189" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.2" incomingEdges="//@children.12/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P501" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.1" incomingEdges="//@children.12/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N190">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L190" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P502" height="8.0" width="8.0" incomingEdges="//@children.12/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P503" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N191">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L191" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P504" height="8.0" width="8.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.0 //@children.12/@children.1/@children.0/@containedEdges.1 //@children.12/@children.1/@children.0/@containedEdges.2 //@children.12/@children.1/@children.0/@containedEdges.3 //@children.12/@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P505" height="8.0" width="8.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N192" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L192" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P506" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P507" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P508" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P509" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P510" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N193" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L193" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P511" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.6 //@children.12/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P512" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N194" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L194" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P513" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P514" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.8 //@children.12/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N195" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L195" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P516" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N196" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L196" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P517" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P518" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N197" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L197" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P520" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P521" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N198" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L198" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P523" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N199" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L199" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P524" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P525" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.14 //@children.12/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N200" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L200" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P526" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P527" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N201" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L201" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P528" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P529" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N202" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L202" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.16 //@children.12/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P531" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P532" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N203" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L203" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P533" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P534" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N204" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L204" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P536" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N205" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L205" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P537" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P538" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P539" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P540" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N206" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L206" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P541" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.0 //@children.12/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P542" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N207" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L207" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P544" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P545" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P546" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N208" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L208" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P547" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.1 //@children.12/@children.1/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P548" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N209" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L209" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.13 //@children.12/@children.1/@children.0/@containedEdges.19 //@children.12/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P550" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N210" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L210" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P553" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N211" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L211" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P554" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P555" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P556" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P557" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N212" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L212" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P558" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.20 //@children.12/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P559" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N213" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L213" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P560" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N214" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L214" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P562" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P563" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N215" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L215" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P564" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P565" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N216" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L216" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P567" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P568" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N217" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L217" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P570" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P571" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N218" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L218" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P573" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P574" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N219" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L219" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P576" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.38 //@children.12/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N220" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L220" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P578" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E334" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E335" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E336" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E337" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E338" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E339" sources="//@children.12/@children.1/@children.0/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E340" sources="//@children.12/@children.1/@children.0/@children.1/@ports.0" targets="//@children.12/@children.1/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E341" sources="//@children.12/@children.1/@children.0/@children.1/@ports.0" targets="//@children.12/@children.1/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E342" sources="//@children.12/@children.1/@children.0/@children.2/@ports.1" targets="//@children.12/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E343" sources="//@children.12/@children.1/@children.0/@children.2/@ports.1" targets="//@children.12/@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E344" sources="//@children.12/@children.1/@children.0/@children.3/@ports.1" targets="//@children.12/@children.1/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E345" sources="//@children.12/@children.1/@children.0/@children.4/@ports.0" targets="//@children.12/@children.1/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E346" sources="//@children.12/@children.1/@children.0/@children.5/@ports.2" targets="//@children.12/@children.1/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E347" sources="//@children.12/@children.1/@children.0/@children.6/@ports.1" targets="//@children.12/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E348" sources="//@children.12/@children.1/@children.0/@children.7/@ports.1" targets="//@children.12/@children.1/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E349" sources="//@children.12/@children.1/@children.0/@children.7/@ports.1" targets="//@children.12/@children.1/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E350" sources="//@children.12/@children.1/@children.0/@children.8/@ports.1" targets="//@children.12/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E351" sources="//@children.12/@children.1/@children.0/@children.9/@ports.0" targets="//@children.12/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E352" sources="//@children.12/@children.1/@children.0/@children.10/@ports.2" targets="//@children.12/@children.1/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E353" sources="//@children.12/@children.1/@children.0/@children.11/@ports.1" targets="//@children.12/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E354" sources="//@children.12/@children.1/@children.0/@children.12/@ports.1" targets="//@children.12/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E355" sources="//@children.12/@children.1/@children.0/@children.13/@ports.2" targets="//@children.12/@children.1/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E356" sources="//@children.12/@children.1/@children.0/@children.13/@ports.3" targets="//@children.12/@children.1/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E357" sources="//@children.12/@children.1/@children.0/@children.14/@ports.1" targets="//@children.12/@children.1/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E358" sources="//@children.12/@children.1/@children.0/@children.15/@ports.2" targets="//@children.12/@children.1/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E359" sources="//@children.12/@children.1/@children.0/@children.15/@ports.3" targets="//@children.12/@children.1/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E360" sources="//@children.12/@children.1/@children.0/@children.16/@ports.1" targets="//@children.12/@children.1/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E361" sources="//@children.12/@children.1/@children.0/@children.17/@ports.1" targets="//@children.12/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E362" sources="//@children.12/@children.1/@children.0/@children.18/@ports.2" targets="//@children.12/@children.1/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E363" sources="//@children.12/@children.1/@children.0/@children.19/@ports.2" targets="//@children.12/@children.1/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E364" sources="//@children.12/@children.1/@children.0/@children.19/@ports.3" targets="//@children.12/@children.1/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E365" sources="//@children.12/@children.1/@children.0/@children.20/@ports.1" targets="//@children.12/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E366" sources="//@children.12/@children.1/@children.0/@children.21/@ports.0" targets="//@children.12/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E367" sources="//@children.12/@children.1/@children.0/@children.22/@ports.1" targets="//@children.12/@children.1/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E368" sources="//@children.12/@children.1/@children.0/@children.23/@ports.0" targets="//@children.12/@children.1/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E369" sources="//@children.12/@children.1/@children.0/@children.24/@ports.1" targets="//@children.12/@children.1/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E370" sources="//@children.12/@children.1/@children.0/@children.25/@ports.1" targets="//@children.12/@children.1/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E371" sources="//@children.12/@children.1/@children.0/@children.26/@ports.1" targets="//@children.12/@children.1/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E372" sources="//@children.12/@children.1/@children.0/@children.27/@ports.1" targets="//@children.12/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E373" sources="//@children.12/@children.1/@children.0/@children.27/@ports.1" targets="//@children.12/@children.1/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E374" sources="//@children.12/@children.1/@children.0/@children.28/@ports.1" targets="//@children.12/@children.1/@children.0/@children.14/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E330" sources="//@children.12/@ports.1" targets="//@children.12/@children.1/@ports.0"/>
+    <containedEdges identifier="E331" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@ports.0"/>
+    <containedEdges identifier="E332" sources="//@children.12/@children.0/@ports.0" targets="//@children.12/@children.0/@ports.1"/>
+    <containedEdges identifier="E333" sources="//@children.12/@children.1/@ports.1" targets="//@children.12/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N221">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L221" height="15.0" width="101.0" text="FeedTargetProfile"/>
+    <ports identifier="P579" height="8.0" width="8.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28" incomingEdges="//@children.13/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P580" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.1" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P581" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.0" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N222" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L222" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P582" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.3" incomingEdges="//@children.13/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P583" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.2" incomingEdges="//@children.13/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N223" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L223" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P584" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.5" incomingEdges="//@children.13/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P585" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.4" incomingEdges="//@children.13/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N224">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L224" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P586" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P587" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P588" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N225">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L225" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P589" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.0 //@children.13/@children.2/@children.0/@containedEdges.1 //@children.13/@children.2/@children.0/@containedEdges.2 //@children.13/@children.2/@children.0/@containedEdges.3 //@children.13/@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P590" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P591" height="8.0" width="8.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N226" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L226" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P592" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P594" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P595" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P596" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N227" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L227" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P597" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.7 //@children.13/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P598" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N228" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L228" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P600" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.9 //@children.13/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N229" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L229" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P602" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N230" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L230" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P603" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P604" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N231" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L231" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P605" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P606" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P607" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N232" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L232" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P609" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N233" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L233" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P610" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P611" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.15 //@children.13/@children.2/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N234" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L234" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P612" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P613" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N235" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L235" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P614" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N236" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L236" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P616" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.17 //@children.13/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P618" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N237" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L237" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P620" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N238" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L238" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P622" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N239" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L239" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P623" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P624" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P625" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P626" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N240" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L240" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.0 //@children.13/@children.2/@children.0/@containedEdges.42">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P628" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N241" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L241" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P629" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P630" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P631" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P632" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N242" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L242" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P633" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.1 //@children.13/@children.2/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P634" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N243" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L243" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.14 //@children.13/@children.2/@children.0/@containedEdges.20 //@children.13/@children.2/@children.0/@containedEdges.45">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P636" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N244" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L244" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P637" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P638" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P639" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N245" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L245" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P641" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P642" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P643" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N246" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L246" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.21 //@children.13/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P645" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.32 //@children.13/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N247" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L247" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P646" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P647" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N248" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L248" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P648" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P649" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N249" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L249" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P650" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P651" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N250" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L250" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P653" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P654" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N251" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L251" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P655" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P656" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P657" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N252" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L252" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P658" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P659" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P660" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N253" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L253" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P661" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P662" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.40 //@children.13/@children.2/@children.0/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N254" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L254" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P663" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P664" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.42">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N255" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L255" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P665" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.43">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P666" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N256" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L256" height="15.0" width="42.0" text="Const5"/>
+          <ports identifier="P667" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.44">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N257" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L257" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.33 //@children.13/@children.2/@children.0/@containedEdges.44">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P670" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.13/@children.2/@children.0/@containedEdges.45">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P671" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.13/@children.2/@children.0/@containedEdges.43">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E382" sources="//@children.13/@children.2/@children.0/@ports.0" targets="//@children.13/@children.2/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E383" sources="//@children.13/@children.2/@children.0/@ports.0" targets="//@children.13/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E384" sources="//@children.13/@children.2/@children.0/@ports.0" targets="//@children.13/@children.2/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E385" sources="//@children.13/@children.2/@children.0/@ports.0" targets="//@children.13/@children.2/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E386" sources="//@children.13/@children.2/@children.0/@ports.0" targets="//@children.13/@children.2/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E387" sources="//@children.13/@children.2/@children.0/@ports.1" targets="//@children.13/@children.2/@children.0/@children.29/@ports.1"/>
+        <containedEdges identifier="E388" sources="//@children.13/@children.2/@children.0/@children.0/@ports.0" targets="//@children.13/@children.2/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E389" sources="//@children.13/@children.2/@children.0/@children.1/@ports.0" targets="//@children.13/@children.2/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E390" sources="//@children.13/@children.2/@children.0/@children.1/@ports.0" targets="//@children.13/@children.2/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E391" sources="//@children.13/@children.2/@children.0/@children.2/@ports.1" targets="//@children.13/@children.2/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E392" sources="//@children.13/@children.2/@children.0/@children.2/@ports.1" targets="//@children.13/@children.2/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E393" sources="//@children.13/@children.2/@children.0/@children.3/@ports.1" targets="//@children.13/@children.2/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E394" sources="//@children.13/@children.2/@children.0/@children.4/@ports.0" targets="//@children.13/@children.2/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E395" sources="//@children.13/@children.2/@children.0/@children.5/@ports.2" targets="//@children.13/@children.2/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E396" sources="//@children.13/@children.2/@children.0/@children.6/@ports.1" targets="//@children.13/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E397" sources="//@children.13/@children.2/@children.0/@children.7/@ports.1" targets="//@children.13/@children.2/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E398" sources="//@children.13/@children.2/@children.0/@children.7/@ports.1" targets="//@children.13/@children.2/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E399" sources="//@children.13/@children.2/@children.0/@children.8/@ports.1" targets="//@children.13/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E400" sources="//@children.13/@children.2/@children.0/@children.9/@ports.0" targets="//@children.13/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E401" sources="//@children.13/@children.2/@children.0/@children.10/@ports.2" targets="//@children.13/@children.2/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E402" sources="//@children.13/@children.2/@children.0/@children.11/@ports.1" targets="//@children.13/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E403" sources="//@children.13/@children.2/@children.0/@children.12/@ports.1" targets="//@children.13/@children.2/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E404" sources="//@children.13/@children.2/@children.0/@children.13/@ports.2" targets="//@children.13/@children.2/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E405" sources="//@children.13/@children.2/@children.0/@children.13/@ports.3" targets="//@children.13/@children.2/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E406" sources="//@children.13/@children.2/@children.0/@children.14/@ports.1" targets="//@children.13/@children.2/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E407" sources="//@children.13/@children.2/@children.0/@children.15/@ports.2" targets="//@children.13/@children.2/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E408" sources="//@children.13/@children.2/@children.0/@children.15/@ports.3" targets="//@children.13/@children.2/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E409" sources="//@children.13/@children.2/@children.0/@children.16/@ports.1" targets="//@children.13/@children.2/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E410" sources="//@children.13/@children.2/@children.0/@children.17/@ports.1" targets="//@children.13/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E411" sources="//@children.13/@children.2/@children.0/@children.18/@ports.2" targets="//@children.13/@children.2/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E412" sources="//@children.13/@children.2/@children.0/@children.19/@ports.2" targets="//@children.13/@children.2/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E413" sources="//@children.13/@children.2/@children.0/@children.19/@ports.3" targets="//@children.13/@children.2/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E414" sources="//@children.13/@children.2/@children.0/@children.20/@ports.1" targets="//@children.13/@children.2/@children.0/@children.30/@ports.1"/>
+        <containedEdges identifier="E415" sources="//@children.13/@children.2/@children.0/@children.20/@ports.1" targets="//@children.13/@children.2/@children.0/@children.31/@ports.0"/>
+        <containedEdges identifier="E416" sources="//@children.13/@children.2/@children.0/@children.21/@ports.0" targets="//@children.13/@children.2/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E417" sources="//@children.13/@children.2/@children.0/@children.22/@ports.1" targets="//@children.13/@children.2/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E418" sources="//@children.13/@children.2/@children.0/@children.23/@ports.0" targets="//@children.13/@children.2/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E419" sources="//@children.13/@children.2/@children.0/@children.24/@ports.1" targets="//@children.13/@children.2/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E420" sources="//@children.13/@children.2/@children.0/@children.25/@ports.1" targets="//@children.13/@children.2/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E421" sources="//@children.13/@children.2/@children.0/@children.26/@ports.1" targets="//@children.13/@children.2/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E422" sources="//@children.13/@children.2/@children.0/@children.27/@ports.1" targets="//@children.13/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E423" sources="//@children.13/@children.2/@children.0/@children.27/@ports.1" targets="//@children.13/@children.2/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E424" sources="//@children.13/@children.2/@children.0/@children.28/@ports.1" targets="//@children.13/@children.2/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E425" sources="//@children.13/@children.2/@children.0/@children.29/@ports.0" targets="//@children.13/@children.2/@children.0/@children.31/@ports.2"/>
+        <containedEdges identifier="E426" sources="//@children.13/@children.2/@children.0/@children.30/@ports.0" targets="//@children.13/@children.2/@children.0/@children.31/@ports.0"/>
+        <containedEdges identifier="E427" sources="//@children.13/@children.2/@children.0/@children.31/@ports.1" targets="//@children.13/@children.2/@children.0/@children.17/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E375" sources="//@children.13/@ports.2" targets="//@children.13/@children.0/@ports.0"/>
+    <containedEdges identifier="E376" sources="//@children.13/@ports.1" targets="//@children.13/@children.2/@ports.0"/>
+    <containedEdges identifier="E377" sources="//@children.13/@children.0/@ports.1" targets="//@children.13/@children.2/@ports.1"/>
+    <containedEdges identifier="E378" sources="//@children.13/@children.0/@ports.0" targets="//@children.13/@children.0/@ports.1"/>
+    <containedEdges identifier="E379" sources="//@children.13/@children.1/@ports.1" targets="//@children.13/@ports.0"/>
+    <containedEdges identifier="E380" sources="//@children.13/@children.1/@ports.0" targets="//@children.13/@children.1/@ports.1"/>
+    <containedEdges identifier="E381" sources="//@children.13/@children.2/@ports.2" targets="//@children.13/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N258" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L258" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P672" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.29 //@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N259">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L259" height="15.0" width="140.0" text="remainingPaperDetector"/>
+    <ports identifier="P673" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P674" height="8.0" width="8.0" outgoingEdges="//@containedEdges.31 //@containedEdges.32 //@containedEdges.33" incomingEdges="//@children.15/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P675" height="8.0" width="8.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35" incomingEdges="//@children.15/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N260">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L260" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P676" height="8.0" width="8.0" outgoingEdges="//@children.15/@children.0/@containedEdges.0" incomingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P677" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.1" incomingEdges="//@children.15/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N261" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L261" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P678" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.15/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P679" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P680" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.15/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N262" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L262" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P681" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P682" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P683" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P684" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P685" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E436" sources="//@children.15/@children.0/@ports.0" targets="//@children.15/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E437" sources="//@children.15/@children.0/@children.0/@ports.1" targets="//@children.15/@children.0/@ports.1"/>
+      <containedEdges identifier="E438" sources="//@children.15/@children.0/@children.1/@ports.0" targets="//@children.15/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N263" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L263" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P686" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.3" incomingEdges="//@children.15/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P687" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.2" incomingEdges="//@children.15/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N264" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L264" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P688" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.5" incomingEdges="//@children.15/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P689" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.4" incomingEdges="//@children.15/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N265">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L265" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P690" height="8.0" width="8.0" incomingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P691" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P692" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N266">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L266" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P693" height="8.0" width="8.0" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.0 //@children.15/@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P694" height="8.0" width="8.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P695" height="8.0" width="8.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N267" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L267" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P696" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P698" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.2 //@children.15/@children.3/@children.0/@containedEdges.3 //@children.15/@children.3/@children.0/@containedEdges.4 //@children.15/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N268" height="25.0" width="111.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L268" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P699" height="8.0" width="8.0" x="111.0" y="8.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N269" height="25.0" width="75.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L269" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P701" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P702" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N270" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L270" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P703" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P704" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N271" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L271" height="15.0" width="68.0" text="Comparator"/>
+          <ports identifier="P705" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P706" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P707" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N272" height="25.0" width="72.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L272" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P708" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P709" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N273" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L273" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P710" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P711" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N274" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L274" height="15.0" width="75.0" text="Comparator2"/>
+          <ports identifier="P712" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P713" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P714" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N275" height="25.0" width="50.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L275" height="15.0" width="114.0" text="UnaryMathFunction"/>
+          <ports identifier="P715" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P716" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N276" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L276" height="15.0" width="54.0" text="TrueGate"/>
+          <ports identifier="P717" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P718" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N277" height="29.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L277" height="15.0" width="59.0" text="Sequence"/>
+          <ports identifier="P719" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P720" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N278" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L278" height="15.0" width="61.0" text="TrueGate2"/>
+          <ports identifier="P721" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P722" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N279" height="29.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L279" height="15.0" width="66.0" text="Sequence2"/>
+          <ports identifier="P723" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.15/@children.3/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P724" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.15/@children.3/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E439" sources="//@children.15/@children.3/@children.0/@ports.0" targets="//@children.15/@children.3/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E440" sources="//@children.15/@children.3/@children.0/@ports.0" targets="//@children.15/@children.3/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E441" sources="//@children.15/@children.3/@children.0/@children.0/@ports.2" targets="//@children.15/@children.3/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E442" sources="//@children.15/@children.3/@children.0/@children.0/@ports.2" targets="//@children.15/@children.3/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E443" sources="//@children.15/@children.3/@children.0/@children.0/@ports.2" targets="//@children.15/@children.3/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E444" sources="//@children.15/@children.3/@children.0/@children.0/@ports.2" targets="//@children.15/@children.3/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E445" sources="//@children.15/@children.3/@children.0/@children.1/@ports.0" targets="//@children.15/@children.3/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E446" sources="//@children.15/@children.3/@children.0/@children.2/@ports.0" targets="//@children.15/@children.3/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E447" sources="//@children.15/@children.3/@children.0/@children.3/@ports.1" targets="//@children.15/@children.3/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E448" sources="//@children.15/@children.3/@children.0/@children.4/@ports.2" targets="//@children.15/@children.3/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E449" sources="//@children.15/@children.3/@children.0/@children.5/@ports.0" targets="//@children.15/@children.3/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E450" sources="//@children.15/@children.3/@children.0/@children.6/@ports.1" targets="//@children.15/@children.3/@children.0/@children.7/@ports.1"/>
+        <containedEdges identifier="E451" sources="//@children.15/@children.3/@children.0/@children.7/@ports.2" targets="//@children.15/@children.3/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E452" sources="//@children.15/@children.3/@children.0/@children.8/@ports.1" targets="//@children.15/@children.3/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E453" sources="//@children.15/@children.3/@children.0/@children.9/@ports.1" targets="//@children.15/@children.3/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E454" sources="//@children.15/@children.3/@children.0/@children.10/@ports.1" targets="//@children.15/@children.3/@children.0/@ports.1"/>
+        <containedEdges identifier="E455" sources="//@children.15/@children.3/@children.0/@children.11/@ports.1" targets="//@children.15/@children.3/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E456" sources="//@children.15/@children.3/@children.0/@children.12/@ports.1" targets="//@children.15/@children.3/@children.0/@ports.2"/>
+      </children>
+    </children>
+    <containedEdges identifier="E428" sources="//@children.15/@ports.0" targets="//@children.15/@children.0/@ports.0"/>
+    <containedEdges identifier="E429" sources="//@children.15/@children.0/@ports.1" targets="//@children.15/@children.3/@ports.0"/>
+    <containedEdges identifier="E430" sources="//@children.15/@children.1/@ports.1" targets="//@children.15/@ports.2"/>
+    <containedEdges identifier="E431" sources="//@children.15/@children.1/@ports.0" targets="//@children.15/@children.1/@ports.1"/>
+    <containedEdges identifier="E432" sources="//@children.15/@children.2/@ports.1" targets="//@children.15/@ports.1"/>
+    <containedEdges identifier="E433" sources="//@children.15/@children.2/@ports.0" targets="//@children.15/@children.2/@ports.1"/>
+    <containedEdges identifier="E434" sources="//@children.15/@children.3/@ports.2" targets="//@children.15/@children.1/@ports.0"/>
+    <containedEdges identifier="E435" sources="//@children.15/@children.3/@ports.1" targets="//@children.15/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N280">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L280" height="15.0" width="101.0" text="ContactController"/>
+    <ports identifier="P725" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P726" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.1" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P727" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.2" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P728" height="8.0" width="8.0" incomingEdges="//@children.16/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P729" height="8.0" width="8.0" outgoingEdges="//@containedEdges.41" incomingEdges="//@children.16/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P730" height="8.0" width="8.0" outgoingEdges="//@containedEdges.36 //@containedEdges.37 //@containedEdges.38 //@containedEdges.39 //@containedEdges.40" incomingEdges="//@children.16/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N281">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L281" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P731" height="8.0" width="8.0" outgoingEdges="//@children.16/@children.0/@containedEdges.0" incomingEdges="//@children.16/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P732" height="8.0" width="8.0" incomingEdges="//@children.16/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N282" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L282" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P733" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.16/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P734" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P735" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.16/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N283" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L283" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P736" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.16/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P737" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P738" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P739" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P740" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E471" sources="//@children.16/@children.0/@ports.0" targets="//@children.16/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E472" sources="//@children.16/@children.0/@children.0/@ports.1" targets="//@children.16/@children.0/@ports.1"/>
+      <containedEdges identifier="E473" sources="//@children.16/@children.0/@children.1/@ports.0" targets="//@children.16/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N284">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L284" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P741" height="8.0" width="8.0" outgoingEdges="//@children.16/@children.1/@containedEdges.0" incomingEdges="//@children.16/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P742" height="8.0" width="8.0" incomingEdges="//@children.16/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N285" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L285" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P743" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.16/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P744" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P745" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.16/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N286" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L286" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P746" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.16/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P747" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P748" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P749" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P750" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E474" sources="//@children.16/@children.1/@ports.0" targets="//@children.16/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E475" sources="//@children.16/@children.1/@children.0/@ports.1" targets="//@children.16/@children.1/@ports.1"/>
+      <containedEdges identifier="E476" sources="//@children.16/@children.1/@children.1/@ports.0" targets="//@children.16/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N287" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L287" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P751" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.4" incomingEdges="//@children.16/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P752" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.3" incomingEdges="//@children.16/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N288" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L288" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P753" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.6" incomingEdges="//@children.16/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P754" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.5" incomingEdges="//@children.16/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N289" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L289" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P755" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.8" incomingEdges="//@children.16/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P756" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.7" incomingEdges="//@children.16/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N290" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L290" height="15.0" width="101.0" text="CompositeActor7"/>
+      <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.10" incomingEdges="//@children.16/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P758" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.9" incomingEdges="//@children.16/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N291">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L291" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P759" height="8.0" width="8.0" incomingEdges="//@children.16/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P760" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P761" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P762" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N292">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L292" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P763" height="8.0" width="8.0" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P764" height="8.0" width="8.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P765" height="8.0" width="8.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P766" height="8.0" width="8.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N293" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L293" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P767" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.1 //@children.16/@children.6/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P768" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P769" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P770" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P771" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N294" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L294" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P772" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P773" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.3 //@children.16/@children.6/@children.0/@containedEdges.4 //@children.16/@children.6/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P774" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N295" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L295" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P775" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P776" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P777" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N296" height="25.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L296" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P778" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P779" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N297" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L297" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P780" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P781" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N298" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L298" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P782" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P783" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N299" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L299" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P784" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.16/@children.6/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P785" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.16/@children.6/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P786" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E477" sources="//@children.16/@children.6/@children.0/@ports.0" targets="//@children.16/@children.6/@children.0/@children.0/@ports.3"/>
+        <containedEdges identifier="E478" sources="//@children.16/@children.6/@children.0/@children.0/@ports.0" targets="//@children.16/@children.6/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E479" sources="//@children.16/@children.6/@children.0/@children.0/@ports.0" targets="//@children.16/@children.6/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E480" sources="//@children.16/@children.6/@children.0/@children.1/@ports.1" targets="//@children.16/@children.6/@children.0/@children.0/@ports.4"/>
+        <containedEdges identifier="E481" sources="//@children.16/@children.6/@children.0/@children.1/@ports.1" targets="//@children.16/@children.6/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E482" sources="//@children.16/@children.6/@children.0/@children.1/@ports.1" targets="//@children.16/@children.6/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E483" sources="//@children.16/@children.6/@children.0/@children.2/@ports.1" targets="//@children.16/@children.6/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E484" sources="//@children.16/@children.6/@children.0/@children.3/@ports.0" targets="//@children.16/@children.6/@children.0/@ports.1"/>
+        <containedEdges identifier="E485" sources="//@children.16/@children.6/@children.0/@children.4/@ports.0" targets="//@children.16/@children.6/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E486" sources="//@children.16/@children.6/@children.0/@children.5/@ports.0" targets="//@children.16/@children.6/@children.0/@ports.3"/>
+        <containedEdges identifier="E487" sources="//@children.16/@children.6/@children.0/@children.6/@ports.1" targets="//@children.16/@children.6/@children.0/@ports.2"/>
+      </children>
+    </children>
+    <containedEdges identifier="E457" sources="//@children.16/@ports.0" targets="//@children.16/@children.0/@ports.0"/>
+    <containedEdges identifier="E458" sources="//@children.16/@ports.1" targets="//@children.16/@children.1/@ports.0"/>
+    <containedEdges identifier="E459" sources="//@children.16/@ports.2" targets="//@children.16/@children.2/@ports.0"/>
+    <containedEdges identifier="E460" sources="//@children.16/@children.2/@ports.1" targets="//@children.16/@children.6/@ports.0"/>
+    <containedEdges identifier="E461" sources="//@children.16/@children.2/@ports.0" targets="//@children.16/@children.2/@ports.1"/>
+    <containedEdges identifier="E462" sources="//@children.16/@children.3/@ports.1" targets="//@children.16/@ports.5"/>
+    <containedEdges identifier="E463" sources="//@children.16/@children.3/@ports.0" targets="//@children.16/@children.3/@ports.1"/>
+    <containedEdges identifier="E464" sources="//@children.16/@children.4/@ports.1" targets="//@children.16/@ports.3"/>
+    <containedEdges identifier="E465" sources="//@children.16/@children.4/@ports.0" targets="//@children.16/@children.4/@ports.1"/>
+    <containedEdges identifier="E466" sources="//@children.16/@children.5/@ports.1" targets="//@children.16/@ports.4"/>
+    <containedEdges identifier="E467" sources="//@children.16/@children.5/@ports.0" targets="//@children.16/@children.5/@ports.1"/>
+    <containedEdges identifier="E468" sources="//@children.16/@children.6/@ports.1" targets="//@children.16/@children.4/@ports.0"/>
+    <containedEdges identifier="E469" sources="//@children.16/@children.6/@ports.3" targets="//@children.16/@children.3/@ports.0"/>
+    <containedEdges identifier="E470" sources="//@children.16/@children.6/@ports.2" targets="//@children.16/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N300">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L300" height="15.0" width="85.0" text="FeedController"/>
+    <ports identifier="P787" height="8.0" width="8.0" outgoingEdges="//@children.17/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P788" height="8.0" width="8.0" outgoingEdges="//@children.17/@containedEdges.1" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P789" height="8.0" width="8.0" outgoingEdges="//@containedEdges.43" incomingEdges="//@children.17/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P790" height="8.0" width="8.0" outgoingEdges="//@containedEdges.42" incomingEdges="//@children.17/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P791" height="8.0" width="8.0" outgoingEdges="//@children.17/@containedEdges.2" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P792" height="8.0" width="8.0" outgoingEdges="//@children.17/@containedEdges.3" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N301" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L301" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P793" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.5" incomingEdges="//@children.17/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P794" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.4" incomingEdges="//@children.17/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N302">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L302" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P795" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.1/@containedEdges.0" incomingEdges="//@children.17/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P796" height="8.0" width="8.0" outgoingEdges="//@children.17/@containedEdges.6" incomingEdges="//@children.17/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N303" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L303" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P797" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.17/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P798" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.17/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P799" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.17/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N304" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L304" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P800" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.17/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P801" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P802" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P803" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P804" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E503" sources="//@children.17/@children.1/@ports.0" targets="//@children.17/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E504" sources="//@children.17/@children.1/@children.0/@ports.1" targets="//@children.17/@children.1/@ports.1"/>
+      <containedEdges identifier="E505" sources="//@children.17/@children.1/@children.1/@ports.0" targets="//@children.17/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N305" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L305" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P805" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.8" incomingEdges="//@children.17/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P806" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.7" incomingEdges="//@children.17/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N306" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L306" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P807" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.10" incomingEdges="//@children.17/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P808" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.9" incomingEdges="//@children.17/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N307" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L307" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P809" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.12" incomingEdges="//@children.17/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P810" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.17/@containedEdges.11" incomingEdges="//@children.17/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N308">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L308" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P811" height="8.0" width="8.0" incomingEdges="//@children.17/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P812" height="8.0" width="8.0" incomingEdges="//@children.17/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P813" height="8.0" width="8.0" incomingEdges="//@children.17/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P814" height="8.0" width="8.0" incomingEdges="//@children.17/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P815" height="8.0" width="8.0" outgoingEdges="//@children.17/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P816" height="8.0" width="8.0" outgoingEdges="//@children.17/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N309">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L309" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P817" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P818" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.0 //@children.17/@children.5/@children.0/@containedEdges.1 //@children.17/@children.5/@children.0/@containedEdges.2 //@children.17/@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P819" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P820" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P821" height="8.0" width="8.0" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P822" height="8.0" width="8.0" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N310" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L310" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P823" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P824" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.7 //@children.17/@children.5/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P825" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N311" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L311" height="15.0" width="68.0" text="TimedDelay"/>
+          <ports identifier="P826" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P827" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N312" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L312" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P828" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P829" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.10 //@children.17/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P830" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N313" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L313" height="15.0" width="56.0" text="Register2"/>
+          <ports identifier="P831" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P832" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P833" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N314" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L314" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P834" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.2 //@children.17/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P835" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P836" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N315" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L315" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P837" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P838" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N316" height="25.0" width="70.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L316" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P839" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P840" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N317" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L317" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P841" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P842" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P843" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N318" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L318" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P844" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.8 //@children.17/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P845" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.17/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P846" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.17/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E506" sources="//@children.17/@children.5/@children.0/@ports.1" targets="//@children.17/@children.5/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E507" sources="//@children.17/@children.5/@children.0/@ports.1" targets="//@children.17/@children.5/@children.0/@children.3/@ports.2"/>
+        <containedEdges identifier="E508" sources="//@children.17/@children.5/@children.0/@ports.1" targets="//@children.17/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E509" sources="//@children.17/@children.5/@children.0/@ports.1" targets="//@children.17/@children.5/@children.0/@children.7/@ports.1"/>
+        <containedEdges identifier="E510" sources="//@children.17/@children.5/@children.0/@ports.0" targets="//@children.17/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E511" sources="//@children.17/@children.5/@children.0/@ports.2" targets="//@children.17/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E512" sources="//@children.17/@children.5/@children.0/@ports.3" targets="//@children.17/@children.5/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E513" sources="//@children.17/@children.5/@children.0/@children.0/@ports.1" targets="//@children.17/@children.5/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E514" sources="//@children.17/@children.5/@children.0/@children.0/@ports.1" targets="//@children.17/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E515" sources="//@children.17/@children.5/@children.0/@children.1/@ports.1" targets="//@children.17/@children.5/@children.0/@ports.4"/>
+        <containedEdges identifier="E516" sources="//@children.17/@children.5/@children.0/@children.2/@ports.1" targets="//@children.17/@children.5/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E517" sources="//@children.17/@children.5/@children.0/@children.2/@ports.1" targets="//@children.17/@children.5/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E518" sources="//@children.17/@children.5/@children.0/@children.3/@ports.1" targets="//@children.17/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E519" sources="//@children.17/@children.5/@children.0/@children.4/@ports.2" targets="//@children.17/@children.5/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E520" sources="//@children.17/@children.5/@children.0/@children.5/@ports.0" targets="//@children.17/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E521" sources="//@children.17/@children.5/@children.0/@children.6/@ports.0" targets="//@children.17/@children.5/@children.0/@children.8/@ports.2"/>
+        <containedEdges identifier="E522" sources="//@children.17/@children.5/@children.0/@children.7/@ports.2" targets="//@children.17/@children.5/@children.0/@ports.5"/>
+        <containedEdges identifier="E523" sources="//@children.17/@children.5/@children.0/@children.8/@ports.1" targets="//@children.17/@children.5/@children.0/@children.1/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E488" sources="//@children.17/@ports.0" targets="//@children.17/@children.1/@ports.0"/>
+    <containedEdges identifier="E489" sources="//@children.17/@ports.1" targets="//@children.17/@children.0/@ports.0"/>
+    <containedEdges identifier="E490" sources="//@children.17/@ports.4" targets="//@children.17/@children.2/@ports.0"/>
+    <containedEdges identifier="E491" sources="//@children.17/@ports.5" targets="//@children.17/@children.4/@ports.0"/>
+    <containedEdges identifier="E492" sources="//@children.17/@children.0/@ports.1" targets="//@children.17/@children.5/@ports.1"/>
+    <containedEdges identifier="E493" sources="//@children.17/@children.0/@ports.0" targets="//@children.17/@children.0/@ports.1"/>
+    <containedEdges identifier="E494" sources="//@children.17/@children.1/@ports.1" targets="//@children.17/@children.5/@ports.2"/>
+    <containedEdges identifier="E495" sources="//@children.17/@children.2/@ports.1" targets="//@children.17/@children.5/@ports.0"/>
+    <containedEdges identifier="E496" sources="//@children.17/@children.2/@ports.0" targets="//@children.17/@children.2/@ports.1"/>
+    <containedEdges identifier="E497" sources="//@children.17/@children.3/@ports.1" targets="//@children.17/@ports.2"/>
+    <containedEdges identifier="E498" sources="//@children.17/@children.3/@ports.0" targets="//@children.17/@children.3/@ports.1"/>
+    <containedEdges identifier="E499" sources="//@children.17/@children.4/@ports.1" targets="//@children.17/@children.5/@ports.3"/>
+    <containedEdges identifier="E500" sources="//@children.17/@children.4/@ports.0" targets="//@children.17/@children.4/@ports.1"/>
+    <containedEdges identifier="E501" sources="//@children.17/@children.5/@ports.4" targets="//@children.17/@children.3/@ports.0"/>
+    <containedEdges identifier="E502" sources="//@children.17/@children.5/@ports.5" targets="//@children.17/@ports.3"/>
+  </children>
+  <children identifier="N319">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L319" height="15.0" width="102.0" text="ReserveController"/>
+    <ports identifier="P847" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P848" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.1" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P849" height="8.0" width="8.0" outgoingEdges="//@containedEdges.45" incomingEdges="//@children.18/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P850" height="8.0" width="8.0" outgoingEdges="//@containedEdges.44" incomingEdges="//@children.18/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P851" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.2" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P852" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.3" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N320" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L320" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P853" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.5" incomingEdges="//@children.18/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P854" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.4" incomingEdges="//@children.18/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N321">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L321" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P855" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.1/@containedEdges.0" incomingEdges="//@children.18/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P856" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.6" incomingEdges="//@children.18/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N322" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L322" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P857" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.18/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P858" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.18/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P859" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.18/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N323" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L323" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P860" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.18/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P861" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P862" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P863" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P864" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E539" sources="//@children.18/@children.1/@ports.0" targets="//@children.18/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E540" sources="//@children.18/@children.1/@children.0/@ports.1" targets="//@children.18/@children.1/@ports.1"/>
+      <containedEdges identifier="E541" sources="//@children.18/@children.1/@children.1/@ports.0" targets="//@children.18/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N324" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L324" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P865" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.8" incomingEdges="//@children.18/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P866" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.7" incomingEdges="//@children.18/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N325" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L325" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P867" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.10" incomingEdges="//@children.18/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P868" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.9" incomingEdges="//@children.18/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N326" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L326" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P869" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.12" incomingEdges="//@children.18/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P870" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.18/@containedEdges.11" incomingEdges="//@children.18/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N327">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L327" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P871" height="8.0" width="8.0" incomingEdges="//@children.18/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P872" height="8.0" width="8.0" incomingEdges="//@children.18/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P873" height="8.0" width="8.0" incomingEdges="//@children.18/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P874" height="8.0" width="8.0" incomingEdges="//@children.18/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P875" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P876" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N328">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L328" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P877" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P878" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.0 //@children.18/@children.5/@children.0/@containedEdges.1 //@children.18/@children.5/@children.0/@containedEdges.2 //@children.18/@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P879" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P880" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P881" height="8.0" width="8.0" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P882" height="8.0" width="8.0" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N329" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L329" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P883" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P884" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.7 //@children.18/@children.5/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P885" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N330" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L330" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P886" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P887" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.9 //@children.18/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P888" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N331" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L331" height="15.0" width="56.0" text="Register2"/>
+          <ports identifier="P889" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P890" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P891" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N332" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L332" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P892" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.2 //@children.18/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P893" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P894" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N333" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L333" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P895" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P896" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N334" height="25.0" width="70.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L334" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P897" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P898" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N335" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L335" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P899" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P900" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P901" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N336" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L336" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P902" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P903" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P904" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N337" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L337" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P905" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.8 //@children.18/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P906" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.18/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P907" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.18/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E542" sources="//@children.18/@children.5/@children.0/@ports.1" targets="//@children.18/@children.5/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E543" sources="//@children.18/@children.5/@children.0/@ports.1" targets="//@children.18/@children.5/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E544" sources="//@children.18/@children.5/@children.0/@ports.1" targets="//@children.18/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E545" sources="//@children.18/@children.5/@children.0/@ports.1" targets="//@children.18/@children.5/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E546" sources="//@children.18/@children.5/@children.0/@ports.3" targets="//@children.18/@children.5/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E547" sources="//@children.18/@children.5/@children.0/@ports.2" targets="//@children.18/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E548" sources="//@children.18/@children.5/@children.0/@ports.0" targets="//@children.18/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E549" sources="//@children.18/@children.5/@children.0/@children.0/@ports.1" targets="//@children.18/@children.5/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E550" sources="//@children.18/@children.5/@children.0/@children.0/@ports.1" targets="//@children.18/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E551" sources="//@children.18/@children.5/@children.0/@children.1/@ports.1" targets="//@children.18/@children.5/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E552" sources="//@children.18/@children.5/@children.0/@children.1/@ports.1" targets="//@children.18/@children.5/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E553" sources="//@children.18/@children.5/@children.0/@children.2/@ports.1" targets="//@children.18/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E554" sources="//@children.18/@children.5/@children.0/@children.3/@ports.2" targets="//@children.18/@children.5/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E555" sources="//@children.18/@children.5/@children.0/@children.4/@ports.0" targets="//@children.18/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E556" sources="//@children.18/@children.5/@children.0/@children.5/@ports.0" targets="//@children.18/@children.5/@children.0/@children.8/@ports.2"/>
+        <containedEdges identifier="E557" sources="//@children.18/@children.5/@children.0/@children.6/@ports.2" targets="//@children.18/@children.5/@children.0/@ports.5"/>
+        <containedEdges identifier="E558" sources="//@children.18/@children.5/@children.0/@children.7/@ports.1" targets="//@children.18/@children.5/@children.0/@ports.4"/>
+        <containedEdges identifier="E559" sources="//@children.18/@children.5/@children.0/@children.8/@ports.1" targets="//@children.18/@children.5/@children.0/@children.7/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E524" sources="//@children.18/@ports.0" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E525" sources="//@children.18/@ports.1" targets="//@children.18/@children.0/@ports.0"/>
+    <containedEdges identifier="E526" sources="//@children.18/@ports.4" targets="//@children.18/@children.2/@ports.0"/>
+    <containedEdges identifier="E527" sources="//@children.18/@ports.5" targets="//@children.18/@children.3/@ports.0"/>
+    <containedEdges identifier="E528" sources="//@children.18/@children.0/@ports.1" targets="//@children.18/@children.5/@ports.1"/>
+    <containedEdges identifier="E529" sources="//@children.18/@children.0/@ports.0" targets="//@children.18/@children.0/@ports.1"/>
+    <containedEdges identifier="E530" sources="//@children.18/@children.1/@ports.1" targets="//@children.18/@children.5/@ports.2"/>
+    <containedEdges identifier="E531" sources="//@children.18/@children.2/@ports.1" targets="//@children.18/@children.5/@ports.0"/>
+    <containedEdges identifier="E532" sources="//@children.18/@children.2/@ports.0" targets="//@children.18/@children.2/@ports.1"/>
+    <containedEdges identifier="E533" sources="//@children.18/@children.3/@ports.1" targets="//@children.18/@children.5/@ports.3"/>
+    <containedEdges identifier="E534" sources="//@children.18/@children.3/@ports.0" targets="//@children.18/@children.3/@ports.1"/>
+    <containedEdges identifier="E535" sources="//@children.18/@children.4/@ports.1" targets="//@children.18/@ports.2"/>
+    <containedEdges identifier="E536" sources="//@children.18/@children.4/@ports.0" targets="//@children.18/@children.4/@ports.1"/>
+    <containedEdges identifier="E537" sources="//@children.18/@children.5/@ports.5" targets="//@children.18/@ports.3"/>
+    <containedEdges identifier="E538" sources="//@children.18/@children.5/@ports.4" targets="//@children.18/@children.4/@ports.0"/>
+  </children>
+  <children identifier="N338">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L338" height="15.0" width="114.0" text="reserveFeedMonitor"/>
+    <ports identifier="P908" height="8.0" width="8.0" outgoingEdges="//@children.19/@containedEdges.1" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P909" height="8.0" width="8.0" outgoingEdges="//@children.19/@containedEdges.2" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P910" height="8.0" width="8.0" outgoingEdges="//@children.19/@containedEdges.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N339">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L339" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P911" height="8.0" width="8.0" outgoingEdges="//@children.19/@children.0/@containedEdges.0" incomingEdges="//@children.19/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P912" height="8.0" width="8.0" outgoingEdges="//@children.19/@containedEdges.3" incomingEdges="//@children.19/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N340" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L340" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P913" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.19/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P914" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.19/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P915" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.19/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N341" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L341" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P916" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.19/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P917" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P918" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P919" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P920" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E567" sources="//@children.19/@children.0/@ports.0" targets="//@children.19/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E568" sources="//@children.19/@children.0/@children.0/@ports.1" targets="//@children.19/@children.0/@ports.1"/>
+      <containedEdges identifier="E569" sources="//@children.19/@children.0/@children.1/@ports.0" targets="//@children.19/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N342" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L342" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P921" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.19/@containedEdges.5" incomingEdges="//@children.19/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P922" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.19/@containedEdges.4" incomingEdges="//@children.19/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N343" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L343" height="15.0" width="150.0" text="reserveFeedPaperVelocity"/>
+      <ports identifier="P923" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.19/@containedEdges.2 //@children.19/@containedEdges.3 //@children.19/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N344">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L344" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P924" height="8.0" width="8.0" incomingEdges="//@children.19/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P925" height="8.0" width="8.0" outgoingEdges="//@children.19/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N345" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L345" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P926" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@children.19/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P927" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@children.19/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E570" sources="//@children.19/@children.3/@children.0/@ports.0" targets="//@children.19/@children.3/@children.0/@ports.1"/>
+    </children>
+    <containedEdges identifier="E560" sources="//@children.19/@ports.2" targets="//@children.19/@children.1/@ports.0"/>
+    <containedEdges identifier="E561" sources="//@children.19/@ports.0" targets="//@children.19/@children.0/@ports.0"/>
+    <containedEdges identifier="E562" sources="//@children.19/@ports.1" targets="//@children.19/@children.2/@ports.0"/>
+    <containedEdges identifier="E563" sources="//@children.19/@children.0/@ports.1" targets="//@children.19/@children.2/@ports.0"/>
+    <containedEdges identifier="E564" sources="//@children.19/@children.1/@ports.1" targets="//@children.19/@children.3/@ports.0"/>
+    <containedEdges identifier="E565" sources="//@children.19/@children.1/@ports.0" targets="//@children.19/@children.1/@ports.1"/>
+    <containedEdges identifier="E566" sources="//@children.19/@children.3/@ports.1" targets="//@children.19/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N346" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L346" height="15.0" width="152.0" text="reserveFeedPaperRadius2"/>
+    <ports identifier="P928" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.12 //@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N347" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L347" height="15.0" width="104.0" text="feedPaperVelocity"/>
+    <ports identifier="P929" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.42 //@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N348" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L348" height="15.0" width="106.0" text="feedPaperRadius2"/>
+    <ports identifier="P930" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.47 //@containedEdges.48 //@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N349" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L349" height="15.0" width="106.0" text="feedPaperRadius3"/>
+    <ports identifier="P931" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N350">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L350" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P932" height="8.0" width="8.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P933" height="8.0" width="8.0" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N351" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L351" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P934" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@children.24/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P935" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@children.24/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E571" sources="//@children.24/@children.0/@ports.0" targets="//@children.24/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N352">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L352" height="15.0" width="93.0" text="PtidesPlatform2"/>
+    <ports identifier="P936" height="8.0" width="8.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P937" height="8.0" width="8.0" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P938" height="8.0" width="8.0" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P939" height="8.0" width="8.0" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P940" height="8.0" width="8.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P941" height="8.0" width="8.0" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N353">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L353" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P942" height="8.0" width="8.0" outgoingEdges="//@children.25/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P943" height="8.0" width="8.0" incomingEdges="//@children.25/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P944" height="8.0" width="8.0" outgoingEdges="//@children.25/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P945" height="8.0" width="8.0" incomingEdges="//@children.25/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P946" height="8.0" width="8.0" outgoingEdges="//@children.25/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P947" height="8.0" width="8.0" incomingEdges="//@children.25/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N354" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L354" height="15.0" width="112.0" text="BooleanToAnything"/>
+        <ports identifier="P948" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.25/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P949" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.25/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N355" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L355" height="15.0" width="119.0" text="BooleanToAnything2"/>
+        <ports identifier="P950" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.25/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P951" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.25/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N356" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L356" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P952" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.25/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P953" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.25/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E572" sources="//@children.25/@children.0/@ports.4" targets="//@children.25/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E573" sources="//@children.25/@children.0/@ports.2" targets="//@children.25/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E574" sources="//@children.25/@children.0/@ports.0" targets="//@children.25/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E575" sources="//@children.25/@children.0/@children.0/@ports.1" targets="//@children.25/@children.0/@ports.1"/>
+      <containedEdges identifier="E576" sources="//@children.25/@children.0/@children.1/@ports.1" targets="//@children.25/@children.0/@ports.3"/>
+      <containedEdges identifier="E577" sources="//@children.25/@children.0/@children.2/@ports.1" targets="//@children.25/@children.0/@ports.5"/>
+    </children>
+  </children>
+  <children identifier="N357" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L357" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P954" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.4" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.3/@ports.1" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.5/@ports.3" targets="//@children.17/@ports.4"/>
+  <containedEdges identifier="E16" sources="//@children.6/@ports.4" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.6/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.6/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.6/@ports.2" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.8/@ports.1" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.10/@ports.3" targets="//@children.18/@ports.4"/>
+  <containedEdges identifier="E24" sources="//@children.11/@ports.0" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.11/@ports.0" targets="//@children.19/@ports.2"/>
+  <containedEdges identifier="E26" sources="//@children.12/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E27" sources="//@children.12/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.13/@ports.0" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.13/@ports.0" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.14/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.14/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.15/@ports.1" targets="//@children.10/@ports.4"/>
+  <containedEdges identifier="E33" sources="//@children.15/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.15/@ports.1" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E35" sources="//@children.15/@ports.2" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E36" sources="//@children.15/@ports.2" targets="//@children.25/@ports.2"/>
+  <containedEdges identifier="E37" sources="//@children.16/@ports.5" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E38" sources="//@children.16/@ports.5" targets="//@children.17/@ports.5"/>
+  <containedEdges identifier="E39" sources="//@children.16/@ports.5" targets="//@children.18/@ports.5"/>
+  <containedEdges identifier="E40" sources="//@children.16/@ports.5" targets="//@children.25/@ports.4"/>
+  <containedEdges identifier="E41" sources="//@children.16/@ports.5" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.16/@ports.4" targets="//@children.6/@ports.5"/>
+  <containedEdges identifier="E43" sources="//@children.17/@ports.3" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.17/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E45" sources="//@children.18/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E46" sources="//@children.18/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E47" sources="//@children.24/@ports.1" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E48" sources="//@children.25/@ports.5" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E49" sources="//@children.25/@ports.3" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E50" sources="//@children.25/@ports.1" targets="//@children.22/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_ptidesmergetomultiframe_PtidesMergeToMultiFrame.elkg
+++ b/realworld/ptolemy/hierarchical/de_ptidesmergetomultiframe_PtidesMergeToMultiFrame.elkg
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L4" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N5" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="69.0" text="TimeDelay3"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="41.0" text="Scale3"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.4 //@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E4" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E5" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E6" sources="//@children.2/@children.0/@children.0/@ports.1" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E7" sources="//@children.2/@children.0/@children.1/@ports.1" targets="//@children.2/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E8" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E9" sources="//@children.2/@children.0/@children.3/@ports.1" targets="//@children.2/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E10" sources="//@children.2/@children.0/@children.4/@ports.1" targets="//@children.2/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.2/@children.0/@children.5/@ports.1" targets="//@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E12" sources="//@children.2/@children.0/@children.6/@ports.1" targets="//@children.2/@children.0/@children.4/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N12" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_realtimecomposite_RealTimeCompositeTones.elkg
+++ b/realworld/ptolemy/hierarchical/de_realtimecomposite_RealTimeCompositeTones.elkg
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="117.0" text="RealTimeComposite"/>
+    <ports identifier="P6" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L4" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N5" height="25.0" width="298.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="298.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="75.0" text="SoundPlayer"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E8" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="124.0" text="RealTimeComposite2"/>
+    <ports identifier="P13" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N9" height="25.0" width="298.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="298.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="75.0" text="SoundPlayer"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="124.0" text="RealTimeComposite3"/>
+    <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N14" height="25.0" width="298.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="298.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="75.0" text="SoundPlayer"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.5/@children.0/@children.0/@ports.0" targets="//@children.5/@children.0/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_switch_CrossbarSwitch.elkg
+++ b/realworld/ptolemy/hierarchical/de_switch_CrossbarSwitch.elkg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="9.0" text="B"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@ports.2" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@ports.3" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="10.0" text="C"/>
+    <ports identifier="P21" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.2/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@ports.2" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@ports.3" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="10.0" text="D"/>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@ports.3" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.2/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_switch_Switch.elkg
+++ b/realworld/ptolemy/hierarchical/de_switch_Switch.elkg
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="9.0" text="A"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="9.0" text="B"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="17.0" text="A2"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="17.0" text="B2"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.4/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="81.0" text="TimedPlotter3"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="10.0" text="C"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.6/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="17.0" text="C2"/>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.7/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E22" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="10.0" text="D"/>
+    <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.8/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.8/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@ports.1"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="17.0" text="D2"/>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.9/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N18" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E25" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.2" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_tcppackettxrx_TCPPacketTXRX.elkg
+++ b/realworld/ptolemy/hierarchical/de_tcppackettxrx_TCPPacketTXRX.elkg
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="58.0" text="LocalClk2"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="60.0" text="Processor"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="81.0" text="TimedPlotter2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="116.0" text="TCPPacketReceiver"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="123.0" text="TCPPacketReceiver2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="17.0" text="P1"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.2/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.2/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="58.0" text="LocalClk1"/>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="17.0" text="P2"/>
+    <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.4/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N18" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.3 //@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.4/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.3/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_timingparadox_TimingParadox.elkg
+++ b/realworld/ptolemy/hierarchical/de_timingparadox_TimingParadox.elkg
@@ -1,0 +1,673 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Clock2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Rician"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="44.0" text="Rician2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="111.0" text="InstanceOfSampler"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3 //@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E26" sources="//@children.6/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.6/@ports.0" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.3/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="118.0" text="InstanceOfSampler2"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.7/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E33" sources="//@children.7/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.7/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E36" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.3/@ports.2"/>
+    <containedEdges identifier="E38" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="118.0" text="InstanceOfSampler3"/>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.1" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.8/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3 //@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E40" sources="//@children.8/@ports.1" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.8/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.8/@children.0/@ports.2" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.3/@ports.2"/>
+    <containedEdges identifier="E45" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.1/@ports.1"/>
+    <containedEdges identifier="E46" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N22">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L22" height="15.0" width="118.0" text="InstanceOfSampler4"/>
+    <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.9/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N23" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E47" sources="//@children.9/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.9/@ports.0" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@ports.2"/>
+    <containedEdges identifier="E50" sources="//@children.9/@children.1/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.9/@children.1/@ports.0" targets="//@children.9/@children.3/@ports.2"/>
+    <containedEdges identifier="E52" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.1/@ports.1"/>
+    <containedEdges identifier="E53" sources="//@children.9/@children.3/@ports.1" targets="//@children.9/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="118.0" text="InstanceOfSampler5"/>
+    <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.10/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.3 //@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E54" sources="//@children.10/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.10/@ports.0" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E57" sources="//@children.10/@children.1/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.10/@children.1/@ports.0" targets="//@children.10/@children.3/@ports.2"/>
+    <containedEdges identifier="E59" sources="//@children.10/@children.2/@ports.1" targets="//@children.10/@children.1/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.10/@children.3/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N32">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L32" height="15.0" width="118.0" text="InstanceOfSampler6"/>
+    <ports identifier="P79" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.1" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.11/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N33" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.3 //@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E61" sources="//@children.11/@ports.1" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.11/@ports.0" targets="//@children.11/@children.3/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.11/@children.0/@ports.2" targets="//@children.11/@ports.2"/>
+    <containedEdges identifier="E64" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.3/@ports.2"/>
+    <containedEdges identifier="E66" sources="//@children.11/@children.2/@ports.1" targets="//@children.11/@children.1/@ports.1"/>
+    <containedEdges identifier="E67" sources="//@children.11/@children.3/@ports.1" targets="//@children.11/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N37" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.13/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.13/@ports.1" targets="//@children.11/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_trilateration_Trilateration.elkg
+++ b/realworld/ptolemy/hierarchical/de_trilateration_Trilateration.elkg
@@ -1,0 +1,8371 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="101.0" text="CompositeActor7"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@containedEdges.3" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@children.0/@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6 //@children.0/@children.0/@containedEdges.7 //@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.4 //@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="53.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E51" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.0/@children.3/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@children.11/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.0/@children.5/@ports.2" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.0/@children.6/@ports.2" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.0/@children.7/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E65" sources="//@children.0/@children.0/@children.8/@ports.0" targets="//@children.0/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.0/@children.9/@ports.0" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.0/@children.10/@ports.1" targets="//@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.0/@children.11/@ports.1" targets="//@children.0/@children.0/@children.10/@ports.2"/>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.0 //@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.2 //@children.0/@children.1/@containedEdges.3" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N16" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.6 //@children.0/@children.1/@containedEdges.7 //@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.4 //@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="25.0" width="53.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.0/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E69" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E71" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.0/@children.1/@children.0/@ports.1" targets="//@children.0/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E74" sources="//@children.0/@children.1/@children.1/@ports.1" targets="//@children.0/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.0/@children.1/@children.2/@ports.1" targets="//@children.0/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.0/@children.1/@children.2/@ports.1" targets="//@children.0/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E77" sources="//@children.0/@children.1/@children.2/@ports.1" targets="//@children.0/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.0/@children.1/@children.3/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.0/@children.1/@children.4/@ports.2" targets="//@children.0/@children.1/@children.11/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.0/@children.1/@children.5/@ports.2" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.1/@children.6/@ports.2" targets="//@children.0/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.1/@children.7/@ports.0" targets="//@children.0/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E83" sources="//@children.0/@children.1/@children.8/@ports.0" targets="//@children.0/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.1/@children.9/@ports.0" targets="//@children.0/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.1/@children.10/@ports.1" targets="//@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.1/@children.11/@ports.1" targets="//@children.0/@children.1/@children.10/@ports.2"/>
+    </children>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.2/@containedEdges.0 //@children.0/@children.2/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.2/@containedEdges.2 //@children.0/@children.2/@containedEdges.3" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@children.0/@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N29" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.6 //@children.0/@children.2/@containedEdges.7 //@children.0/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.2/@containedEdges.4 //@children.0/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P94" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="25.0" width="53.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P96" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="113.0" text="Discrete TimeDelay"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.0/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E87" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.7/@ports.1"/>
+      <containedEdges identifier="E89" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E90" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.2/@children.8/@ports.1"/>
+      <containedEdges identifier="E91" sources="//@children.0/@children.2/@children.0/@ports.1" targets="//@children.0/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E92" sources="//@children.0/@children.2/@children.1/@ports.1" targets="//@children.0/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.0/@children.2/@children.2/@ports.1" targets="//@children.0/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E94" sources="//@children.0/@children.2/@children.2/@ports.1" targets="//@children.0/@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E95" sources="//@children.0/@children.2/@children.2/@ports.1" targets="//@children.0/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E96" sources="//@children.0/@children.2/@children.3/@ports.2" targets="//@children.0/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.0/@children.2/@children.4/@ports.2" targets="//@children.0/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.0/@children.2/@children.5/@ports.2" targets="//@children.0/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.0/@children.2/@children.6/@ports.2" targets="//@children.0/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.0/@children.2/@children.7/@ports.0" targets="//@children.0/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E101" sources="//@children.0/@children.2/@children.8/@ports.0" targets="//@children.0/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E102" sources="//@children.0/@children.2/@children.9/@ports.0" targets="//@children.0/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E103" sources="//@children.0/@children.2/@children.10/@ports.1" targets="//@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E104" sources="//@children.0/@children.2/@children.11/@ports.1" targets="//@children.0/@children.2/@children.10/@ports.2"/>
+    </children>
+    <children identifier="N41" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L42" height="15.0" width="85.0" text="PathGenerator"/>
+      <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@children.0/@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.4/@containedEdges.0 //@children.0/@children.4/@containedEdges.1 //@children.0/@children.4/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N43" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P107" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="25.0" width="103.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P111" height="8.0" width="8.0" x="103.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P114" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.5 //@children.0/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="25.0" width="40.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P119" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E105" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E106" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.4/@children.1/@ports.1"/>
+      <containedEdges identifier="E107" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.4/@children.4/@ports.1"/>
+      <containedEdges identifier="E108" sources="//@children.0/@children.4/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E109" sources="//@children.0/@children.4/@children.1/@ports.0" targets="//@children.0/@children.4/@children.2/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.0/@children.4/@children.2/@ports.1" targets="//@children.0/@children.4/@children.0/@ports.2"/>
+      <containedEdges identifier="E111" sources="//@children.0/@children.4/@children.2/@ports.1" targets="//@children.0/@children.4/@children.3/@ports.0"/>
+      <containedEdges identifier="E112" sources="//@children.0/@children.4/@children.3/@ports.2" targets="//@children.0/@children.4/@children.5/@ports.0"/>
+      <containedEdges identifier="E113" sources="//@children.0/@children.4/@children.4/@ports.0" targets="//@children.0/@children.4/@children.3/@ports.1"/>
+      <containedEdges identifier="E114" sources="//@children.0/@children.4/@children.5/@ports.1" targets="//@children.0/@children.4/@children.6/@ports.0"/>
+      <containedEdges identifier="E115" sources="//@children.0/@children.4/@children.6/@ports.1" targets="//@children.0/@children.4/@children.0/@ports.3"/>
+    </children>
+    <children identifier="N50">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L50" height="15.0" width="82.0" text="FixedLocation"/>
+      <ports identifier="P125" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5" incomingEdges="//@children.0/@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@containedEdges.0 //@children.0/@children.5/@containedEdges.1 //@children.0/@children.5/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N51" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P127" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P131" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P133" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.0/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E116" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E117" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E118" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.5/@children.2/@ports.1"/>
+      <containedEdges identifier="E119" sources="//@children.0/@children.5/@children.0/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.0/@children.5/@children.1/@ports.0" targets="//@children.0/@children.5/@children.0/@ports.2"/>
+      <containedEdges identifier="E121" sources="//@children.0/@children.5/@children.2/@ports.0" targets="//@children.0/@children.5/@children.0/@ports.3"/>
+    </children>
+    <children identifier="N54" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P136" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P137" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.11 //@children.0/@containedEdges.12 //@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="25.0" width="68.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P139" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P141" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P144" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P149" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P152" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E29" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.10/@ports.2" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.10/@ports.3" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.8/@ports.3"/>
+  </children>
+  <children identifier="N60">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L60" height="15.0" width="101.0" text="CompositeActor9"/>
+    <ports identifier="P153" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P156" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.1/@containedEdges.78">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.1/@containedEdges.79">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.1/@containedEdges.105">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N61" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="121.0" text="UnaryMathFunction8"/>
+      <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7 //@children.1/@containedEdges.8 //@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="121.0" text="UnaryMathFunction9"/>
+      <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P162" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12 //@children.1/@containedEdges.13 //@children.1/@containedEdges.14 //@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N63" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="127.0" text="UnaryMathFunction11"/>
+      <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P164" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N64" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="128.0" text="UnaryMathFunction12"/>
+      <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P169" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.18 //@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N66" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P172" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N67" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="48.0" text="Const11"/>
+      <ports identifier="P173" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="86.0" text="AddSubtract11"/>
+      <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.19 //@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.22 //@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="87.0" text="AddSubtract12"/>
+      <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P180" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.24 //@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="87.0" text="AddSubtract13"/>
+      <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P183" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.26 //@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.80">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P185" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.28 //@children.1/@containedEdges.29 //@children.1/@containedEdges.30 //@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P186" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.32 //@children.1/@containedEdges.33 //@children.1/@containedEdges.34 //@children.1/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N72" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L72" height="15.0" width="49.0" text="Const14"/>
+      <ports identifier="P187" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.81">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N73" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="49.0" text="Const15"/>
+      <ports identifier="P189" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.82">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="128.0" text="UnaryMathFunction13"/>
+      <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P192" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="128.0" text="UnaryMathFunction14"/>
+      <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P194" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.24 //@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P197" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.26 //@children.1/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P200" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N78" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L78" height="15.0" width="87.0" text="AddSubtract14"/>
+      <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.40 //@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P203" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.42 //@children.1/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N79" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L79" height="15.0" width="128.0" text="UnaryMathFunction15"/>
+      <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P205" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N80" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L80" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P207" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N81" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L81" height="15.0" width="128.0" text="UnaryMathFunction16"/>
+      <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P209" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N82" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L82" height="15.0" width="41.0" text="Scale3"/>
+      <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P211" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N83" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L83" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P214" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N84" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L84" height="15.0" width="87.0" text="MultiplyDivide6"/>
+      <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P217" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N85" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="87.0" text="AddSubtract15"/>
+      <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.48 //@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P220" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="128.0" text="UnaryMathFunction17"/>
+      <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P222" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L87" height="15.0" width="87.0" text="MultiplyDivide7"/>
+      <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.50 //@children.1/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P225" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N88" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L88" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P227" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N89" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L89" height="15.0" width="87.0" text="AddSubtract16"/>
+      <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P230" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.54">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N90" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L90" height="15.0" width="128.0" text="UnaryMathFunction18"/>
+      <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.65">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P232" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N91" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L91" height="15.0" width="87.0" text="AddSubtract17"/>
+      <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.64">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P235" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.56">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N92" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L92" height="15.0" width="87.0" text="MultiplyDivide8"/>
+      <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.56">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.63">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P238" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.57 //@children.1/@containedEdges.58 //@children.1/@containedEdges.59 //@children.1/@containedEdges.60 //@children.1/@containedEdges.61 //@children.1/@containedEdges.62">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N93" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L93" height="15.0" width="41.0" text="Scale5"/>
+      <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P240" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.63">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N94" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L94" height="15.0" width="41.0" text="Scale6"/>
+      <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P242" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.64">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N95" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L95" height="15.0" width="40.0" text="Limiter"/>
+      <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.54">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P244" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.65">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N96" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L96" height="15.0" width="87.0" text="AddSubtract19"/>
+      <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.57">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P247" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.66">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N97" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L97" height="15.0" width="128.0" text="UnaryMathFunction19"/>
+      <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.58">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P249" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.67 //@children.1/@containedEdges.68">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N98" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L98" height="15.0" width="128.0" text="UnaryMathFunction20"/>
+      <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.66">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P251" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.69">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N99" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L99" height="15.0" width="87.0" text="AddSubtract20"/>
+      <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.67">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.69">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P254" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.70">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N100" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L100" height="15.0" width="87.0" text="AddSubtract21"/>
+      <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.59">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P257" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.71">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N101" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L101" height="15.0" width="128.0" text="UnaryMathFunction21"/>
+      <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.71">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P259" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.72">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N102" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L102" height="15.0" width="87.0" text="AddSubtract22"/>
+      <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.15 //@children.1/@containedEdges.68">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.72">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P262" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.73">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N103" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L103" height="15.0" width="41.0" text="Scale7"/>
+      <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.76">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P264" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.74">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N104" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L104" height="15.0" width="41.0" text="Scale8"/>
+      <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.77">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P266" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.75">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N105" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L105" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P267" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.76">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.83">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N106" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L106" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P269" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.77">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.84">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N107" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L107" height="15.0" width="87.0" text="MultiplyDivide9"/>
+      <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.70">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.74">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P273" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.78">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N108" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L108" height="15.0" width="94.0" text="MultiplyDivide10"/>
+      <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.73">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.75">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P276" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.79">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N109" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L109" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P277" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.80 //@children.1/@containedEdges.81 //@children.1/@containedEdges.82 //@children.1/@containedEdges.83 //@children.1/@containedEdges.84">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.97">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.99">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N110" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L110" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P281" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.85 //@children.1/@containedEdges.86 //@children.1/@containedEdges.87">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P282" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.1/@containedEdges.91">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N111" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L111" height="15.0" width="78.0" text="MostRecent2"/>
+      <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P284" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.88">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P285" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.1/@containedEdges.92">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N112" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L112" height="15.0" width="78.0" text="MostRecent3"/>
+      <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P287" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.89">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P288" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.1/@containedEdges.93">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N113" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L113" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.3 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P290" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.90">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N114" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L114" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.90">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P292" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.91 //@children.1/@containedEdges.92 //@children.1/@containedEdges.93">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N115" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L115" height="15.0" width="93.0" text="MultiplyDivide11"/>
+      <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.60">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.95">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P295" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.94">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N116" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L116" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P296" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.95">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.61">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N117" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L117" height="15.0" width="42.0" text="Const8"/>
+      <ports identifier="P298" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.96">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.102">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N118" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L118" height="15.0" width="94.0" text="MultiplyDivide13"/>
+      <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.96 //@children.1/@containedEdges.103">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P302" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.97">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N119" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L119" height="15.0" width="42.0" text="Const9"/>
+      <ports identifier="P303" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.98">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.100">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N120" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L120" height="15.0" width="94.0" text="MultiplyDivide14"/>
+      <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.98 //@children.1/@containedEdges.101">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P307" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.99">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N121" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L121" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.89">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.85">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P310" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.100 //@children.1/@containedEdges.101">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N122" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L122" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.88">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.86">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P313" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.102 //@children.1/@containedEdges.103">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N123" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L123" height="15.0" width="78.0" text="MostRecent4"/>
+      <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.87">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P315" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.104">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P316" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.1/@containedEdges.62">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N124" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L124" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.94 //@children.1/@containedEdges.104">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P319" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.105">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E122" sources="//@children.1/@ports.0" targets="//@children.1/@children.49/@ports.0"/>
+    <containedEdges identifier="E123" sources="//@children.1/@ports.0" targets="//@children.1/@children.52/@ports.0"/>
+    <containedEdges identifier="E124" sources="//@children.1/@ports.1" targets="//@children.1/@children.50/@ports.0"/>
+    <containedEdges identifier="E125" sources="//@children.1/@ports.1" targets="//@children.1/@children.52/@ports.0"/>
+    <containedEdges identifier="E126" sources="//@children.1/@ports.2" targets="//@children.1/@children.51/@ports.0"/>
+    <containedEdges identifier="E127" sources="//@children.1/@ports.2" targets="//@children.1/@children.52/@ports.0"/>
+    <containedEdges identifier="E128" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E129" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E130" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.15/@ports.1"/>
+    <containedEdges identifier="E131" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.19/@ports.0"/>
+    <containedEdges identifier="E132" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.38/@ports.0"/>
+    <containedEdges identifier="E133" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E134" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E135" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.16/@ports.1"/>
+    <containedEdges identifier="E136" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E137" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.41/@ports.0"/>
+    <containedEdges identifier="E138" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E139" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E140" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E141" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E142" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E143" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.27/@ports.0"/>
+    <containedEdges identifier="E145" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.32/@ports.0"/>
+    <containedEdges identifier="E146" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.15/@ports.0"/>
+    <containedEdges identifier="E147" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.18/@ports.0"/>
+    <containedEdges identifier="E148" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.16/@ports.0"/>
+    <containedEdges identifier="E149" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.20/@ports.0"/>
+    <containedEdges identifier="E150" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E151" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.35/@ports.0"/>
+    <containedEdges identifier="E152" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.13/@ports.0"/>
+    <containedEdges identifier="E153" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.15/@ports.0"/>
+    <containedEdges identifier="E154" sources="//@children.1/@children.10/@ports.2" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E155" sources="//@children.1/@children.10/@ports.2" targets="//@children.1/@children.39/@ports.0"/>
+    <containedEdges identifier="E156" sources="//@children.1/@children.10/@ports.2" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E157" sources="//@children.1/@children.10/@ports.2" targets="//@children.1/@children.16/@ports.0"/>
+    <containedEdges identifier="E158" sources="//@children.1/@children.11/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E159" sources="//@children.1/@children.12/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E160" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E161" sources="//@children.1/@children.14/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E162" sources="//@children.1/@children.15/@ports.2" targets="//@children.1/@children.17/@ports.1"/>
+    <containedEdges identifier="E163" sources="//@children.1/@children.16/@ports.2" targets="//@children.1/@children.17/@ports.1"/>
+    <containedEdges identifier="E164" sources="//@children.1/@children.17/@ports.2" targets="//@children.1/@children.25/@ports.0"/>
+    <containedEdges identifier="E165" sources="//@children.1/@children.17/@ports.2" targets="//@children.1/@children.30/@ports.1"/>
+    <containedEdges identifier="E166" sources="//@children.1/@children.18/@ports.1" targets="//@children.1/@children.22/@ports.0"/>
+    <containedEdges identifier="E167" sources="//@children.1/@children.19/@ports.1" targets="//@children.1/@children.22/@ports.1"/>
+    <containedEdges identifier="E168" sources="//@children.1/@children.20/@ports.1" targets="//@children.1/@children.23/@ports.0"/>
+    <containedEdges identifier="E169" sources="//@children.1/@children.21/@ports.1" targets="//@children.1/@children.23/@ports.1"/>
+    <containedEdges identifier="E170" sources="//@children.1/@children.22/@ports.2" targets="//@children.1/@children.24/@ports.1"/>
+    <containedEdges identifier="E171" sources="//@children.1/@children.23/@ports.2" targets="//@children.1/@children.24/@ports.1"/>
+    <containedEdges identifier="E172" sources="//@children.1/@children.24/@ports.2" targets="//@children.1/@children.26/@ports.0"/>
+    <containedEdges identifier="E173" sources="//@children.1/@children.25/@ports.1" targets="//@children.1/@children.28/@ports.0"/>
+    <containedEdges identifier="E174" sources="//@children.1/@children.26/@ports.2" targets="//@children.1/@children.28/@ports.1"/>
+    <containedEdges identifier="E175" sources="//@children.1/@children.27/@ports.1" targets="//@children.1/@children.26/@ports.0"/>
+    <containedEdges identifier="E176" sources="//@children.1/@children.28/@ports.2" targets="//@children.1/@children.34/@ports.0"/>
+    <containedEdges identifier="E177" sources="//@children.1/@children.29/@ports.1" targets="//@children.1/@children.33/@ports.0"/>
+    <containedEdges identifier="E178" sources="//@children.1/@children.30/@ports.2" targets="//@children.1/@children.31/@ports.0"/>
+    <containedEdges identifier="E179" sources="//@children.1/@children.31/@ports.2" targets="//@children.1/@children.35/@ports.1"/>
+    <containedEdges identifier="E180" sources="//@children.1/@children.31/@ports.2" targets="//@children.1/@children.36/@ports.0"/>
+    <containedEdges identifier="E181" sources="//@children.1/@children.31/@ports.2" targets="//@children.1/@children.39/@ports.1"/>
+    <containedEdges identifier="E182" sources="//@children.1/@children.31/@ports.2" targets="//@children.1/@children.54/@ports.0"/>
+    <containedEdges identifier="E183" sources="//@children.1/@children.31/@ports.2" targets="//@children.1/@children.55/@ports.1"/>
+    <containedEdges identifier="E184" sources="//@children.1/@children.31/@ports.2" targets="//@children.1/@children.62/@ports.2"/>
+    <containedEdges identifier="E185" sources="//@children.1/@children.32/@ports.1" targets="//@children.1/@children.31/@ports.1"/>
+    <containedEdges identifier="E186" sources="//@children.1/@children.33/@ports.1" targets="//@children.1/@children.30/@ports.0"/>
+    <containedEdges identifier="E187" sources="//@children.1/@children.34/@ports.1" targets="//@children.1/@children.29/@ports.0"/>
+    <containedEdges identifier="E188" sources="//@children.1/@children.35/@ports.2" targets="//@children.1/@children.37/@ports.0"/>
+    <containedEdges identifier="E189" sources="//@children.1/@children.36/@ports.1" targets="//@children.1/@children.38/@ports.0"/>
+    <containedEdges identifier="E190" sources="//@children.1/@children.36/@ports.1" targets="//@children.1/@children.41/@ports.0"/>
+    <containedEdges identifier="E191" sources="//@children.1/@children.37/@ports.1" targets="//@children.1/@children.38/@ports.1"/>
+    <containedEdges identifier="E192" sources="//@children.1/@children.38/@ports.2" targets="//@children.1/@children.46/@ports.0"/>
+    <containedEdges identifier="E193" sources="//@children.1/@children.39/@ports.2" targets="//@children.1/@children.40/@ports.0"/>
+    <containedEdges identifier="E194" sources="//@children.1/@children.40/@ports.1" targets="//@children.1/@children.41/@ports.1"/>
+    <containedEdges identifier="E195" sources="//@children.1/@children.41/@ports.2" targets="//@children.1/@children.47/@ports.0"/>
+    <containedEdges identifier="E196" sources="//@children.1/@children.42/@ports.1" targets="//@children.1/@children.46/@ports.1"/>
+    <containedEdges identifier="E197" sources="//@children.1/@children.43/@ports.1" targets="//@children.1/@children.47/@ports.1"/>
+    <containedEdges identifier="E198" sources="//@children.1/@children.44/@ports.0" targets="//@children.1/@children.42/@ports.0"/>
+    <containedEdges identifier="E199" sources="//@children.1/@children.45/@ports.0" targets="//@children.1/@children.43/@ports.0"/>
+    <containedEdges identifier="E200" sources="//@children.1/@children.46/@ports.2" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E201" sources="//@children.1/@children.47/@ports.2" targets="//@children.1/@ports.4"/>
+    <containedEdges identifier="E202" sources="//@children.1/@children.48/@ports.0" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E203" sources="//@children.1/@children.48/@ports.0" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E204" sources="//@children.1/@children.48/@ports.0" targets="//@children.1/@children.12/@ports.1"/>
+    <containedEdges identifier="E205" sources="//@children.1/@children.48/@ports.0" targets="//@children.1/@children.44/@ports.1"/>
+    <containedEdges identifier="E206" sources="//@children.1/@children.48/@ports.0" targets="//@children.1/@children.45/@ports.1"/>
+    <containedEdges identifier="E207" sources="//@children.1/@children.49/@ports.1" targets="//@children.1/@children.60/@ports.1"/>
+    <containedEdges identifier="E208" sources="//@children.1/@children.49/@ports.1" targets="//@children.1/@children.61/@ports.1"/>
+    <containedEdges identifier="E209" sources="//@children.1/@children.49/@ports.1" targets="//@children.1/@children.62/@ports.0"/>
+    <containedEdges identifier="E210" sources="//@children.1/@children.50/@ports.1" targets="//@children.1/@children.61/@ports.0"/>
+    <containedEdges identifier="E211" sources="//@children.1/@children.51/@ports.1" targets="//@children.1/@children.60/@ports.0"/>
+    <containedEdges identifier="E212" sources="//@children.1/@children.52/@ports.1" targets="//@children.1/@children.53/@ports.0"/>
+    <containedEdges identifier="E213" sources="//@children.1/@children.53/@ports.1" targets="//@children.1/@children.49/@ports.2"/>
+    <containedEdges identifier="E214" sources="//@children.1/@children.53/@ports.1" targets="//@children.1/@children.50/@ports.2"/>
+    <containedEdges identifier="E215" sources="//@children.1/@children.53/@ports.1" targets="//@children.1/@children.51/@ports.2"/>
+    <containedEdges identifier="E216" sources="//@children.1/@children.54/@ports.2" targets="//@children.1/@children.63/@ports.0"/>
+    <containedEdges identifier="E217" sources="//@children.1/@children.55/@ports.0" targets="//@children.1/@children.54/@ports.1"/>
+    <containedEdges identifier="E218" sources="//@children.1/@children.56/@ports.0" targets="//@children.1/@children.57/@ports.0"/>
+    <containedEdges identifier="E219" sources="//@children.1/@children.57/@ports.2" targets="//@children.1/@children.48/@ports.1"/>
+    <containedEdges identifier="E220" sources="//@children.1/@children.58/@ports.0" targets="//@children.1/@children.59/@ports.0"/>
+    <containedEdges identifier="E221" sources="//@children.1/@children.59/@ports.2" targets="//@children.1/@children.48/@ports.2"/>
+    <containedEdges identifier="E222" sources="//@children.1/@children.60/@ports.2" targets="//@children.1/@children.58/@ports.1"/>
+    <containedEdges identifier="E223" sources="//@children.1/@children.60/@ports.2" targets="//@children.1/@children.59/@ports.0"/>
+    <containedEdges identifier="E224" sources="//@children.1/@children.61/@ports.2" targets="//@children.1/@children.56/@ports.1"/>
+    <containedEdges identifier="E225" sources="//@children.1/@children.61/@ports.2" targets="//@children.1/@children.57/@ports.0"/>
+    <containedEdges identifier="E226" sources="//@children.1/@children.62/@ports.1" targets="//@children.1/@children.63/@ports.0"/>
+    <containedEdges identifier="E227" sources="//@children.1/@children.63/@ports.2" targets="//@children.1/@ports.5"/>
+  </children>
+  <children identifier="N125">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L125" height="15.0" width="108.0" text="StatisticsAndPlots"/>
+    <ports identifier="P320" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.9 //@children.2/@containedEdges.10" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P321" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P322" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P323" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4 //@children.2/@containedEdges.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.6" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P325" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.8" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P326" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.13" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P327" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.14" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N126" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L126" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P330" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N127" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L127" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P333" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N128" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L128" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P336" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N129" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L129" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P338" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P339" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N130" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L130" height="15.0" width="78.0" text="MostRecent2"/>
+      <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P341" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P342" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N131" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L131" height="15.0" width="78.0" text="MostRecent3"/>
+      <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P344" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P345" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N132" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L132" height="15.0" width="114.0" text="UnaryMathFunction"/>
+      <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P347" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N133" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L133" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+      <ports identifier="P348" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P349" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N134" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L134" height="15.0" width="80.0" text="AddSubtract4"/>
+      <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.21 //@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P352" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N135" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L135" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+      <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P354" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N136">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L136" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P355" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.10/@containedEdges.0 //@children.2/@children.10/@containedEdges.1 //@children.2/@children.10/@containedEdges.2 //@children.2/@children.10/@containedEdges.3" incomingEdges="//@children.2/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P356" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.26 //@children.2/@containedEdges.27 //@children.2/@containedEdges.28 //@children.2/@containedEdges.29" incomingEdges="//@children.2/@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P357" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.25" incomingEdges="//@children.2/@children.10/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N137" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L137" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P358" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N138" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L138" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P361" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.5 //@children.2/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N139" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L139" height="15.0" width="81.0" text="Accumulator2"/>
+        <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P364" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N140" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L140" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P367" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P368" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.8 //@children.2/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N141" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L141" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P370" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P371" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.10/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N142" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L142" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P372" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P373" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.11 //@children.2/@children.10/@containedEdges.12 //@children.2/@children.10/@containedEdges.13 //@children.2/@children.10/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P374" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.10/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N143" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="40.0" text="Equals"/>
+        <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.10/@containedEdges.6 //@children.2/@children.10/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P376" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@children.10/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N144" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L144" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P377" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.2/@children.10/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P378" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N145" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L145" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P379" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.10/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P380" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.2/@children.10/@containedEdges.17 //@children.2/@children.10/@containedEdges.18 //@children.2/@children.10/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N146" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L146" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P382" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.2/@children.10/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N147" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L147" height="15.0" width="81.0" text="Accumulator3"/>
+        <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P384" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P385" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N148" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L148" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.10/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P387" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P388" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.10/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N149" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L149" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.12 //@children.2/@children.10/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P390" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P391" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N150" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L150" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.10/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P394" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N151" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L151" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P395" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P396" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.2/@children.10/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N152" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L152" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.10/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P399" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N153" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L153" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P400" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@children.10/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P401" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.10/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N154" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L154" height="15.0" width="87.0" text="MultiplyDivide3"/>
+        <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.10/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P404" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N155" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L155" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.10/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P406" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N156" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L156" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.10/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P408" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.2/@children.10/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E287" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E288" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.10/@children.2/@ports.0"/>
+      <containedEdges identifier="E289" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.10/@children.7/@ports.1"/>
+      <containedEdges identifier="E290" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.10/@children.9/@ports.0"/>
+      <containedEdges identifier="E291" sources="//@children.2/@children.10/@children.0/@ports.0" targets="//@children.2/@children.10/@children.1/@ports.0"/>
+      <containedEdges identifier="E292" sources="//@children.2/@children.10/@children.1/@ports.1" targets="//@children.2/@children.10/@children.5/@ports.0"/>
+      <containedEdges identifier="E293" sources="//@children.2/@children.10/@children.1/@ports.1" targets="//@children.2/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E294" sources="//@children.2/@children.10/@children.2/@ports.1" targets="//@children.2/@children.10/@children.4/@ports.0"/>
+      <containedEdges identifier="E295" sources="//@children.2/@children.10/@children.3/@ports.2" targets="//@children.2/@children.10/@ports.1"/>
+      <containedEdges identifier="E296" sources="//@children.2/@children.10/@children.3/@ports.2" targets="//@children.2/@children.10/@children.14/@ports.0"/>
+      <containedEdges identifier="E297" sources="//@children.2/@children.10/@children.4/@ports.1" targets="//@children.2/@children.10/@children.3/@ports.0"/>
+      <containedEdges identifier="E298" sources="//@children.2/@children.10/@children.5/@ports.1" targets="//@children.2/@children.10/@children.3/@ports.1"/>
+      <containedEdges identifier="E299" sources="//@children.2/@children.10/@children.5/@ports.1" targets="//@children.2/@children.10/@children.12/@ports.0"/>
+      <containedEdges identifier="E300" sources="//@children.2/@children.10/@children.5/@ports.1" targets="//@children.2/@children.10/@children.15/@ports.0"/>
+      <containedEdges identifier="E301" sources="//@children.2/@children.10/@children.5/@ports.1" targets="//@children.2/@children.10/@children.16/@ports.1"/>
+      <containedEdges identifier="E302" sources="//@children.2/@children.10/@children.6/@ports.1" targets="//@children.2/@children.10/@children.8/@ports.0"/>
+      <containedEdges identifier="E303" sources="//@children.2/@children.10/@children.7/@ports.0" targets="//@children.2/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E304" sources="//@children.2/@children.10/@children.8/@ports.1" targets="//@children.2/@children.10/@children.4/@ports.2"/>
+      <containedEdges identifier="E305" sources="//@children.2/@children.10/@children.8/@ports.1" targets="//@children.2/@children.10/@children.5/@ports.2"/>
+      <containedEdges identifier="E306" sources="//@children.2/@children.10/@children.8/@ports.1" targets="//@children.2/@children.10/@children.11/@ports.2"/>
+      <containedEdges identifier="E307" sources="//@children.2/@children.10/@children.9/@ports.1" targets="//@children.2/@children.10/@children.10/@ports.0"/>
+      <containedEdges identifier="E308" sources="//@children.2/@children.10/@children.10/@ports.1" targets="//@children.2/@children.10/@children.11/@ports.0"/>
+      <containedEdges identifier="E309" sources="//@children.2/@children.10/@children.11/@ports.1" targets="//@children.2/@children.10/@children.13/@ports.0"/>
+      <containedEdges identifier="E310" sources="//@children.2/@children.10/@children.12/@ports.2" targets="//@children.2/@children.10/@children.13/@ports.1"/>
+      <containedEdges identifier="E311" sources="//@children.2/@children.10/@children.13/@ports.2" targets="//@children.2/@children.10/@children.17/@ports.0"/>
+      <containedEdges identifier="E312" sources="//@children.2/@children.10/@children.14/@ports.1" targets="//@children.2/@children.10/@children.12/@ports.0"/>
+      <containedEdges identifier="E313" sources="//@children.2/@children.10/@children.15/@ports.2" targets="//@children.2/@children.10/@children.18/@ports.0"/>
+      <containedEdges identifier="E314" sources="//@children.2/@children.10/@children.16/@ports.0" targets="//@children.2/@children.10/@children.15/@ports.1"/>
+      <containedEdges identifier="E315" sources="//@children.2/@children.10/@children.17/@ports.2" targets="//@children.2/@children.10/@children.19/@ports.0"/>
+      <containedEdges identifier="E316" sources="//@children.2/@children.10/@children.18/@ports.1" targets="//@children.2/@children.10/@children.17/@ports.1"/>
+      <containedEdges identifier="E317" sources="//@children.2/@children.10/@children.19/@ports.1" targets="//@children.2/@children.10/@ports.2"/>
+    </children>
+    <children identifier="N157">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L157" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P409" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.11/@containedEdges.0 //@children.2/@children.11/@containedEdges.1 //@children.2/@children.11/@containedEdges.2 //@children.2/@children.11/@containedEdges.3" incomingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P410" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.31 //@children.2/@containedEdges.32 //@children.2/@containedEdges.33 //@children.2/@containedEdges.34" incomingEdges="//@children.2/@children.11/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P411" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.30" incomingEdges="//@children.2/@children.11/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N158" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L158" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P412" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@children.11/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P413" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.11/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N159" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L159" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P415" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.5 //@children.2/@children.11/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P416" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N160" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L160" height="15.0" width="81.0" text="Accumulator2"/>
+        <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P418" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N161" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L161" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P420" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.11/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P422" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.8 //@children.2/@children.11/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N162" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L162" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P424" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P425" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.11/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N163" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L163" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P426" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.11/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P427" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.11 //@children.2/@children.11/@containedEdges.12 //@children.2/@children.11/@containedEdges.13 //@children.2/@children.11/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P428" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.11/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N164" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L164" height="15.0" width="40.0" text="Equals"/>
+        <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.11/@containedEdges.6 //@children.2/@children.11/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P430" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@children.11/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N165" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L165" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P431" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.2/@children.11/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N166" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L166" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P433" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.11/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P434" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.2/@children.11/@containedEdges.17 //@children.2/@children.11/@containedEdges.18 //@children.2/@children.11/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N167" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L167" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P436" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.2/@children.11/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N168" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L168" height="15.0" width="81.0" text="Accumulator3"/>
+        <ports identifier="P437" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P438" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P439" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N169" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L169" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P440" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.11/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P441" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P442" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.11/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N170" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L170" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P443" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.12 //@children.2/@children.11/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P444" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P445" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N171" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L171" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P447" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.11/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P448" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N172" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L172" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.11/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P450" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.2/@children.11/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N173" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L173" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P451" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.11/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P453" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N174" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L174" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P454" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@children.11/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.11/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N175" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L175" height="15.0" width="87.0" text="MultiplyDivide3"/>
+        <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.11/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.11/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P458" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N176" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L176" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P459" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.11/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P460" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.11/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N177" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L177" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P461" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.11/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P462" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.2/@children.11/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E318" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.11/@children.0/@ports.1"/>
+      <containedEdges identifier="E319" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.11/@children.2/@ports.0"/>
+      <containedEdges identifier="E320" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.11/@children.7/@ports.1"/>
+      <containedEdges identifier="E321" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.11/@children.9/@ports.0"/>
+      <containedEdges identifier="E322" sources="//@children.2/@children.11/@children.0/@ports.0" targets="//@children.2/@children.11/@children.1/@ports.0"/>
+      <containedEdges identifier="E323" sources="//@children.2/@children.11/@children.1/@ports.1" targets="//@children.2/@children.11/@children.5/@ports.0"/>
+      <containedEdges identifier="E324" sources="//@children.2/@children.11/@children.1/@ports.1" targets="//@children.2/@children.11/@children.6/@ports.0"/>
+      <containedEdges identifier="E325" sources="//@children.2/@children.11/@children.2/@ports.1" targets="//@children.2/@children.11/@children.4/@ports.0"/>
+      <containedEdges identifier="E326" sources="//@children.2/@children.11/@children.3/@ports.2" targets="//@children.2/@children.11/@ports.1"/>
+      <containedEdges identifier="E327" sources="//@children.2/@children.11/@children.3/@ports.2" targets="//@children.2/@children.11/@children.14/@ports.0"/>
+      <containedEdges identifier="E328" sources="//@children.2/@children.11/@children.4/@ports.1" targets="//@children.2/@children.11/@children.3/@ports.0"/>
+      <containedEdges identifier="E329" sources="//@children.2/@children.11/@children.5/@ports.1" targets="//@children.2/@children.11/@children.3/@ports.1"/>
+      <containedEdges identifier="E330" sources="//@children.2/@children.11/@children.5/@ports.1" targets="//@children.2/@children.11/@children.12/@ports.0"/>
+      <containedEdges identifier="E331" sources="//@children.2/@children.11/@children.5/@ports.1" targets="//@children.2/@children.11/@children.15/@ports.0"/>
+      <containedEdges identifier="E332" sources="//@children.2/@children.11/@children.5/@ports.1" targets="//@children.2/@children.11/@children.16/@ports.1"/>
+      <containedEdges identifier="E333" sources="//@children.2/@children.11/@children.6/@ports.1" targets="//@children.2/@children.11/@children.8/@ports.0"/>
+      <containedEdges identifier="E334" sources="//@children.2/@children.11/@children.7/@ports.0" targets="//@children.2/@children.11/@children.6/@ports.0"/>
+      <containedEdges identifier="E335" sources="//@children.2/@children.11/@children.8/@ports.1" targets="//@children.2/@children.11/@children.4/@ports.2"/>
+      <containedEdges identifier="E336" sources="//@children.2/@children.11/@children.8/@ports.1" targets="//@children.2/@children.11/@children.5/@ports.2"/>
+      <containedEdges identifier="E337" sources="//@children.2/@children.11/@children.8/@ports.1" targets="//@children.2/@children.11/@children.11/@ports.2"/>
+      <containedEdges identifier="E338" sources="//@children.2/@children.11/@children.9/@ports.1" targets="//@children.2/@children.11/@children.10/@ports.0"/>
+      <containedEdges identifier="E339" sources="//@children.2/@children.11/@children.10/@ports.1" targets="//@children.2/@children.11/@children.11/@ports.0"/>
+      <containedEdges identifier="E340" sources="//@children.2/@children.11/@children.11/@ports.1" targets="//@children.2/@children.11/@children.13/@ports.0"/>
+      <containedEdges identifier="E341" sources="//@children.2/@children.11/@children.12/@ports.2" targets="//@children.2/@children.11/@children.13/@ports.1"/>
+      <containedEdges identifier="E342" sources="//@children.2/@children.11/@children.13/@ports.2" targets="//@children.2/@children.11/@children.17/@ports.0"/>
+      <containedEdges identifier="E343" sources="//@children.2/@children.11/@children.14/@ports.1" targets="//@children.2/@children.11/@children.12/@ports.0"/>
+      <containedEdges identifier="E344" sources="//@children.2/@children.11/@children.15/@ports.2" targets="//@children.2/@children.11/@children.18/@ports.0"/>
+      <containedEdges identifier="E345" sources="//@children.2/@children.11/@children.16/@ports.0" targets="//@children.2/@children.11/@children.15/@ports.1"/>
+      <containedEdges identifier="E346" sources="//@children.2/@children.11/@children.17/@ports.2" targets="//@children.2/@children.11/@children.19/@ports.0"/>
+      <containedEdges identifier="E347" sources="//@children.2/@children.11/@children.18/@ports.1" targets="//@children.2/@children.11/@children.17/@ports.1"/>
+      <containedEdges identifier="E348" sources="//@children.2/@children.11/@children.19/@ports.1" targets="//@children.2/@children.11/@ports.2"/>
+    </children>
+    <children identifier="N178" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L178" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P463" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P465" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N179" height="41.0" width="320.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L179" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P466" height="8.0" width="8.0" x="320.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P467" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N180" height="40.0" width="403.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L180" height="15.0" width="76.0" text="StringConst2"/>
+      <ports identifier="P468" height="8.0" width="8.0" x="403.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P469" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N181" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L181" height="15.0" width="111.0" text="RecordAssembler2"/>
+      <ports identifier="P470" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P471" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P472" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N182" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L182" height="15.0" width="111.0" text="RecordAssembler3"/>
+      <ports identifier="P473" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P475" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N183" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L183" height="15.0" width="111.0" text="RecordAssembler4"/>
+      <ports identifier="P476" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P478" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N184" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L184" height="15.0" width="111.0" text="RecordAssembler5"/>
+      <ports identifier="P479" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N185">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L185" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P482" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.42" incomingEdges="//@children.2/@children.19/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P483" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.43" incomingEdges="//@children.2/@children.19/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N186" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L186" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P484" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.19/@containedEdges.0 //@children.2/@children.19/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P486" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P487" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P488" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N187" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L187" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P489" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.2/@children.19/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P490" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.2/@children.19/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N188" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L188" height="15.0" width="66.0" text="Sequence2"/>
+        <ports identifier="P491" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.2/@children.19/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P492" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.2/@children.19/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N189" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L189" height="15.0" width="82.0" text="LogicFunction"/>
+        <ports identifier="P493" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.19/@containedEdges.0 //@children.2/@children.19/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P494" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.2/@children.19/@containedEdges.4 //@children.2/@children.19/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N190" height="25.0" width="68.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L190" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P495" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.2/@children.19/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.19/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E349" sources="//@children.2/@children.19/@children.0/@ports.0" targets="//@children.2/@children.19/@children.3/@ports.0"/>
+      <containedEdges identifier="E350" sources="//@children.2/@children.19/@children.0/@ports.0" targets="//@children.2/@children.19/@children.4/@ports.1"/>
+      <containedEdges identifier="E351" sources="//@children.2/@children.19/@children.1/@ports.1" targets="//@children.2/@children.19/@ports.0"/>
+      <containedEdges identifier="E352" sources="//@children.2/@children.19/@children.2/@ports.1" targets="//@children.2/@children.19/@ports.1"/>
+      <containedEdges identifier="E353" sources="//@children.2/@children.19/@children.3/@ports.1" targets="//@children.2/@children.19/@children.1/@ports.0"/>
+      <containedEdges identifier="E354" sources="//@children.2/@children.19/@children.3/@ports.1" targets="//@children.2/@children.19/@children.2/@ports.0"/>
+      <containedEdges identifier="E355" sources="//@children.2/@children.19/@children.4/@ports.0" targets="//@children.2/@children.19/@children.3/@ports.0"/>
+    </children>
+    <children identifier="N191" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L191" height="15.0" width="67.0" text="XYPlotPath"/>
+      <ports identifier="P497" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.44 //@children.2/@containedEdges.45 //@children.2/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P498" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.46 //@children.2/@containedEdges.47 //@children.2/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N192" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L192" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P500" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P501" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N193" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L193" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P502" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P503" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P504" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N194" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L194" height="15.0" width="128.0" text="RecordDisassembler3"/>
+      <ports identifier="P505" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P506" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P507" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N195" height="25.0" width="134.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L195" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P508" height="8.0" width="8.0" x="134.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N196" height="40.0" width="431.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L196" height="15.0" width="76.0" text="StringConst6"/>
+      <ports identifier="P510" height="8.0" width="8.0" x="431.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P511" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N197" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L197" height="15.0" width="78.0" text="MostRecent4"/>
+      <ports identifier="P512" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P513" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P514" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N198" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L198" height="15.0" width="128.0" text="RecordDisassembler4"/>
+      <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P516" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P517" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.54">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N199" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L199" height="15.0" width="59.0" text="ErrorStats"/>
+      <ports identifier="P518" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.35 //@children.2/@containedEdges.36 //@children.2/@containedEdges.37 //@children.2/@containedEdges.38 //@children.2/@containedEdges.50 //@children.2/@containedEdges.51 //@children.2/@containedEdges.53 //@children.2/@containedEdges.54 //@children.2/@containedEdges.56 //@children.2/@containedEdges.57 //@children.2/@containedEdges.58">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N200" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L200" height="15.0" width="78.0" text="MostRecent5"/>
+      <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P520" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P521" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N201" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L201" height="15.0" width="128.0" text="RecordDisassembler5"/>
+      <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P523" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.2/@containedEdges.56">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P524" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.57">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P525" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.2/@containedEdges.58">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E228" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E229" sources="//@children.2/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E230" sources="//@children.2/@ports.1" targets="//@children.2/@children.16/@ports.2"/>
+    <containedEdges identifier="E231" sources="//@children.2/@ports.3" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E232" sources="//@children.2/@ports.3" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E233" sources="//@children.2/@ports.3" targets="//@children.2/@children.17/@ports.2"/>
+    <containedEdges identifier="E234" sources="//@children.2/@ports.4" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E235" sources="//@children.2/@ports.5" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E236" sources="//@children.2/@ports.5" targets="//@children.2/@children.5/@ports.2"/>
+    <containedEdges identifier="E237" sources="//@children.2/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E238" sources="//@children.2/@ports.0" targets="//@children.2/@children.16/@ports.1"/>
+    <containedEdges identifier="E239" sources="//@children.2/@ports.2" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E240" sources="//@children.2/@ports.2" targets="//@children.2/@children.17/@ports.1"/>
+    <containedEdges identifier="E241" sources="//@children.2/@ports.6" targets="//@children.2/@children.26/@ports.0"/>
+    <containedEdges identifier="E242" sources="//@children.2/@ports.7" targets="//@children.2/@children.29/@ports.0"/>
+    <containedEdges identifier="E243" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E244" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E245" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.11/@ports.0"/>
+    <containedEdges identifier="E246" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E247" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E248" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E249" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E250" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E251" sources="//@children.2/@children.8/@ports.2" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E252" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E253" sources="//@children.2/@children.10/@ports.2" targets="//@children.2/@children.12/@ports.2"/>
+    <containedEdges identifier="E254" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.12/@ports.1"/>
+    <containedEdges identifier="E255" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.13/@ports.1"/>
+    <containedEdges identifier="E256" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.24/@ports.1"/>
+    <containedEdges identifier="E257" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.29/@ports.2"/>
+    <containedEdges identifier="E258" sources="//@children.2/@children.11/@ports.2" targets="//@children.2/@children.15/@ports.2"/>
+    <containedEdges identifier="E259" sources="//@children.2/@children.11/@ports.1" targets="//@children.2/@children.14/@ports.1"/>
+    <containedEdges identifier="E260" sources="//@children.2/@children.11/@ports.1" targets="//@children.2/@children.15/@ports.1"/>
+    <containedEdges identifier="E261" sources="//@children.2/@children.11/@ports.1" targets="//@children.2/@children.25/@ports.1"/>
+    <containedEdges identifier="E262" sources="//@children.2/@children.11/@ports.1" targets="//@children.2/@children.26/@ports.2"/>
+    <containedEdges identifier="E263" sources="//@children.2/@children.12/@ports.0" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E264" sources="//@children.2/@children.13/@ports.0" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E265" sources="//@children.2/@children.14/@ports.0" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E266" sources="//@children.2/@children.15/@ports.0" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E267" sources="//@children.2/@children.16/@ports.0" targets="//@children.2/@children.21/@ports.0"/>
+    <containedEdges identifier="E268" sources="//@children.2/@children.17/@ports.0" targets="//@children.2/@children.22/@ports.0"/>
+    <containedEdges identifier="E269" sources="//@children.2/@children.18/@ports.0" targets="//@children.2/@children.23/@ports.0"/>
+    <containedEdges identifier="E270" sources="//@children.2/@children.19/@ports.0" targets="//@children.2/@children.18/@ports.1"/>
+    <containedEdges identifier="E271" sources="//@children.2/@children.19/@ports.1" targets="//@children.2/@children.18/@ports.2"/>
+    <containedEdges identifier="E272" sources="//@children.2/@children.21/@ports.1" targets="//@children.2/@children.20/@ports.0"/>
+    <containedEdges identifier="E273" sources="//@children.2/@children.21/@ports.2" targets="//@children.2/@children.20/@ports.0"/>
+    <containedEdges identifier="E274" sources="//@children.2/@children.22/@ports.1" targets="//@children.2/@children.20/@ports.1"/>
+    <containedEdges identifier="E275" sources="//@children.2/@children.22/@ports.2" targets="//@children.2/@children.20/@ports.1"/>
+    <containedEdges identifier="E276" sources="//@children.2/@children.23/@ports.1" targets="//@children.2/@children.20/@ports.0"/>
+    <containedEdges identifier="E277" sources="//@children.2/@children.23/@ports.2" targets="//@children.2/@children.20/@ports.1"/>
+    <containedEdges identifier="E278" sources="//@children.2/@children.24/@ports.0" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E279" sources="//@children.2/@children.25/@ports.0" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E280" sources="//@children.2/@children.26/@ports.1" targets="//@children.2/@children.27/@ports.0"/>
+    <containedEdges identifier="E281" sources="//@children.2/@children.27/@ports.1" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E282" sources="//@children.2/@children.27/@ports.2" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E283" sources="//@children.2/@children.29/@ports.1" targets="//@children.2/@children.30/@ports.0"/>
+    <containedEdges identifier="E284" sources="//@children.2/@children.30/@ports.1" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E285" sources="//@children.2/@children.30/@ports.2" targets="//@children.2/@children.28/@ports.0"/>
+    <containedEdges identifier="E286" sources="//@children.2/@children.30/@ports.3" targets="//@children.2/@children.28/@ports.0"/>
+  </children>
+  <children identifier="N202">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L202" height="15.0" width="112.0" text="SystemParameters"/>
+    <ports identifier="P526" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.3/@containedEdges.96">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N203" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L203" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P527" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2 //@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5 //@children.3/@containedEdges.6 //@children.3/@containedEdges.7 //@children.3/@containedEdges.8 //@children.3/@containedEdges.9 //@children.3/@containedEdges.10 //@children.3/@containedEdges.11 //@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N204" height="25.0" width="85.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L204" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P528" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.13 //@children.3/@containedEdges.14 //@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P529" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N205" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L205" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P531" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N206" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L206" height="15.0" width="74.0" text="SetVariable4"/>
+      <ports identifier="P532" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P533" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N207" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L207" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P534" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N208" height="25.0" width="85.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L208" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P536" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P537" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N209" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L209" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P538" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.18 //@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N210" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L210" height="15.0" width="54.0" text="TrueGate"/>
+      <ports identifier="P540" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P541" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.20 //@children.3/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N211" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L211" height="15.0" width="61.0" text="TrueGate2"/>
+      <ports identifier="P542" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P543" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.22 //@children.3/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N212" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L212" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P544" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P545" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N213" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L213" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.16 //@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P547" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N214" height="25.0" width="90.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L214" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P548" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.26 //@children.3/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N215" height="25.0" width="74.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L215" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P550" height="8.0" width="8.0" x="74.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.28 //@children.3/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N216" height="25.0" width="84.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L216" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P552" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P553" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N217" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L217" height="15.0" width="42.0" text="Const8"/>
+      <ports identifier="P554" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P555" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N218" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L218" height="15.0" width="42.0" text="Const9"/>
+      <ports identifier="P556" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N219" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L219" height="15.0" width="61.0" text="TrueGate3"/>
+      <ports identifier="P558" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P559" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.33 //@children.3/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N220" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L220" height="15.0" width="61.0" text="TrueGate4"/>
+      <ports identifier="P560" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P561" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.35 //@children.3/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N221" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L221" height="15.0" width="69.0" text="LogicalNot2"/>
+      <ports identifier="P562" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P563" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N222" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L222" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P564" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.31 //@children.3/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P565" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N223" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L223" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P567" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N224" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L224" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P568" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.28 //@children.3/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P569" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N225" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L225" height="15.0" width="69.0" text="LogicalNot3"/>
+      <ports identifier="P570" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P571" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.40 //@children.3/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N226" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L226" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.3/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.3/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P574" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N227" height="25.0" width="72.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L227" height="15.0" width="49.0" text="Const10"/>
+      <ports identifier="P575" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P576" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N228" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L228" height="15.0" width="48.0" text="Const11"/>
+      <ports identifier="P577" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P578" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N229" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L229" height="15.0" width="61.0" text="TrueGate5"/>
+      <ports identifier="P579" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P580" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N230" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L230" height="15.0" width="93.0" text="ThrowException"/>
+      <ports identifier="P581" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N231" height="39.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L231" height="15.0" width="28.0" text="Stop"/>
+      <ports identifier="P582" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@children.3/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N232" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L232" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P583" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N233" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L233" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P584" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.3/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P585" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.3/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P586" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N234" height="25.0" width="108.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L234" height="15.0" width="49.0" text="Const12"/>
+      <ports identifier="P587" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P588" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N235" height="25.0" width="153.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L235" height="15.0" width="49.0" text="Const13"/>
+      <ports identifier="P589" height="8.0" width="8.0" x="153.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N236" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L236" height="15.0" width="61.0" text="TrueGate6"/>
+      <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P592" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N237" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L237" height="15.0" width="100.0" text="ThrowException2"/>
+      <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N238" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L238" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P594" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.41 //@children.3/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P595" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N239" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L239" height="15.0" width="69.0" text="LogicalNot4"/>
+      <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P597" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N240" height="25.0" width="84.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L240" height="15.0" width="49.0" text="Const14"/>
+      <ports identifier="P598" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N241" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L241" height="15.0" width="49.0" text="Const15"/>
+      <ports identifier="P600" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.54">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.66">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N242" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L242" height="15.0" width="49.0" text="Const16"/>
+      <ports identifier="P602" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.67">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N243" height="25.0" width="84.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L243" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P604" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.56">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P605" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.68">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N244" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L244" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P606" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.63">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P607" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N245" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L245" height="15.0" width="74.0" text="SetVariable5"/>
+      <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.64">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P609" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N246" height="25.0" width="113.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L246" height="15.0" width="49.0" text="Const17"/>
+      <ports identifier="P610" height="8.0" width="8.0" x="113.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.57">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.69">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N247" height="25.0" width="208.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L247" height="15.0" width="49.0" text="Const18"/>
+      <ports identifier="P612" height="8.0" width="8.0" x="208.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.58">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P613" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.70">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N248" height="25.0" width="70.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L248" height="15.0" width="76.0" text="StringConst2"/>
+      <ports identifier="P614" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.59">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.71">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N249" height="25.0" width="94.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L249" height="15.0" width="49.0" text="Const19"/>
+      <ports identifier="P616" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.60">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.72">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N250" height="25.0" width="196.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L250" height="15.0" width="49.0" text="Const20"/>
+      <ports identifier="P618" height="8.0" width="8.0" x="196.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.61">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.73">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N251" height="25.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L251" height="15.0" width="76.0" text="StringConst3"/>
+      <ports identifier="P620" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.62">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.74">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N252" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L252" height="15.0" width="44.0" text="Merge3"/>
+      <ports identifier="P622" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.55 //@children.3/@containedEdges.58 //@children.3/@containedEdges.61">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P623" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.63">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N253" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L253" height="15.0" width="44.0" text="Merge4"/>
+      <ports identifier="P624" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.54 //@children.3/@containedEdges.57 //@children.3/@containedEdges.60">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P625" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.64">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N254" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L254" height="15.0" width="44.0" text="Merge5"/>
+      <ports identifier="P626" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.56 //@children.3/@containedEdges.59 //@children.3/@containedEdges.62">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P627" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.65">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N255" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L255" height="15.0" width="61.0" text="TrueGate7"/>
+      <ports identifier="P628" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P629" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.66 //@children.3/@containedEdges.67 //@children.3/@containedEdges.68">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N256" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L256" height="15.0" width="61.0" text="TrueGate8"/>
+      <ports identifier="P630" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P631" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.69 //@children.3/@containedEdges.70 //@children.3/@containedEdges.71">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N257" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L257" height="15.0" width="61.0" text="TrueGate9"/>
+      <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P633" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.72 //@children.3/@containedEdges.73 //@children.3/@containedEdges.74">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N258" height="25.0" width="245.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L258" height="15.0" width="76.0" text="StringConst4"/>
+      <ports identifier="P634" height="8.0" width="8.0" x="245.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.75">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N259" height="25.0" width="194.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L259" height="15.0" width="76.0" text="StringConst5"/>
+      <ports identifier="P636" height="8.0" width="8.0" x="194.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.76">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P637" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N260" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L260" height="15.0" width="44.0" text="Merge6"/>
+      <ports identifier="P638" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.75 //@children.3/@containedEdges.76">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P639" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.77 //@children.3/@containedEdges.78">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N261" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L261" height="15.0" width="76.0" text="StringConst6"/>
+      <ports identifier="P640" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.79">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P641" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N262" height="25.0" width="102.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L262" height="15.0" width="76.0" text="StringConst7"/>
+      <ports identifier="P642" height="8.0" width="8.0" x="102.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.80">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P643" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N263" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L263" height="15.0" width="44.0" text="Merge7"/>
+      <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.79 //@children.3/@containedEdges.80">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P645" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.81">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N264" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L264" height="15.0" width="68.0" text="TrueGate10"/>
+      <ports identifier="P646" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P647" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.82">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N265" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L265" height="15.0" width="69.0" text="LogicalNot5"/>
+      <ports identifier="P648" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P649" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.83">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N266" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L266" height="15.0" width="67.0" text="TrueGate11"/>
+      <ports identifier="P650" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.83">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P651" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.84">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N267" height="25.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L267" height="15.0" width="76.0" text="StringConst8"/>
+      <ports identifier="P652" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.85">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P653" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.82">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N268" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L268" height="15.0" width="76.0" text="StringConst9"/>
+      <ports identifier="P654" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.86">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P655" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.84">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N269" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L269" height="15.0" width="44.0" text="Merge8"/>
+      <ports identifier="P656" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.85 //@children.3/@containedEdges.86">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P657" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.87 //@children.3/@containedEdges.88">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N270" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L270" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P658" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.89">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P659" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.3/@containedEdges.90">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P660" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.91">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P661" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.3/@containedEdges.92">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N271" height="25.0" width="202.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L271" height="15.0" width="83.0" text="StringConst10"/>
+      <ports identifier="P662" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.90">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P663" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N272" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L272" height="15.0" width="49.0" text="Const21"/>
+      <ports identifier="P664" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.91">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P665" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N273" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L273" height="15.0" width="49.0" text="Const22"/>
+      <ports identifier="P666" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.92">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P667" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N274" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L274" height="15.0" width="111.0" text="RecordAssembler2"/>
+      <ports identifier="P668" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.93">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.3/@containedEdges.94">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P670" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.81">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P671" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.3/@containedEdges.87">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N275" height="25.0" width="86.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L275" height="15.0" width="82.0" text="StringConst11"/>
+      <ports identifier="P672" height="8.0" width="8.0" x="86.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.94">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P673" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.88">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N276" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L276" height="15.0" width="83.0" text="StringConst12"/>
+      <ports identifier="P674" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.95">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.77">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N277" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L277" height="15.0" width="111.0" text="RecordAssembler4"/>
+      <ports identifier="P676" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.96">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P677" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.3/@containedEdges.89">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P678" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.93">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P679" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.3/@containedEdges.97">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N278" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L278" height="15.0" width="111.0" text="RecordAssembler3"/>
+      <ports identifier="P680" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.97">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P681" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.3/@containedEdges.95">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P682" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.78">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P683" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.3/@containedEdges.65">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E356" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E357" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E358" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.11/@ports.1"/>
+    <containedEdges identifier="E359" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.12/@ports.1"/>
+    <containedEdges identifier="E360" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.13/@ports.1"/>
+    <containedEdges identifier="E361" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.24/@ports.1"/>
+    <containedEdges identifier="E362" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.25/@ports.1"/>
+    <containedEdges identifier="E363" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.31/@ports.1"/>
+    <containedEdges identifier="E364" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.32/@ports.1"/>
+    <containedEdges identifier="E365" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.37/@ports.1"/>
+    <containedEdges identifier="E366" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.68/@ports.1"/>
+    <containedEdges identifier="E367" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.69/@ports.1"/>
+    <containedEdges identifier="E368" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.70/@ports.1"/>
+    <containedEdges identifier="E369" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E370" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.61/@ports.0"/>
+    <containedEdges identifier="E371" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.62/@ports.0"/>
+    <containedEdges identifier="E372" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E373" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E374" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E375" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E376" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E377" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.58/@ports.1"/>
+    <containedEdges identifier="E378" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.5/@ports.1"/>
+    <containedEdges identifier="E379" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.59/@ports.1"/>
+    <containedEdges identifier="E380" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E381" sources="//@children.3/@children.10/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E382" sources="//@children.3/@children.11/@ports.0" targets="//@children.3/@children.16/@ports.0"/>
+    <containedEdges identifier="E383" sources="//@children.3/@children.11/@ports.0" targets="//@children.3/@children.18/@ports.0"/>
+    <containedEdges identifier="E384" sources="//@children.3/@children.12/@ports.0" targets="//@children.3/@children.21/@ports.0"/>
+    <containedEdges identifier="E385" sources="//@children.3/@children.12/@ports.0" targets="//@children.3/@children.36/@ports.0"/>
+    <containedEdges identifier="E386" sources="//@children.3/@children.13/@ports.0" targets="//@children.3/@children.22/@ports.0"/>
+    <containedEdges identifier="E387" sources="//@children.3/@children.14/@ports.0" targets="//@children.3/@children.19/@ports.0"/>
+    <containedEdges identifier="E388" sources="//@children.3/@children.15/@ports.0" targets="//@children.3/@children.19/@ports.0"/>
+    <containedEdges identifier="E389" sources="//@children.3/@children.16/@ports.1" targets="//@children.3/@children.14/@ports.1"/>
+    <containedEdges identifier="E390" sources="//@children.3/@children.16/@ports.1" targets="//@children.3/@children.55/@ports.1"/>
+    <containedEdges identifier="E391" sources="//@children.3/@children.17/@ports.1" targets="//@children.3/@children.15/@ports.1"/>
+    <containedEdges identifier="E392" sources="//@children.3/@children.17/@ports.1" targets="//@children.3/@children.56/@ports.1"/>
+    <containedEdges identifier="E393" sources="//@children.3/@children.18/@ports.1" targets="//@children.3/@children.17/@ports.0"/>
+    <containedEdges identifier="E394" sources="//@children.3/@children.19/@ports.1" targets="//@children.3/@children.20/@ports.0"/>
+    <containedEdges identifier="E395" sources="//@children.3/@children.21/@ports.1" targets="//@children.3/@children.54/@ports.0"/>
+    <containedEdges identifier="E396" sources="//@children.3/@children.22/@ports.1" targets="//@children.3/@children.21/@ports.0"/>
+    <containedEdges identifier="E397" sources="//@children.3/@children.22/@ports.1" targets="//@children.3/@children.35/@ports.0"/>
+    <containedEdges identifier="E398" sources="//@children.3/@children.23/@ports.2" targets="//@children.3/@children.26/@ports.0"/>
+    <containedEdges identifier="E399" sources="//@children.3/@children.24/@ports.0" targets="//@children.3/@children.23/@ports.0"/>
+    <containedEdges identifier="E400" sources="//@children.3/@children.25/@ports.0" targets="//@children.3/@children.23/@ports.1"/>
+    <containedEdges identifier="E401" sources="//@children.3/@children.26/@ports.1" targets="//@children.3/@children.27/@ports.0"/>
+    <containedEdges identifier="E402" sources="//@children.3/@children.29/@ports.0" targets="//@children.3/@children.28/@ports.0"/>
+    <containedEdges identifier="E403" sources="//@children.3/@children.30/@ports.2" targets="//@children.3/@children.33/@ports.0"/>
+    <containedEdges identifier="E404" sources="//@children.3/@children.31/@ports.0" targets="//@children.3/@children.30/@ports.0"/>
+    <containedEdges identifier="E405" sources="//@children.3/@children.32/@ports.0" targets="//@children.3/@children.30/@ports.1"/>
+    <containedEdges identifier="E406" sources="//@children.3/@children.33/@ports.1" targets="//@children.3/@children.34/@ports.0"/>
+    <containedEdges identifier="E407" sources="//@children.3/@children.35/@ports.1" targets="//@children.3/@children.53/@ports.0"/>
+    <containedEdges identifier="E408" sources="//@children.3/@children.36/@ports.1" targets="//@children.3/@children.35/@ports.0"/>
+    <containedEdges identifier="E409" sources="//@children.3/@children.37/@ports.0" targets="//@children.3/@children.52/@ports.0"/>
+    <containedEdges identifier="E410" sources="//@children.3/@children.38/@ports.0" targets="//@children.3/@children.50/@ports.0"/>
+    <containedEdges identifier="E411" sources="//@children.3/@children.39/@ports.0" targets="//@children.3/@children.49/@ports.0"/>
+    <containedEdges identifier="E412" sources="//@children.3/@children.40/@ports.0" targets="//@children.3/@children.51/@ports.0"/>
+    <containedEdges identifier="E413" sources="//@children.3/@children.43/@ports.0" targets="//@children.3/@children.50/@ports.0"/>
+    <containedEdges identifier="E414" sources="//@children.3/@children.44/@ports.0" targets="//@children.3/@children.49/@ports.0"/>
+    <containedEdges identifier="E415" sources="//@children.3/@children.45/@ports.0" targets="//@children.3/@children.51/@ports.0"/>
+    <containedEdges identifier="E416" sources="//@children.3/@children.46/@ports.0" targets="//@children.3/@children.50/@ports.0"/>
+    <containedEdges identifier="E417" sources="//@children.3/@children.47/@ports.0" targets="//@children.3/@children.49/@ports.0"/>
+    <containedEdges identifier="E418" sources="//@children.3/@children.48/@ports.0" targets="//@children.3/@children.51/@ports.0"/>
+    <containedEdges identifier="E419" sources="//@children.3/@children.49/@ports.1" targets="//@children.3/@children.41/@ports.0"/>
+    <containedEdges identifier="E420" sources="//@children.3/@children.50/@ports.1" targets="//@children.3/@children.42/@ports.0"/>
+    <containedEdges identifier="E421" sources="//@children.3/@children.51/@ports.1" targets="//@children.3/@children.75/@ports.3"/>
+    <containedEdges identifier="E422" sources="//@children.3/@children.52/@ports.1" targets="//@children.3/@children.38/@ports.1"/>
+    <containedEdges identifier="E423" sources="//@children.3/@children.52/@ports.1" targets="//@children.3/@children.39/@ports.1"/>
+    <containedEdges identifier="E424" sources="//@children.3/@children.52/@ports.1" targets="//@children.3/@children.40/@ports.1"/>
+    <containedEdges identifier="E425" sources="//@children.3/@children.53/@ports.1" targets="//@children.3/@children.43/@ports.1"/>
+    <containedEdges identifier="E426" sources="//@children.3/@children.53/@ports.1" targets="//@children.3/@children.44/@ports.1"/>
+    <containedEdges identifier="E427" sources="//@children.3/@children.53/@ports.1" targets="//@children.3/@children.45/@ports.1"/>
+    <containedEdges identifier="E428" sources="//@children.3/@children.54/@ports.1" targets="//@children.3/@children.46/@ports.1"/>
+    <containedEdges identifier="E429" sources="//@children.3/@children.54/@ports.1" targets="//@children.3/@children.47/@ports.1"/>
+    <containedEdges identifier="E430" sources="//@children.3/@children.54/@ports.1" targets="//@children.3/@children.48/@ports.1"/>
+    <containedEdges identifier="E431" sources="//@children.3/@children.55/@ports.0" targets="//@children.3/@children.57/@ports.0"/>
+    <containedEdges identifier="E432" sources="//@children.3/@children.56/@ports.0" targets="//@children.3/@children.57/@ports.0"/>
+    <containedEdges identifier="E433" sources="//@children.3/@children.57/@ports.1" targets="//@children.3/@children.73/@ports.1"/>
+    <containedEdges identifier="E434" sources="//@children.3/@children.57/@ports.1" targets="//@children.3/@children.75/@ports.2"/>
+    <containedEdges identifier="E435" sources="//@children.3/@children.58/@ports.0" targets="//@children.3/@children.60/@ports.0"/>
+    <containedEdges identifier="E436" sources="//@children.3/@children.59/@ports.0" targets="//@children.3/@children.60/@ports.0"/>
+    <containedEdges identifier="E437" sources="//@children.3/@children.60/@ports.1" targets="//@children.3/@children.71/@ports.2"/>
+    <containedEdges identifier="E438" sources="//@children.3/@children.61/@ports.1" targets="//@children.3/@children.64/@ports.1"/>
+    <containedEdges identifier="E439" sources="//@children.3/@children.62/@ports.1" targets="//@children.3/@children.63/@ports.0"/>
+    <containedEdges identifier="E440" sources="//@children.3/@children.63/@ports.1" targets="//@children.3/@children.65/@ports.1"/>
+    <containedEdges identifier="E441" sources="//@children.3/@children.64/@ports.0" targets="//@children.3/@children.66/@ports.0"/>
+    <containedEdges identifier="E442" sources="//@children.3/@children.65/@ports.0" targets="//@children.3/@children.66/@ports.0"/>
+    <containedEdges identifier="E443" sources="//@children.3/@children.66/@ports.1" targets="//@children.3/@children.71/@ports.3"/>
+    <containedEdges identifier="E444" sources="//@children.3/@children.66/@ports.1" targets="//@children.3/@children.72/@ports.1"/>
+    <containedEdges identifier="E445" sources="//@children.3/@children.67/@ports.0" targets="//@children.3/@children.74/@ports.1"/>
+    <containedEdges identifier="E446" sources="//@children.3/@children.68/@ports.0" targets="//@children.3/@children.67/@ports.1"/>
+    <containedEdges identifier="E447" sources="//@children.3/@children.69/@ports.0" targets="//@children.3/@children.67/@ports.2"/>
+    <containedEdges identifier="E448" sources="//@children.3/@children.70/@ports.0" targets="//@children.3/@children.67/@ports.3"/>
+    <containedEdges identifier="E449" sources="//@children.3/@children.71/@ports.0" targets="//@children.3/@children.74/@ports.2"/>
+    <containedEdges identifier="E450" sources="//@children.3/@children.72/@ports.0" targets="//@children.3/@children.71/@ports.1"/>
+    <containedEdges identifier="E451" sources="//@children.3/@children.73/@ports.0" targets="//@children.3/@children.75/@ports.1"/>
+    <containedEdges identifier="E452" sources="//@children.3/@children.74/@ports.0" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E453" sources="//@children.3/@children.75/@ports.0" targets="//@children.3/@children.74/@ports.3"/>
+  </children>
+  <children identifier="N279">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L279" height="15.0" width="108.0" text="CompositeActor10"/>
+    <ports identifier="P684" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P685" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P686" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P687" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.4/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P688" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.4/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P689" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16" incomingEdges="//@children.4/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P690" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P691" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.3" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P692" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.4/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P693" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.4/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N280">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L280" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P694" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.5" incomingEdges="//@children.4/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P695" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.6" incomingEdges="//@children.4/@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P696" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0 //@children.4/@children.0/@containedEdges.1" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P697" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N281" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L281" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P698" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@children.0/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P699" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N282" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L282" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P701" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P702" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N283" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L283" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P703" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P704" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P705" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.4/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N284" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L284" height="15.0" width="63.0" text="IsPresent2"/>
+        <ports identifier="P706" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P707" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N285" height="25.0" width="22.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L285" height="15.0" width="82.0" text="LogicFunction"/>
+        <ports identifier="P708" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.3 //@children.4/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P709" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.7 //@children.4/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N286" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L286" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P710" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.4 //@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P711" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P712" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.9 //@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N287" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L287" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P713" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P714" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N288" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L288" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P715" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.11 //@children.4/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P717" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.12 //@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N289" height="25.0" width="77.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L289" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P718" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P719" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N290" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L290" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P720" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.14 //@children.4/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P721" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P722" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.15 //@children.4/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N291">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L291" height="15.0" width="94.0" text="CompositeActor"/>
+        <ports identifier="P723" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.10/@containedEdges.0" incomingEdges="//@children.4/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P724" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.17" incomingEdges="//@children.4/@children.0/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N292" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L292" height="15.0" width="73.0" text="LookupTable"/>
+          <ports identifier="P725" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P726" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N293" height="46.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L293" height="15.0" width="44.0" text="Uniform"/>
+          <ports identifier="P727" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P728" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.4/@children.0/@children.10/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P729" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P730" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N294" height="34.0" width="34.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L294" height="15.0" width="38.0" text="Round"/>
+          <ports identifier="P731" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.4/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P732" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@children.4/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E509" sources="//@children.4/@children.0/@children.10/@ports.0" targets="//@children.4/@children.0/@children.10/@children.1/@ports.1"/>
+        <containedEdges identifier="E510" sources="//@children.4/@children.0/@children.10/@children.0/@ports.1" targets="//@children.4/@children.0/@children.10/@ports.1"/>
+        <containedEdges identifier="E511" sources="//@children.4/@children.0/@children.10/@children.1/@ports.0" targets="//@children.4/@children.0/@children.10/@children.2/@ports.0"/>
+        <containedEdges identifier="E512" sources="//@children.4/@children.0/@children.10/@children.2/@ports.1" targets="//@children.4/@children.0/@children.10/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N295" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L295" height="15.0" width="89.0" text="DiscreteClock2"/>
+        <ports identifier="P733" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.18 //@children.4/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P734" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P735" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P736" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P737" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N296" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L296" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P738" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.21 //@children.4/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P739" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P740" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N297" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L297" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P741" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P742" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P743" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.4/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N298">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L298" height="15.0" width="101.0" text="CompositeActor2"/>
+        <ports identifier="P744" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.0 //@children.4/@children.0/@children.14/@containedEdges.1" incomingEdges="//@children.4/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P745" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.22 //@children.4/@children.0/@containedEdges.23 //@children.4/@children.0/@containedEdges.24" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N299" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L299" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P746" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P747" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N300" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L300" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P748" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P749" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P750" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N301" height="25.0" width="282.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L301" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P751" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P752" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N302" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L302" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P753" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P754" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N303" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L303" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P755" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P756" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P757" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N304" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L304" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P758" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P759" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N305" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L305" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P760" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P761" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P762" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N306" height="25.0" width="282.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L306" height="15.0" width="42.0" text="Const5"/>
+          <ports identifier="P763" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P764" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N307" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L307" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P765" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P766" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P767" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.12 //@children.4/@children.0/@children.14/@containedEdges.13 //@children.4/@children.0/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P768" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.10 //@children.4/@children.0/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N308" height="25.0" width="93.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L308" height="15.0" width="42.0" text="Const6"/>
+          <ports identifier="P769" height="8.0" width="8.0" x="93.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P770" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N309" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L309" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P771" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@children.14/@containedEdges.2 //@children.4/@children.0/@children.14/@containedEdges.4 //@children.4/@children.0/@children.14/@containedEdges.5 //@children.4/@children.0/@children.14/@containedEdges.7 //@children.4/@children.0/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P772" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.14/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E513" sources="//@children.4/@children.0/@children.14/@ports.0" targets="//@children.4/@children.0/@children.14/@children.8/@ports.0"/>
+        <containedEdges identifier="E514" sources="//@children.4/@children.0/@children.14/@ports.0" targets="//@children.4/@children.0/@children.14/@children.9/@ports.1"/>
+        <containedEdges identifier="E515" sources="//@children.4/@children.0/@children.14/@children.0/@ports.0" targets="//@children.4/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E516" sources="//@children.4/@children.0/@children.14/@children.1/@ports.1" targets="//@children.4/@children.0/@children.14/@children.2/@ports.1"/>
+        <containedEdges identifier="E517" sources="//@children.4/@children.0/@children.14/@children.2/@ports.0" targets="//@children.4/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E518" sources="//@children.4/@children.0/@children.14/@children.3/@ports.0" targets="//@children.4/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E519" sources="//@children.4/@children.0/@children.14/@children.4/@ports.1" targets="//@children.4/@children.0/@children.14/@children.3/@ports.1"/>
+        <containedEdges identifier="E520" sources="//@children.4/@children.0/@children.14/@children.5/@ports.0" targets="//@children.4/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E521" sources="//@children.4/@children.0/@children.14/@children.6/@ports.1" targets="//@children.4/@children.0/@children.14/@children.7/@ports.1"/>
+        <containedEdges identifier="E522" sources="//@children.4/@children.0/@children.14/@children.7/@ports.0" targets="//@children.4/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E523" sources="//@children.4/@children.0/@children.14/@children.8/@ports.3" targets="//@children.4/@children.0/@children.14/@children.5/@ports.1"/>
+        <containedEdges identifier="E524" sources="//@children.4/@children.0/@children.14/@children.8/@ports.3" targets="//@children.4/@children.0/@children.14/@children.6/@ports.0"/>
+        <containedEdges identifier="E525" sources="//@children.4/@children.0/@children.14/@children.8/@ports.2" targets="//@children.4/@children.0/@children.14/@children.0/@ports.1"/>
+        <containedEdges identifier="E526" sources="//@children.4/@children.0/@children.14/@children.8/@ports.2" targets="//@children.4/@children.0/@children.14/@children.1/@ports.0"/>
+        <containedEdges identifier="E527" sources="//@children.4/@children.0/@children.14/@children.8/@ports.2" targets="//@children.4/@children.0/@children.14/@children.4/@ports.0"/>
+        <containedEdges identifier="E528" sources="//@children.4/@children.0/@children.14/@children.9/@ports.0" targets="//@children.4/@children.0/@children.14/@children.8/@ports.1"/>
+        <containedEdges identifier="E529" sources="//@children.4/@children.0/@children.14/@children.10/@ports.1" targets="//@children.4/@children.0/@children.14/@ports.1"/>
+      </children>
+      <children identifier="N310" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L310" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P773" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.25 //@children.4/@children.0/@containedEdges.26 //@children.4/@children.0/@containedEdges.27 //@children.4/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P774" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P775" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P776" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P777" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N311" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L311" height="15.0" width="80.0" text="AddSubtract4"/>
+        <ports identifier="P778" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P779" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.30 //@children.4/@children.0/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P780" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N312" height="25.0" width="68.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L312" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P781" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P782" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N313">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L313" height="15.0" width="101.0" text="CompositeActor3"/>
+        <ports identifier="P783" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P784" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.18/@containedEdges.0" incomingEdges="//@children.4/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P785" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.32" incomingEdges="//@children.4/@children.0/@children.18/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P786" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.18/@containedEdges.1" incomingEdges="//@children.4/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P787" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.31" incomingEdges="//@children.4/@children.0/@children.18/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N314" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L314" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P788" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.18/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P789" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@children.18/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N315" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L315" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P790" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.18/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P791" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@children.18/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E530" sources="//@children.4/@children.0/@children.18/@ports.1" targets="//@children.4/@children.0/@children.18/@children.0/@ports.1"/>
+        <containedEdges identifier="E531" sources="//@children.4/@children.0/@children.18/@ports.3" targets="//@children.4/@children.0/@children.18/@children.1/@ports.1"/>
+        <containedEdges identifier="E532" sources="//@children.4/@children.0/@children.18/@children.0/@ports.0" targets="//@children.4/@children.0/@children.18/@ports.2"/>
+        <containedEdges identifier="E533" sources="//@children.4/@children.0/@children.18/@children.1/@ports.0" targets="//@children.4/@children.0/@children.18/@ports.4"/>
+      </children>
+      <children identifier="N316" height="28.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L316" height="15.0" width="90.0" text="MicrostepDelay"/>
+        <ports identifier="P792" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P793" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.4/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N317" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L317" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P794" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P795" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N318" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L318" height="15.0" width="22.0" text="PID"/>
+        <ports identifier="P796" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P797" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.35 //@children.4/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P798" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.42">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N319" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L319" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P799" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P800" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N320" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L320" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P801" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P802" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N321" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L321" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P803" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P804" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N322" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L322" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P805" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.4/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P806" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P807" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P808" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@children.4/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P809" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@children.4/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P810" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@children.4/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P811" height="8.0" width="8.0" x="61.0" y="31.200000762939453" outgoingEdges="//@children.4/@children.0/@containedEdges.42">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N323" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L323" height="15.0" width="78.0" text="ModalModel2"/>
+        <ports identifier="P812" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P813" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P814" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.43">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N324" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L324" height="15.0" width="74.0" text="SetVariable2"/>
+        <ports identifier="P815" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.43">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P816" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E465" sources="//@children.4/@children.0/@ports.2" targets="//@children.4/@children.0/@children.25/@ports.2"/>
+      <containedEdges identifier="E466" sources="//@children.4/@children.0/@ports.2" targets="//@children.4/@children.0/@children.26/@ports.0"/>
+      <containedEdges identifier="E467" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@children.0/@children.24/@ports.0"/>
+      <containedEdges identifier="E468" sources="//@children.4/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E469" sources="//@children.4/@children.0/@children.1/@ports.1" targets="//@children.4/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E470" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E471" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E472" sources="//@children.4/@children.0/@children.4/@ports.1" targets="//@children.4/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E473" sources="//@children.4/@children.0/@children.4/@ports.1" targets="//@children.4/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E474" sources="//@children.4/@children.0/@children.5/@ports.2" targets="//@children.4/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E475" sources="//@children.4/@children.0/@children.5/@ports.2" targets="//@children.4/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E476" sources="//@children.4/@children.0/@children.6/@ports.0" targets="//@children.4/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E477" sources="//@children.4/@children.0/@children.7/@ports.2" targets="//@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E478" sources="//@children.4/@children.0/@children.7/@ports.2" targets="//@children.4/@children.0/@children.19/@ports.0"/>
+      <containedEdges identifier="E479" sources="//@children.4/@children.0/@children.8/@ports.0" targets="//@children.4/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E480" sources="//@children.4/@children.0/@children.9/@ports.2" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E481" sources="//@children.4/@children.0/@children.9/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E482" sources="//@children.4/@children.0/@children.10/@ports.1" targets="//@children.4/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E483" sources="//@children.4/@children.0/@children.11/@ports.0" targets="//@children.4/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E484" sources="//@children.4/@children.0/@children.11/@ports.0" targets="//@children.4/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E485" sources="//@children.4/@children.0/@children.12/@ports.2" targets="//@children.4/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E486" sources="//@children.4/@children.0/@children.13/@ports.1" targets="//@children.4/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E487" sources="//@children.4/@children.0/@children.14/@ports.1" targets="//@children.4/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E488" sources="//@children.4/@children.0/@children.14/@ports.1" targets="//@children.4/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E489" sources="//@children.4/@children.0/@children.14/@ports.1" targets="//@children.4/@children.0/@children.13/@ports.2"/>
+      <containedEdges identifier="E490" sources="//@children.4/@children.0/@children.15/@ports.0" targets="//@children.4/@children.0/@children.18/@ports.3"/>
+      <containedEdges identifier="E491" sources="//@children.4/@children.0/@children.15/@ports.0" targets="//@children.4/@children.0/@children.22/@ports.1"/>
+      <containedEdges identifier="E492" sources="//@children.4/@children.0/@children.15/@ports.0" targets="//@children.4/@children.0/@children.23/@ports.1"/>
+      <containedEdges identifier="E493" sources="//@children.4/@children.0/@children.15/@ports.0" targets="//@children.4/@children.0/@children.26/@ports.1"/>
+      <containedEdges identifier="E494" sources="//@children.4/@children.0/@children.16/@ports.2" targets="//@children.4/@children.0/@children.21/@ports.0"/>
+      <containedEdges identifier="E495" sources="//@children.4/@children.0/@children.17/@ports.0" targets="//@children.4/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E496" sources="//@children.4/@children.0/@children.18/@ports.4" targets="//@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E497" sources="//@children.4/@children.0/@children.18/@ports.2" targets="//@children.4/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E498" sources="//@children.4/@children.0/@children.19/@ports.1" targets="//@children.4/@children.0/@children.18/@ports.0"/>
+      <containedEdges identifier="E499" sources="//@children.4/@children.0/@children.20/@ports.1" targets="//@children.4/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E500" sources="//@children.4/@children.0/@children.21/@ports.1" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E501" sources="//@children.4/@children.0/@children.21/@ports.1" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E502" sources="//@children.4/@children.0/@children.22/@ports.0" targets="//@children.4/@children.0/@children.25/@ports.1"/>
+      <containedEdges identifier="E503" sources="//@children.4/@children.0/@children.23/@ports.0" targets="//@children.4/@children.0/@children.25/@ports.0"/>
+      <containedEdges identifier="E504" sources="//@children.4/@children.0/@children.25/@ports.3" targets="//@children.4/@children.0/@children.17/@ports.1"/>
+      <containedEdges identifier="E505" sources="//@children.4/@children.0/@children.25/@ports.4" targets="//@children.4/@children.0/@children.18/@ports.1"/>
+      <containedEdges identifier="E506" sources="//@children.4/@children.0/@children.25/@ports.5" targets="//@children.4/@children.0/@children.16/@ports.0"/>
+      <containedEdges identifier="E507" sources="//@children.4/@children.0/@children.25/@ports.6" targets="//@children.4/@children.0/@children.21/@ports.2"/>
+      <containedEdges identifier="E508" sources="//@children.4/@children.0/@children.26/@ports.2" targets="//@children.4/@children.0/@children.27/@ports.0"/>
+    </children>
+    <children identifier="N325">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L325" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P817" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P818" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P819" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.10" incomingEdges="//@children.4/@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P820" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.1" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P821" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.7" incomingEdges="//@children.4/@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P822" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.2" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P823" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.3" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P824" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.8" incomingEdges="//@children.4/@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P825" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.9" incomingEdges="//@children.4/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="8"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N326" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L326" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P826" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P827" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N327" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L327" height="15.0" width="78.0" text="CurrentTime2"/>
+        <ports identifier="P828" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P829" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N328" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L328" height="15.0" width="78.0" text="CurrentTime3"/>
+        <ports identifier="P830" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P831" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N329" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L329" height="15.0" width="78.0" text="CurrentTime4"/>
+        <ports identifier="P832" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P833" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E534" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E535" sources="//@children.4/@children.1/@ports.3" targets="//@children.4/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E536" sources="//@children.4/@children.1/@ports.5" targets="//@children.4/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E537" sources="//@children.4/@children.1/@ports.6" targets="//@children.4/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E538" sources="//@children.4/@children.1/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.2"/>
+      <containedEdges identifier="E539" sources="//@children.4/@children.1/@children.1/@ports.0" targets="//@children.4/@children.1/@ports.4"/>
+      <containedEdges identifier="E540" sources="//@children.4/@children.1/@children.2/@ports.0" targets="//@children.4/@children.1/@ports.7"/>
+      <containedEdges identifier="E541" sources="//@children.4/@children.1/@children.3/@ports.0" targets="//@children.4/@children.1/@ports.8"/>
+    </children>
+    <containedEdges identifier="E454" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.2"/>
+    <containedEdges identifier="E455" sources="//@children.4/@ports.1" targets="//@children.4/@children.1/@ports.3"/>
+    <containedEdges identifier="E456" sources="//@children.4/@ports.2" targets="//@children.4/@children.1/@ports.5"/>
+    <containedEdges identifier="E457" sources="//@children.4/@ports.7" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E458" sources="//@children.4/@ports.6" targets="//@children.4/@children.1/@ports.6"/>
+    <containedEdges identifier="E459" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E460" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.9"/>
+    <containedEdges identifier="E461" sources="//@children.4/@children.1/@ports.4" targets="//@children.4/@ports.3"/>
+    <containedEdges identifier="E462" sources="//@children.4/@children.1/@ports.7" targets="//@children.4/@ports.4"/>
+    <containedEdges identifier="E463" sources="//@children.4/@children.1/@ports.8" targets="//@children.4/@ports.5"/>
+    <containedEdges identifier="E464" sources="//@children.4/@children.1/@ports.2" targets="//@children.4/@ports.8"/>
+  </children>
+  <children identifier="N330">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L330" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P834" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P835" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P836" height="8.0" width="8.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20" incomingEdges="//@children.5/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P837" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P838" height="8.0" width="8.0" outgoingEdges="//@containedEdges.18" incomingEdges="//@children.5/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P839" height="8.0" width="8.0" outgoingEdges="//@containedEdges.17" incomingEdges="//@children.5/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N331">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L331" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P840" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.4" incomingEdges="//@children.5/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P841" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.3" incomingEdges="//@children.5/@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P842" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0 //@children.5/@children.0/@containedEdges.1" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P843" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N332" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L332" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P844" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@children.0/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P845" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N333" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L333" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P846" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P847" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P848" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.5/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N334" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L334" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P849" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P850" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P851" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.5/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N335" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L335" height="15.0" width="63.0" text="IsPresent2"/>
+        <ports identifier="P852" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P853" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N336" height="25.0" width="22.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L336" height="15.0" width="82.0" text="LogicFunction"/>
+        <ports identifier="P854" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.3 //@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P855" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.7 //@children.5/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N337" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L337" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P856" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.4 //@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P857" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P858" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.9 //@children.5/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N338" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L338" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P859" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P860" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N339" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L339" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P861" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.11 //@children.5/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P862" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P863" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.12 //@children.5/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N340" height="25.0" width="77.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L340" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P864" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P865" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N341" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L341" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P866" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.14 //@children.5/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P867" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P868" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.15 //@children.5/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N342">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L342" height="15.0" width="94.0" text="CompositeActor"/>
+        <ports identifier="P869" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@children.10/@containedEdges.0" incomingEdges="//@children.5/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P870" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.17" incomingEdges="//@children.5/@children.0/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N343" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L343" height="15.0" width="73.0" text="LookupTable"/>
+          <ports identifier="P871" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P872" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N344" height="46.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L344" height="15.0" width="44.0" text="Uniform"/>
+          <ports identifier="P873" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.5/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P874" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.5/@children.0/@children.10/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P875" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P876" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N345" height="34.0" width="34.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L345" height="15.0" width="38.0" text="Round"/>
+          <ports identifier="P877" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.5/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P878" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@children.5/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E593" sources="//@children.5/@children.0/@children.10/@ports.0" targets="//@children.5/@children.0/@children.10/@children.1/@ports.1"/>
+        <containedEdges identifier="E594" sources="//@children.5/@children.0/@children.10/@children.0/@ports.1" targets="//@children.5/@children.0/@children.10/@ports.1"/>
+        <containedEdges identifier="E595" sources="//@children.5/@children.0/@children.10/@children.1/@ports.0" targets="//@children.5/@children.0/@children.10/@children.2/@ports.0"/>
+        <containedEdges identifier="E596" sources="//@children.5/@children.0/@children.10/@children.2/@ports.1" targets="//@children.5/@children.0/@children.10/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N346" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L346" height="15.0" width="89.0" text="DiscreteClock2"/>
+        <ports identifier="P879" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.18 //@children.5/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P880" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P881" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P882" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P883" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N347" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L347" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P884" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.21 //@children.5/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P885" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P886" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N348" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L348" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P887" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P888" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P889" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.5/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N349">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L349" height="15.0" width="101.0" text="CompositeActor2"/>
+        <ports identifier="P890" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.0 //@children.5/@children.0/@children.14/@containedEdges.1" incomingEdges="//@children.5/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P891" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.22 //@children.5/@children.0/@containedEdges.23 //@children.5/@children.0/@containedEdges.24" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N350" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L350" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P892" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P893" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N351" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L351" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P894" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P895" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P896" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N352" height="25.0" width="282.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L352" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P897" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P898" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N353" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L353" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P899" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P900" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N354" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L354" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P901" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P902" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P903" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N355" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L355" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P904" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P905" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N356" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L356" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P906" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P907" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P908" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N357" height="25.0" width="282.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L357" height="15.0" width="42.0" text="Const5"/>
+          <ports identifier="P909" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P910" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N358" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L358" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P911" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P912" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P913" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.12 //@children.5/@children.0/@children.14/@containedEdges.13 //@children.5/@children.0/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P914" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.10 //@children.5/@children.0/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N359" height="25.0" width="93.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L359" height="15.0" width="42.0" text="Const6"/>
+          <ports identifier="P915" height="8.0" width="8.0" x="93.0" y="8.5" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P916" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N360" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L360" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P917" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@children.14/@containedEdges.2 //@children.5/@children.0/@children.14/@containedEdges.4 //@children.5/@children.0/@children.14/@containedEdges.5 //@children.5/@children.0/@children.14/@containedEdges.7 //@children.5/@children.0/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P918" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.0/@children.14/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E597" sources="//@children.5/@children.0/@children.14/@ports.0" targets="//@children.5/@children.0/@children.14/@children.8/@ports.0"/>
+        <containedEdges identifier="E598" sources="//@children.5/@children.0/@children.14/@ports.0" targets="//@children.5/@children.0/@children.14/@children.9/@ports.1"/>
+        <containedEdges identifier="E599" sources="//@children.5/@children.0/@children.14/@children.0/@ports.0" targets="//@children.5/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E600" sources="//@children.5/@children.0/@children.14/@children.1/@ports.1" targets="//@children.5/@children.0/@children.14/@children.2/@ports.1"/>
+        <containedEdges identifier="E601" sources="//@children.5/@children.0/@children.14/@children.2/@ports.0" targets="//@children.5/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E602" sources="//@children.5/@children.0/@children.14/@children.3/@ports.0" targets="//@children.5/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E603" sources="//@children.5/@children.0/@children.14/@children.4/@ports.1" targets="//@children.5/@children.0/@children.14/@children.3/@ports.1"/>
+        <containedEdges identifier="E604" sources="//@children.5/@children.0/@children.14/@children.5/@ports.0" targets="//@children.5/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E605" sources="//@children.5/@children.0/@children.14/@children.6/@ports.1" targets="//@children.5/@children.0/@children.14/@children.7/@ports.1"/>
+        <containedEdges identifier="E606" sources="//@children.5/@children.0/@children.14/@children.7/@ports.0" targets="//@children.5/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E607" sources="//@children.5/@children.0/@children.14/@children.8/@ports.3" targets="//@children.5/@children.0/@children.14/@children.5/@ports.1"/>
+        <containedEdges identifier="E608" sources="//@children.5/@children.0/@children.14/@children.8/@ports.3" targets="//@children.5/@children.0/@children.14/@children.6/@ports.0"/>
+        <containedEdges identifier="E609" sources="//@children.5/@children.0/@children.14/@children.8/@ports.2" targets="//@children.5/@children.0/@children.14/@children.0/@ports.1"/>
+        <containedEdges identifier="E610" sources="//@children.5/@children.0/@children.14/@children.8/@ports.2" targets="//@children.5/@children.0/@children.14/@children.1/@ports.0"/>
+        <containedEdges identifier="E611" sources="//@children.5/@children.0/@children.14/@children.8/@ports.2" targets="//@children.5/@children.0/@children.14/@children.4/@ports.0"/>
+        <containedEdges identifier="E612" sources="//@children.5/@children.0/@children.14/@children.9/@ports.0" targets="//@children.5/@children.0/@children.14/@children.8/@ports.1"/>
+        <containedEdges identifier="E613" sources="//@children.5/@children.0/@children.14/@children.10/@ports.1" targets="//@children.5/@children.0/@children.14/@ports.1"/>
+      </children>
+      <children identifier="N361" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L361" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P919" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.25 //@children.5/@children.0/@containedEdges.26 //@children.5/@children.0/@containedEdges.27 //@children.5/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P920" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P921" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P922" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P923" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N362" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L362" height="15.0" width="80.0" text="AddSubtract4"/>
+        <ports identifier="P924" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P925" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.0/@containedEdges.30 //@children.5/@children.0/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P926" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N363" height="25.0" width="68.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L363" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P927" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P928" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N364">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L364" height="15.0" width="101.0" text="CompositeActor3"/>
+        <ports identifier="P929" height="8.0" width="8.0" incomingEdges="//@children.5/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P930" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@children.18/@containedEdges.0" incomingEdges="//@children.5/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P931" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.32" incomingEdges="//@children.5/@children.0/@children.18/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P932" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@children.18/@containedEdges.1" incomingEdges="//@children.5/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P933" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.31" incomingEdges="//@children.5/@children.0/@children.18/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N365" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L365" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P934" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@children.18/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P935" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@children.18/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N366" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L366" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P936" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@children.18/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P937" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@children.18/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E614" sources="//@children.5/@children.0/@children.18/@ports.1" targets="//@children.5/@children.0/@children.18/@children.0/@ports.1"/>
+        <containedEdges identifier="E615" sources="//@children.5/@children.0/@children.18/@ports.3" targets="//@children.5/@children.0/@children.18/@children.1/@ports.1"/>
+        <containedEdges identifier="E616" sources="//@children.5/@children.0/@children.18/@children.0/@ports.0" targets="//@children.5/@children.0/@children.18/@ports.2"/>
+        <containedEdges identifier="E617" sources="//@children.5/@children.0/@children.18/@children.1/@ports.0" targets="//@children.5/@children.0/@children.18/@ports.4"/>
+      </children>
+      <children identifier="N367" height="28.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L367" height="15.0" width="90.0" text="MicrostepDelay"/>
+        <ports identifier="P938" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.5/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P939" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.5/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N368" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L368" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P940" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P941" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N369" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L369" height="15.0" width="22.0" text="PID"/>
+        <ports identifier="P942" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P943" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.35 //@children.5/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P944" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.0/@containedEdges.42">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N370" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L370" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P945" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P946" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N371" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L371" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P947" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P948" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N372" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L372" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P949" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P950" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N373" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L373" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P951" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P952" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P953" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P954" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@children.5/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P955" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@children.5/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P956" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@children.5/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P957" height="8.0" width="8.0" x="61.0" y="31.200000762939453" outgoingEdges="//@children.5/@children.0/@containedEdges.42">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N374" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L374" height="15.0" width="78.0" text="ModalModel2"/>
+        <ports identifier="P958" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P959" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P960" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.43">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N375" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L375" height="15.0" width="74.0" text="SetVariable2"/>
+        <ports identifier="P961" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.43">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P962" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E549" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.0/@children.25/@ports.2"/>
+      <containedEdges identifier="E550" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.0/@children.26/@ports.0"/>
+      <containedEdges identifier="E551" sources="//@children.5/@children.0/@ports.3" targets="//@children.5/@children.0/@children.24/@ports.0"/>
+      <containedEdges identifier="E552" sources="//@children.5/@children.0/@children.0/@ports.1" targets="//@children.5/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E553" sources="//@children.5/@children.0/@children.1/@ports.1" targets="//@children.5/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E554" sources="//@children.5/@children.0/@children.2/@ports.1" targets="//@children.5/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E555" sources="//@children.5/@children.0/@children.3/@ports.1" targets="//@children.5/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E556" sources="//@children.5/@children.0/@children.4/@ports.1" targets="//@children.5/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E557" sources="//@children.5/@children.0/@children.4/@ports.1" targets="//@children.5/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E558" sources="//@children.5/@children.0/@children.5/@ports.2" targets="//@children.5/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E559" sources="//@children.5/@children.0/@children.5/@ports.2" targets="//@children.5/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E560" sources="//@children.5/@children.0/@children.6/@ports.0" targets="//@children.5/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E561" sources="//@children.5/@children.0/@children.7/@ports.2" targets="//@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E562" sources="//@children.5/@children.0/@children.7/@ports.2" targets="//@children.5/@children.0/@children.19/@ports.0"/>
+      <containedEdges identifier="E563" sources="//@children.5/@children.0/@children.8/@ports.0" targets="//@children.5/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E564" sources="//@children.5/@children.0/@children.9/@ports.2" targets="//@children.5/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E565" sources="//@children.5/@children.0/@children.9/@ports.2" targets="//@children.5/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E566" sources="//@children.5/@children.0/@children.10/@ports.1" targets="//@children.5/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E567" sources="//@children.5/@children.0/@children.11/@ports.0" targets="//@children.5/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E568" sources="//@children.5/@children.0/@children.11/@ports.0" targets="//@children.5/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E569" sources="//@children.5/@children.0/@children.12/@ports.2" targets="//@children.5/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E570" sources="//@children.5/@children.0/@children.13/@ports.1" targets="//@children.5/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E571" sources="//@children.5/@children.0/@children.14/@ports.1" targets="//@children.5/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E572" sources="//@children.5/@children.0/@children.14/@ports.1" targets="//@children.5/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E573" sources="//@children.5/@children.0/@children.14/@ports.1" targets="//@children.5/@children.0/@children.13/@ports.2"/>
+      <containedEdges identifier="E574" sources="//@children.5/@children.0/@children.15/@ports.0" targets="//@children.5/@children.0/@children.18/@ports.3"/>
+      <containedEdges identifier="E575" sources="//@children.5/@children.0/@children.15/@ports.0" targets="//@children.5/@children.0/@children.22/@ports.1"/>
+      <containedEdges identifier="E576" sources="//@children.5/@children.0/@children.15/@ports.0" targets="//@children.5/@children.0/@children.23/@ports.1"/>
+      <containedEdges identifier="E577" sources="//@children.5/@children.0/@children.15/@ports.0" targets="//@children.5/@children.0/@children.26/@ports.1"/>
+      <containedEdges identifier="E578" sources="//@children.5/@children.0/@children.16/@ports.2" targets="//@children.5/@children.0/@children.21/@ports.0"/>
+      <containedEdges identifier="E579" sources="//@children.5/@children.0/@children.17/@ports.0" targets="//@children.5/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E580" sources="//@children.5/@children.0/@children.18/@ports.4" targets="//@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E581" sources="//@children.5/@children.0/@children.18/@ports.2" targets="//@children.5/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E582" sources="//@children.5/@children.0/@children.19/@ports.1" targets="//@children.5/@children.0/@children.18/@ports.0"/>
+      <containedEdges identifier="E583" sources="//@children.5/@children.0/@children.20/@ports.1" targets="//@children.5/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E584" sources="//@children.5/@children.0/@children.21/@ports.1" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E585" sources="//@children.5/@children.0/@children.21/@ports.1" targets="//@children.5/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E586" sources="//@children.5/@children.0/@children.22/@ports.0" targets="//@children.5/@children.0/@children.25/@ports.1"/>
+      <containedEdges identifier="E587" sources="//@children.5/@children.0/@children.23/@ports.0" targets="//@children.5/@children.0/@children.25/@ports.0"/>
+      <containedEdges identifier="E588" sources="//@children.5/@children.0/@children.25/@ports.3" targets="//@children.5/@children.0/@children.17/@ports.1"/>
+      <containedEdges identifier="E589" sources="//@children.5/@children.0/@children.25/@ports.4" targets="//@children.5/@children.0/@children.18/@ports.1"/>
+      <containedEdges identifier="E590" sources="//@children.5/@children.0/@children.25/@ports.5" targets="//@children.5/@children.0/@children.16/@ports.0"/>
+      <containedEdges identifier="E591" sources="//@children.5/@children.0/@children.25/@ports.6" targets="//@children.5/@children.0/@children.21/@ports.2"/>
+      <containedEdges identifier="E592" sources="//@children.5/@children.0/@children.26/@ports.2" targets="//@children.5/@children.0/@children.27/@ports.0"/>
+    </children>
+    <children identifier="N376">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L376" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P963" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P964" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@containedEdges.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P965" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.5" incomingEdges="//@children.5/@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P966" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@containedEdges.1" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P967" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.6" incomingEdges="//@children.5/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N377" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L377" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P968" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P969" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N378" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L378" height="15.0" width="78.0" text="CurrentTime2"/>
+        <ports identifier="P970" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P971" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E618" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E619" sources="//@children.5/@children.1/@ports.3" targets="//@children.5/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E620" sources="//@children.5/@children.1/@children.0/@ports.0" targets="//@children.5/@children.1/@ports.2"/>
+      <containedEdges identifier="E621" sources="//@children.5/@children.1/@children.1/@ports.0" targets="//@children.5/@children.1/@ports.4"/>
+    </children>
+    <containedEdges identifier="E542" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.2"/>
+    <containedEdges identifier="E543" sources="//@children.5/@ports.3" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E544" sources="//@children.5/@ports.1" targets="//@children.5/@children.1/@ports.3"/>
+    <containedEdges identifier="E545" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@ports.5"/>
+    <containedEdges identifier="E546" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E547" sources="//@children.5/@children.1/@ports.2" targets="//@children.5/@ports.4"/>
+    <containedEdges identifier="E548" sources="//@children.5/@children.1/@ports.4" targets="//@children.5/@ports.2"/>
+  </children>
+  <children identifier="N379">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L379" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P972" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P973" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P974" height="8.0" width="8.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23" incomingEdges="//@children.6/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P975" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P976" height="8.0" width="8.0" outgoingEdges="//@containedEdges.21" incomingEdges="//@children.6/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P977" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N380">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L380" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P978" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.3" incomingEdges="//@children.6/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P979" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.4" incomingEdges="//@children.6/@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P980" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P981" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N381" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L381" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P982" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@children.0/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P983" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N382" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L382" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P984" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P985" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P986" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N383" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L383" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P987" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P988" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P989" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N384" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L384" height="15.0" width="63.0" text="IsPresent2"/>
+        <ports identifier="P990" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P991" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.6/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N385" height="25.0" width="22.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L385" height="15.0" width="82.0" text="LogicFunction"/>
+        <ports identifier="P992" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.3 //@children.6/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P993" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.7 //@children.6/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N386" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L386" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P994" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.4 //@children.6/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P995" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P996" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.9 //@children.6/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N387" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L387" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P997" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P998" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N388" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L388" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P999" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.11 //@children.6/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1000" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1001" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.12 //@children.6/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N389" height="25.0" width="77.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L389" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P1002" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1003" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N390" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L390" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P1004" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.14 //@children.6/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1005" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1006" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.15 //@children.6/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N391">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L391" height="15.0" width="94.0" text="CompositeActor"/>
+        <ports identifier="P1007" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.10/@containedEdges.0" incomingEdges="//@children.6/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1008" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.17" incomingEdges="//@children.6/@children.0/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N392" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L392" height="15.0" width="73.0" text="LookupTable"/>
+          <ports identifier="P1009" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1010" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N393" height="46.0" width="67.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L393" height="15.0" width="44.0" text="Uniform"/>
+          <ports identifier="P1011" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.6/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1012" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.6/@children.0/@children.10/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1013" height="8.0" width="8.0" x="-8.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1014" height="8.0" width="8.0" x="-8.0" y="32.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N394" height="34.0" width="34.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L394" height="15.0" width="38.0" text="Round"/>
+          <ports identifier="P1015" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.6/@children.0/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1016" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@children.6/@children.0/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E673" sources="//@children.6/@children.0/@children.10/@ports.0" targets="//@children.6/@children.0/@children.10/@children.1/@ports.1"/>
+        <containedEdges identifier="E674" sources="//@children.6/@children.0/@children.10/@children.0/@ports.1" targets="//@children.6/@children.0/@children.10/@ports.1"/>
+        <containedEdges identifier="E675" sources="//@children.6/@children.0/@children.10/@children.1/@ports.0" targets="//@children.6/@children.0/@children.10/@children.2/@ports.0"/>
+        <containedEdges identifier="E676" sources="//@children.6/@children.0/@children.10/@children.2/@ports.1" targets="//@children.6/@children.0/@children.10/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N395" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L395" height="15.0" width="89.0" text="DiscreteClock2"/>
+        <ports identifier="P1017" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.18 //@children.6/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1018" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1019" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1020" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P1021" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N396" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L396" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P1022" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.21 //@children.6/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1023" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1024" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N397" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L397" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P1025" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1026" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1027" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N398">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L398" height="15.0" width="101.0" text="CompositeActor2"/>
+        <ports identifier="P1028" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.0 //@children.6/@children.0/@children.14/@containedEdges.1" incomingEdges="//@children.6/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1029" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.22 //@children.6/@children.0/@containedEdges.23 //@children.6/@children.0/@containedEdges.24" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N399" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L399" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P1030" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1031" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N400" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L400" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P1032" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1033" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1034" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N401" height="25.0" width="282.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L401" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P1035" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1036" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N402" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L402" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P1037" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1038" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N403" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L403" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P1039" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1040" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1041" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N404" height="25.0" width="278.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L404" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P1042" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1043" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N405" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L405" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P1044" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1045" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1046" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N406" height="25.0" width="282.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L406" height="15.0" width="42.0" text="Const5"/>
+          <ports identifier="P1047" height="8.0" width="8.0" x="282.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1048" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N407" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L407" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P1049" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1050" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P1051" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.12 //@children.6/@children.0/@children.14/@containedEdges.13 //@children.6/@children.0/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1052" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.10 //@children.6/@children.0/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N408" height="25.0" width="93.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L408" height="15.0" width="42.0" text="Const6"/>
+          <ports identifier="P1053" height="8.0" width="8.0" x="93.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1054" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N409" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L409" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P1055" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@children.14/@containedEdges.2 //@children.6/@children.0/@children.14/@containedEdges.4 //@children.6/@children.0/@children.14/@containedEdges.5 //@children.6/@children.0/@children.14/@containedEdges.7 //@children.6/@children.0/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P1056" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.14/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E677" sources="//@children.6/@children.0/@children.14/@ports.0" targets="//@children.6/@children.0/@children.14/@children.8/@ports.0"/>
+        <containedEdges identifier="E678" sources="//@children.6/@children.0/@children.14/@ports.0" targets="//@children.6/@children.0/@children.14/@children.9/@ports.1"/>
+        <containedEdges identifier="E679" sources="//@children.6/@children.0/@children.14/@children.0/@ports.0" targets="//@children.6/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E680" sources="//@children.6/@children.0/@children.14/@children.1/@ports.1" targets="//@children.6/@children.0/@children.14/@children.2/@ports.1"/>
+        <containedEdges identifier="E681" sources="//@children.6/@children.0/@children.14/@children.2/@ports.0" targets="//@children.6/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E682" sources="//@children.6/@children.0/@children.14/@children.3/@ports.0" targets="//@children.6/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E683" sources="//@children.6/@children.0/@children.14/@children.4/@ports.1" targets="//@children.6/@children.0/@children.14/@children.3/@ports.1"/>
+        <containedEdges identifier="E684" sources="//@children.6/@children.0/@children.14/@children.5/@ports.0" targets="//@children.6/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E685" sources="//@children.6/@children.0/@children.14/@children.6/@ports.1" targets="//@children.6/@children.0/@children.14/@children.7/@ports.1"/>
+        <containedEdges identifier="E686" sources="//@children.6/@children.0/@children.14/@children.7/@ports.0" targets="//@children.6/@children.0/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E687" sources="//@children.6/@children.0/@children.14/@children.8/@ports.3" targets="//@children.6/@children.0/@children.14/@children.5/@ports.1"/>
+        <containedEdges identifier="E688" sources="//@children.6/@children.0/@children.14/@children.8/@ports.3" targets="//@children.6/@children.0/@children.14/@children.6/@ports.0"/>
+        <containedEdges identifier="E689" sources="//@children.6/@children.0/@children.14/@children.8/@ports.2" targets="//@children.6/@children.0/@children.14/@children.0/@ports.1"/>
+        <containedEdges identifier="E690" sources="//@children.6/@children.0/@children.14/@children.8/@ports.2" targets="//@children.6/@children.0/@children.14/@children.1/@ports.0"/>
+        <containedEdges identifier="E691" sources="//@children.6/@children.0/@children.14/@children.8/@ports.2" targets="//@children.6/@children.0/@children.14/@children.4/@ports.0"/>
+        <containedEdges identifier="E692" sources="//@children.6/@children.0/@children.14/@children.9/@ports.0" targets="//@children.6/@children.0/@children.14/@children.8/@ports.1"/>
+        <containedEdges identifier="E693" sources="//@children.6/@children.0/@children.14/@children.10/@ports.1" targets="//@children.6/@children.0/@children.14/@ports.1"/>
+      </children>
+      <children identifier="N410" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L410" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P1057" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.25 //@children.6/@children.0/@containedEdges.26 //@children.6/@children.0/@containedEdges.27 //@children.6/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1058" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1059" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1060" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P1061" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N411" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L411" height="15.0" width="80.0" text="AddSubtract4"/>
+        <ports identifier="P1062" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1063" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@containedEdges.30 //@children.6/@children.0/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1064" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N412" height="25.0" width="68.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L412" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P1065" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1066" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N413">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L413" height="15.0" width="101.0" text="CompositeActor3"/>
+        <ports identifier="P1067" height="8.0" width="8.0" incomingEdges="//@children.6/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1068" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.18/@containedEdges.0" incomingEdges="//@children.6/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1069" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.32" incomingEdges="//@children.6/@children.0/@children.18/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1070" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.18/@containedEdges.1" incomingEdges="//@children.6/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1071" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.31" incomingEdges="//@children.6/@children.0/@children.18/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N414" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L414" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P1072" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.18/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1073" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@children.18/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N415" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L415" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P1074" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.18/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P1075" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@children.18/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E694" sources="//@children.6/@children.0/@children.18/@ports.1" targets="//@children.6/@children.0/@children.18/@children.0/@ports.1"/>
+        <containedEdges identifier="E695" sources="//@children.6/@children.0/@children.18/@ports.3" targets="//@children.6/@children.0/@children.18/@children.1/@ports.1"/>
+        <containedEdges identifier="E696" sources="//@children.6/@children.0/@children.18/@children.0/@ports.0" targets="//@children.6/@children.0/@children.18/@ports.2"/>
+        <containedEdges identifier="E697" sources="//@children.6/@children.0/@children.18/@children.1/@ports.0" targets="//@children.6/@children.0/@children.18/@ports.4"/>
+      </children>
+      <children identifier="N416" height="28.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L416" height="15.0" width="90.0" text="MicrostepDelay"/>
+        <ports identifier="P1076" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.6/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1077" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.6/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N417" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L417" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P1078" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1079" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N418" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L418" height="15.0" width="22.0" text="PID"/>
+        <ports identifier="P1080" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1081" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.35 //@children.6/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1082" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@containedEdges.42">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N419" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L419" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P1083" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1084" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N420" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L420" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P1085" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1086" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N421" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L421" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P1087" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1088" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N422" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L422" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P1089" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.6/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1090" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1091" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1092" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@children.6/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1093" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@children.6/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1094" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@children.6/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1095" height="8.0" width="8.0" x="61.0" y="31.200000762939453" outgoingEdges="//@children.6/@children.0/@containedEdges.42">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N423" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L423" height="15.0" width="78.0" text="ModalModel2"/>
+        <ports identifier="P1096" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1097" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1098" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.43">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N424" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L424" height="15.0" width="74.0" text="SetVariable2"/>
+        <ports identifier="P1099" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.43">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1100" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E629" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.0/@children.25/@ports.2"/>
+      <containedEdges identifier="E630" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.0/@children.26/@ports.0"/>
+      <containedEdges identifier="E631" sources="//@children.6/@children.0/@ports.3" targets="//@children.6/@children.0/@children.24/@ports.0"/>
+      <containedEdges identifier="E632" sources="//@children.6/@children.0/@children.0/@ports.1" targets="//@children.6/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E633" sources="//@children.6/@children.0/@children.1/@ports.1" targets="//@children.6/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E634" sources="//@children.6/@children.0/@children.2/@ports.1" targets="//@children.6/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E635" sources="//@children.6/@children.0/@children.3/@ports.1" targets="//@children.6/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E636" sources="//@children.6/@children.0/@children.4/@ports.1" targets="//@children.6/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E637" sources="//@children.6/@children.0/@children.4/@ports.1" targets="//@children.6/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E638" sources="//@children.6/@children.0/@children.5/@ports.2" targets="//@children.6/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E639" sources="//@children.6/@children.0/@children.5/@ports.2" targets="//@children.6/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E640" sources="//@children.6/@children.0/@children.6/@ports.0" targets="//@children.6/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E641" sources="//@children.6/@children.0/@children.7/@ports.2" targets="//@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E642" sources="//@children.6/@children.0/@children.7/@ports.2" targets="//@children.6/@children.0/@children.19/@ports.0"/>
+      <containedEdges identifier="E643" sources="//@children.6/@children.0/@children.8/@ports.0" targets="//@children.6/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E644" sources="//@children.6/@children.0/@children.9/@ports.2" targets="//@children.6/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E645" sources="//@children.6/@children.0/@children.9/@ports.2" targets="//@children.6/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E646" sources="//@children.6/@children.0/@children.10/@ports.1" targets="//@children.6/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E647" sources="//@children.6/@children.0/@children.11/@ports.0" targets="//@children.6/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E648" sources="//@children.6/@children.0/@children.11/@ports.0" targets="//@children.6/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E649" sources="//@children.6/@children.0/@children.12/@ports.2" targets="//@children.6/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E650" sources="//@children.6/@children.0/@children.13/@ports.1" targets="//@children.6/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E651" sources="//@children.6/@children.0/@children.14/@ports.1" targets="//@children.6/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E652" sources="//@children.6/@children.0/@children.14/@ports.1" targets="//@children.6/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E653" sources="//@children.6/@children.0/@children.14/@ports.1" targets="//@children.6/@children.0/@children.13/@ports.2"/>
+      <containedEdges identifier="E654" sources="//@children.6/@children.0/@children.15/@ports.0" targets="//@children.6/@children.0/@children.18/@ports.3"/>
+      <containedEdges identifier="E655" sources="//@children.6/@children.0/@children.15/@ports.0" targets="//@children.6/@children.0/@children.22/@ports.1"/>
+      <containedEdges identifier="E656" sources="//@children.6/@children.0/@children.15/@ports.0" targets="//@children.6/@children.0/@children.23/@ports.1"/>
+      <containedEdges identifier="E657" sources="//@children.6/@children.0/@children.15/@ports.0" targets="//@children.6/@children.0/@children.26/@ports.1"/>
+      <containedEdges identifier="E658" sources="//@children.6/@children.0/@children.16/@ports.2" targets="//@children.6/@children.0/@children.21/@ports.0"/>
+      <containedEdges identifier="E659" sources="//@children.6/@children.0/@children.17/@ports.0" targets="//@children.6/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E660" sources="//@children.6/@children.0/@children.18/@ports.4" targets="//@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E661" sources="//@children.6/@children.0/@children.18/@ports.2" targets="//@children.6/@children.0/@children.16/@ports.1"/>
+      <containedEdges identifier="E662" sources="//@children.6/@children.0/@children.19/@ports.1" targets="//@children.6/@children.0/@children.18/@ports.0"/>
+      <containedEdges identifier="E663" sources="//@children.6/@children.0/@children.20/@ports.1" targets="//@children.6/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E664" sources="//@children.6/@children.0/@children.21/@ports.1" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E665" sources="//@children.6/@children.0/@children.21/@ports.1" targets="//@children.6/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E666" sources="//@children.6/@children.0/@children.22/@ports.0" targets="//@children.6/@children.0/@children.25/@ports.1"/>
+      <containedEdges identifier="E667" sources="//@children.6/@children.0/@children.23/@ports.0" targets="//@children.6/@children.0/@children.25/@ports.0"/>
+      <containedEdges identifier="E668" sources="//@children.6/@children.0/@children.25/@ports.3" targets="//@children.6/@children.0/@children.17/@ports.1"/>
+      <containedEdges identifier="E669" sources="//@children.6/@children.0/@children.25/@ports.4" targets="//@children.6/@children.0/@children.18/@ports.1"/>
+      <containedEdges identifier="E670" sources="//@children.6/@children.0/@children.25/@ports.5" targets="//@children.6/@children.0/@children.16/@ports.0"/>
+      <containedEdges identifier="E671" sources="//@children.6/@children.0/@children.25/@ports.6" targets="//@children.6/@children.0/@children.21/@ports.2"/>
+      <containedEdges identifier="E672" sources="//@children.6/@children.0/@children.26/@ports.2" targets="//@children.6/@children.0/@children.27/@ports.0"/>
+    </children>
+    <children identifier="N425">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L425" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P1101" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1102" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1103" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.5" incomingEdges="//@children.6/@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1104" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1105" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.6" incomingEdges="//@children.6/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N426" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L426" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P1106" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N427" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L427" height="15.0" width="78.0" text="CurrentTime2"/>
+        <ports identifier="P1108" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E698" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E699" sources="//@children.6/@children.1/@ports.3" targets="//@children.6/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E700" sources="//@children.6/@children.1/@children.0/@ports.0" targets="//@children.6/@children.1/@ports.2"/>
+      <containedEdges identifier="E701" sources="//@children.6/@children.1/@children.1/@ports.0" targets="//@children.6/@children.1/@ports.4"/>
+    </children>
+    <containedEdges identifier="E622" sources="//@children.6/@ports.0" targets="//@children.6/@children.0/@ports.2"/>
+    <containedEdges identifier="E623" sources="//@children.6/@ports.3" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E624" sources="//@children.6/@ports.1" targets="//@children.6/@children.1/@ports.3"/>
+    <containedEdges identifier="E625" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E626" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@ports.5"/>
+    <containedEdges identifier="E627" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@ports.4"/>
+    <containedEdges identifier="E628" sources="//@children.6/@children.1/@ports.4" targets="//@children.6/@ports.2"/>
+  </children>
+  <children identifier="N428">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L428" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P1110" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1111" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1112" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1113" height="8.0" width="8.0" outgoingEdges="//@containedEdges.24 //@containedEdges.25 //@containedEdges.26" incomingEdges="//@children.7/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N429" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L429" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P1114" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1115" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1116" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1117" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P1118" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N430" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L430" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P1119" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5 //@children.7/@containedEdges.6 //@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1120" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N431" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L431" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P1121" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1122" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1123" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N432" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L432" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P1124" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1125" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1126" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N433" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L433" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P1127" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1128" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1129" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N434" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L434" height="15.0" width="117.0" text="DetectorClockTimes"/>
+      <ports identifier="P1130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.8 //@children.7/@containedEdges.9 //@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E702" sources="//@children.7/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E703" sources="//@children.7/@ports.1" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E704" sources="//@children.7/@ports.2" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E705" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@ports.3"/>
+    <containedEdges identifier="E706" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.1/@ports.1"/>
+    <containedEdges identifier="E707" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.2/@ports.1"/>
+    <containedEdges identifier="E708" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.3/@ports.1"/>
+    <containedEdges identifier="E709" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.4/@ports.1"/>
+    <containedEdges identifier="E710" sources="//@children.7/@children.2/@ports.2" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E711" sources="//@children.7/@children.3/@ports.2" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E712" sources="//@children.7/@children.4/@ports.2" targets="//@children.7/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N435">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L435" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P1131" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1132" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.2 //@children.8/@containedEdges.3" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1133" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.4 //@children.8/@containedEdges.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1134" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.6 //@children.8/@containedEdges.7" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P1135" height="8.0" width="8.0" outgoingEdges="//@containedEdges.27" incomingEdges="//@children.8/@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N436" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L436" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P1136" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1137" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1138" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N437" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L437" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P1139" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1140" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1141" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.9 //@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N438" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L438" height="15.0" width="78.0" text="MostRecent2"/>
+      <ports identifier="P1142" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1143" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1144" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N439" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L439" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P1145" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1146" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1147" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N440" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L440" height="15.0" width="78.0" text="ModalModel2"/>
+      <ports identifier="P1148" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1149" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1150" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.13 //@children.8/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N441" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L441" height="15.0" width="78.0" text="MostRecent3"/>
+      <ports identifier="P1151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1152" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1153" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N442" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L442" height="15.0" width="78.0" text="MostRecent4"/>
+      <ports identifier="P1154" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1155" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1156" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N443" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L443" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P1157" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1158" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1159" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N444">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L444" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P1160" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.8/@containedEdges.0 //@children.8/@children.8/@containedEdges.1 //@children.8/@children.8/@containedEdges.2 //@children.8/@children.8/@containedEdges.3" incomingEdges="//@children.8/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1161" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.18" incomingEdges="//@children.8/@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1162" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.19" incomingEdges="//@children.8/@children.8/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N445" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L445" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P1163" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1164" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.8/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N446" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L446" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P1165" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1166" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.5 //@children.8/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1167" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N447" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L447" height="15.0" width="81.0" text="Accumulator2"/>
+        <ports identifier="P1168" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1169" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1170" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N448" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L448" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P1171" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1172" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.8/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1173" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.8 //@children.8/@children.8/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N449" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L449" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P1174" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1175" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1176" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@children.8/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N450" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L450" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P1177" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1178" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.11 //@children.8/@children.8/@containedEdges.12 //@children.8/@children.8/@containedEdges.13 //@children.8/@children.8/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1179" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@children.8/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N451" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L451" height="15.0" width="40.0" text="Equals"/>
+        <ports identifier="P1180" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.8/@containedEdges.6 //@children.8/@children.8/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1181" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.8/@children.8/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N452" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L452" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P1182" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.8/@children.8/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1183" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N453" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L453" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P1184" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.8/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1185" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.8/@children.8/@containedEdges.17 //@children.8/@children.8/@containedEdges.18 //@children.8/@children.8/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N454" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L454" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P1186" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1187" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.8/@children.8/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N455" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L455" height="15.0" width="81.0" text="Accumulator3"/>
+        <ports identifier="P1188" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1189" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1190" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N456" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L456" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P1191" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.8/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1192" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1193" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@children.8/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N457" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L457" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P1194" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.12 //@children.8/@children.8/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1195" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1196" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N458" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L458" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P1197" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1198" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.8/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1199" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N459" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L459" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P1200" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.8/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1201" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.8/@children.8/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N460" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L460" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P1202" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1203" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.8/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1204" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N461" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L461" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P1205" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@children.8/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1206" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.8/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N462" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L462" height="15.0" width="87.0" text="MultiplyDivide3"/>
+        <ports identifier="P1207" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.8/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1208" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.8/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1209" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N463" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L463" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P1210" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.8/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1211" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.8/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N464" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L464" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P1212" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.8/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1213" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.8/@children.8/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E738" sources="//@children.8/@children.8/@ports.0" targets="//@children.8/@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E739" sources="//@children.8/@children.8/@ports.0" targets="//@children.8/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E740" sources="//@children.8/@children.8/@ports.0" targets="//@children.8/@children.8/@children.7/@ports.1"/>
+      <containedEdges identifier="E741" sources="//@children.8/@children.8/@ports.0" targets="//@children.8/@children.8/@children.9/@ports.0"/>
+      <containedEdges identifier="E742" sources="//@children.8/@children.8/@children.0/@ports.0" targets="//@children.8/@children.8/@children.1/@ports.0"/>
+      <containedEdges identifier="E743" sources="//@children.8/@children.8/@children.1/@ports.1" targets="//@children.8/@children.8/@children.5/@ports.0"/>
+      <containedEdges identifier="E744" sources="//@children.8/@children.8/@children.1/@ports.1" targets="//@children.8/@children.8/@children.6/@ports.0"/>
+      <containedEdges identifier="E745" sources="//@children.8/@children.8/@children.2/@ports.1" targets="//@children.8/@children.8/@children.4/@ports.0"/>
+      <containedEdges identifier="E746" sources="//@children.8/@children.8/@children.3/@ports.2" targets="//@children.8/@children.8/@ports.1"/>
+      <containedEdges identifier="E747" sources="//@children.8/@children.8/@children.3/@ports.2" targets="//@children.8/@children.8/@children.14/@ports.0"/>
+      <containedEdges identifier="E748" sources="//@children.8/@children.8/@children.4/@ports.1" targets="//@children.8/@children.8/@children.3/@ports.0"/>
+      <containedEdges identifier="E749" sources="//@children.8/@children.8/@children.5/@ports.1" targets="//@children.8/@children.8/@children.3/@ports.1"/>
+      <containedEdges identifier="E750" sources="//@children.8/@children.8/@children.5/@ports.1" targets="//@children.8/@children.8/@children.12/@ports.0"/>
+      <containedEdges identifier="E751" sources="//@children.8/@children.8/@children.5/@ports.1" targets="//@children.8/@children.8/@children.15/@ports.0"/>
+      <containedEdges identifier="E752" sources="//@children.8/@children.8/@children.5/@ports.1" targets="//@children.8/@children.8/@children.16/@ports.1"/>
+      <containedEdges identifier="E753" sources="//@children.8/@children.8/@children.6/@ports.1" targets="//@children.8/@children.8/@children.8/@ports.0"/>
+      <containedEdges identifier="E754" sources="//@children.8/@children.8/@children.7/@ports.0" targets="//@children.8/@children.8/@children.6/@ports.0"/>
+      <containedEdges identifier="E755" sources="//@children.8/@children.8/@children.8/@ports.1" targets="//@children.8/@children.8/@children.4/@ports.2"/>
+      <containedEdges identifier="E756" sources="//@children.8/@children.8/@children.8/@ports.1" targets="//@children.8/@children.8/@children.5/@ports.2"/>
+      <containedEdges identifier="E757" sources="//@children.8/@children.8/@children.8/@ports.1" targets="//@children.8/@children.8/@children.11/@ports.2"/>
+      <containedEdges identifier="E758" sources="//@children.8/@children.8/@children.9/@ports.1" targets="//@children.8/@children.8/@children.10/@ports.0"/>
+      <containedEdges identifier="E759" sources="//@children.8/@children.8/@children.10/@ports.1" targets="//@children.8/@children.8/@children.11/@ports.0"/>
+      <containedEdges identifier="E760" sources="//@children.8/@children.8/@children.11/@ports.1" targets="//@children.8/@children.8/@children.13/@ports.0"/>
+      <containedEdges identifier="E761" sources="//@children.8/@children.8/@children.12/@ports.2" targets="//@children.8/@children.8/@children.13/@ports.1"/>
+      <containedEdges identifier="E762" sources="//@children.8/@children.8/@children.13/@ports.2" targets="//@children.8/@children.8/@children.17/@ports.0"/>
+      <containedEdges identifier="E763" sources="//@children.8/@children.8/@children.14/@ports.1" targets="//@children.8/@children.8/@children.12/@ports.0"/>
+      <containedEdges identifier="E764" sources="//@children.8/@children.8/@children.15/@ports.2" targets="//@children.8/@children.8/@children.18/@ports.0"/>
+      <containedEdges identifier="E765" sources="//@children.8/@children.8/@children.16/@ports.0" targets="//@children.8/@children.8/@children.15/@ports.1"/>
+      <containedEdges identifier="E766" sources="//@children.8/@children.8/@children.17/@ports.2" targets="//@children.8/@children.8/@children.19/@ports.0"/>
+      <containedEdges identifier="E767" sources="//@children.8/@children.8/@children.18/@ports.1" targets="//@children.8/@children.8/@children.17/@ports.1"/>
+      <containedEdges identifier="E768" sources="//@children.8/@children.8/@children.19/@ports.1" targets="//@children.8/@children.8/@ports.2"/>
+    </children>
+    <children identifier="N465">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L465" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P1214" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.9/@containedEdges.0 //@children.8/@children.9/@containedEdges.1 //@children.8/@children.9/@containedEdges.2 //@children.8/@children.9/@containedEdges.3" incomingEdges="//@children.8/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1215" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.20" incomingEdges="//@children.8/@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1216" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.21" incomingEdges="//@children.8/@children.9/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N466" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L466" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P1217" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1218" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N467" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L467" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P1219" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1220" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.5 //@children.8/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N468" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L468" height="15.0" width="81.0" text="Accumulator2"/>
+        <ports identifier="P1222" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1223" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N469" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L469" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P1225" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1226" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.9/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1227" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.8 //@children.8/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N470" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L470" height="15.0" width="70.0" text="MostRecent"/>
+        <ports identifier="P1228" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1229" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1230" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@children.9/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N471" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L471" height="15.0" width="78.0" text="MostRecent2"/>
+        <ports identifier="P1231" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1232" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.11 //@children.8/@children.9/@containedEdges.12 //@children.8/@children.9/@containedEdges.13 //@children.8/@children.9/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1233" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@children.9/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N472" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L472" height="15.0" width="40.0" text="Equals"/>
+        <ports identifier="P1234" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.9/@containedEdges.6 //@children.8/@children.9/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1235" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.8/@children.9/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N473" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L473" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P1236" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.8/@children.9/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1237" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N474" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L474" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P1238" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.9/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1239" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.8/@children.9/@containedEdges.17 //@children.8/@children.9/@containedEdges.18 //@children.8/@children.9/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N475" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L475" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P1240" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1241" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.8/@children.9/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N476" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L476" height="15.0" width="81.0" text="Accumulator3"/>
+        <ports identifier="P1242" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1243" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1244" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N477" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L477" height="15.0" width="78.0" text="MostRecent3"/>
+        <ports identifier="P1245" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.9/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1246" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1247" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@children.9/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N478" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L478" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P1248" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.12 //@children.8/@children.9/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1249" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1250" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N479" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L479" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P1251" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1252" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.9/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1253" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N480" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L480" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P1254" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1255" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.8/@children.9/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N481" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L481" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P1256" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1257" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.9/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1258" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N482" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L482" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P1259" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@children.9/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P1260" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.9/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N483" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L483" height="15.0" width="87.0" text="MultiplyDivide3"/>
+        <ports identifier="P1261" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.9/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1262" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.9/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1263" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N484" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L484" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P1264" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.9/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1265" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.9/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N485" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L485" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P1266" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.9/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P1267" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.8/@children.9/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E769" sources="//@children.8/@children.9/@ports.0" targets="//@children.8/@children.9/@children.0/@ports.1"/>
+      <containedEdges identifier="E770" sources="//@children.8/@children.9/@ports.0" targets="//@children.8/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E771" sources="//@children.8/@children.9/@ports.0" targets="//@children.8/@children.9/@children.7/@ports.1"/>
+      <containedEdges identifier="E772" sources="//@children.8/@children.9/@ports.0" targets="//@children.8/@children.9/@children.9/@ports.0"/>
+      <containedEdges identifier="E773" sources="//@children.8/@children.9/@children.0/@ports.0" targets="//@children.8/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E774" sources="//@children.8/@children.9/@children.1/@ports.1" targets="//@children.8/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E775" sources="//@children.8/@children.9/@children.1/@ports.1" targets="//@children.8/@children.9/@children.6/@ports.0"/>
+      <containedEdges identifier="E776" sources="//@children.8/@children.9/@children.2/@ports.1" targets="//@children.8/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E777" sources="//@children.8/@children.9/@children.3/@ports.2" targets="//@children.8/@children.9/@ports.1"/>
+      <containedEdges identifier="E778" sources="//@children.8/@children.9/@children.3/@ports.2" targets="//@children.8/@children.9/@children.14/@ports.0"/>
+      <containedEdges identifier="E779" sources="//@children.8/@children.9/@children.4/@ports.1" targets="//@children.8/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E780" sources="//@children.8/@children.9/@children.5/@ports.1" targets="//@children.8/@children.9/@children.3/@ports.1"/>
+      <containedEdges identifier="E781" sources="//@children.8/@children.9/@children.5/@ports.1" targets="//@children.8/@children.9/@children.12/@ports.0"/>
+      <containedEdges identifier="E782" sources="//@children.8/@children.9/@children.5/@ports.1" targets="//@children.8/@children.9/@children.15/@ports.0"/>
+      <containedEdges identifier="E783" sources="//@children.8/@children.9/@children.5/@ports.1" targets="//@children.8/@children.9/@children.16/@ports.1"/>
+      <containedEdges identifier="E784" sources="//@children.8/@children.9/@children.6/@ports.1" targets="//@children.8/@children.9/@children.8/@ports.0"/>
+      <containedEdges identifier="E785" sources="//@children.8/@children.9/@children.7/@ports.0" targets="//@children.8/@children.9/@children.6/@ports.0"/>
+      <containedEdges identifier="E786" sources="//@children.8/@children.9/@children.8/@ports.1" targets="//@children.8/@children.9/@children.4/@ports.2"/>
+      <containedEdges identifier="E787" sources="//@children.8/@children.9/@children.8/@ports.1" targets="//@children.8/@children.9/@children.5/@ports.2"/>
+      <containedEdges identifier="E788" sources="//@children.8/@children.9/@children.8/@ports.1" targets="//@children.8/@children.9/@children.11/@ports.2"/>
+      <containedEdges identifier="E789" sources="//@children.8/@children.9/@children.9/@ports.1" targets="//@children.8/@children.9/@children.10/@ports.0"/>
+      <containedEdges identifier="E790" sources="//@children.8/@children.9/@children.10/@ports.1" targets="//@children.8/@children.9/@children.11/@ports.0"/>
+      <containedEdges identifier="E791" sources="//@children.8/@children.9/@children.11/@ports.1" targets="//@children.8/@children.9/@children.13/@ports.0"/>
+      <containedEdges identifier="E792" sources="//@children.8/@children.9/@children.12/@ports.2" targets="//@children.8/@children.9/@children.13/@ports.1"/>
+      <containedEdges identifier="E793" sources="//@children.8/@children.9/@children.13/@ports.2" targets="//@children.8/@children.9/@children.17/@ports.0"/>
+      <containedEdges identifier="E794" sources="//@children.8/@children.9/@children.14/@ports.1" targets="//@children.8/@children.9/@children.12/@ports.0"/>
+      <containedEdges identifier="E795" sources="//@children.8/@children.9/@children.15/@ports.2" targets="//@children.8/@children.9/@children.18/@ports.0"/>
+      <containedEdges identifier="E796" sources="//@children.8/@children.9/@children.16/@ports.0" targets="//@children.8/@children.9/@children.15/@ports.1"/>
+      <containedEdges identifier="E797" sources="//@children.8/@children.9/@children.17/@ports.2" targets="//@children.8/@children.9/@children.19/@ports.0"/>
+      <containedEdges identifier="E798" sources="//@children.8/@children.9/@children.18/@ports.1" targets="//@children.8/@children.9/@children.17/@ports.1"/>
+      <containedEdges identifier="E799" sources="//@children.8/@children.9/@children.19/@ports.1" targets="//@children.8/@children.9/@ports.2"/>
+    </children>
+    <children identifier="N486" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L486" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P1268" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1269" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1270" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N487" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L487" height="15.0" width="111.0" text="RecordAssembler2"/>
+      <ports identifier="P1271" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1272" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1273" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N488" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L488" height="15.0" width="111.0" text="RecordAssembler3"/>
+      <ports identifier="P1274" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P1275" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P1276" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E713" sources="//@children.8/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E714" sources="//@children.8/@ports.0" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E715" sources="//@children.8/@ports.1" targets="//@children.8/@children.1/@ports.1"/>
+    <containedEdges identifier="E716" sources="//@children.8/@ports.1" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E717" sources="//@children.8/@ports.2" targets="//@children.8/@children.4/@ports.0"/>
+    <containedEdges identifier="E718" sources="//@children.8/@ports.2" targets="//@children.8/@children.5/@ports.0"/>
+    <containedEdges identifier="E719" sources="//@children.8/@ports.3" targets="//@children.8/@children.4/@ports.1"/>
+    <containedEdges identifier="E720" sources="//@children.8/@ports.3" targets="//@children.8/@children.6/@ports.0"/>
+    <containedEdges identifier="E721" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E722" sources="//@children.8/@children.1/@ports.2" targets="//@children.8/@children.0/@ports.2"/>
+    <containedEdges identifier="E723" sources="//@children.8/@children.1/@ports.2" targets="//@children.8/@children.2/@ports.2"/>
+    <containedEdges identifier="E724" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.3/@ports.1"/>
+    <containedEdges identifier="E725" sources="//@children.8/@children.3/@ports.2" targets="//@children.8/@children.8/@ports.0"/>
+    <containedEdges identifier="E726" sources="//@children.8/@children.4/@ports.2" targets="//@children.8/@children.5/@ports.2"/>
+    <containedEdges identifier="E727" sources="//@children.8/@children.4/@ports.2" targets="//@children.8/@children.6/@ports.2"/>
+    <containedEdges identifier="E728" sources="//@children.8/@children.5/@ports.1" targets="//@children.8/@children.7/@ports.0"/>
+    <containedEdges identifier="E729" sources="//@children.8/@children.6/@ports.1" targets="//@children.8/@children.7/@ports.1"/>
+    <containedEdges identifier="E730" sources="//@children.8/@children.7/@ports.2" targets="//@children.8/@children.9/@ports.0"/>
+    <containedEdges identifier="E731" sources="//@children.8/@children.8/@ports.1" targets="//@children.8/@children.10/@ports.1"/>
+    <containedEdges identifier="E732" sources="//@children.8/@children.8/@ports.2" targets="//@children.8/@children.10/@ports.2"/>
+    <containedEdges identifier="E733" sources="//@children.8/@children.9/@ports.1" targets="//@children.8/@children.11/@ports.1"/>
+    <containedEdges identifier="E734" sources="//@children.8/@children.9/@ports.2" targets="//@children.8/@children.11/@ports.2"/>
+    <containedEdges identifier="E735" sources="//@children.8/@children.10/@ports.0" targets="//@children.8/@children.12/@ports.1"/>
+    <containedEdges identifier="E736" sources="//@children.8/@children.11/@ports.0" targets="//@children.8/@children.12/@ports.2"/>
+    <containedEdges identifier="E737" sources="//@children.8/@children.12/@ports.0" targets="//@children.8/@ports.4"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.4" targets="//@children.4/@ports.6"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.4" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.3" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.5" targets="//@children.2/@ports.5"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.4" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.3" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.3/@ports.0" targets="//@children.2/@ports.7"/>
+  <containedEdges identifier="E13" sources="//@children.4/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.4/@ports.9" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.4/@ports.8" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.4/@ports.4" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.4/@ports.5" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.5/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.5/@ports.4" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.5/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.5/@ports.2" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.6/@ports.4" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E23" sources="//@children.6/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E24" sources="//@children.6/@ports.2" targets="//@children.8/@ports.3"/>
+  <containedEdges identifier="E25" sources="//@children.7/@ports.3" targets="//@children.4/@ports.7"/>
+  <containedEdges identifier="E26" sources="//@children.7/@ports.3" targets="//@children.5/@ports.3"/>
+  <containedEdges identifier="E27" sources="//@children.7/@ports.3" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E28" sources="//@children.8/@ports.4" targets="//@children.2/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/de_tte_TTE.elkg
+++ b/realworld/ptolemy/hierarchical/de_tte_TTE.elkg
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="101.0" text="CompositeActor2"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="101.0" text="CompositeActor4"/>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.1"/>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="101.0" text="CompositeActor5"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.5/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="101.0" text="CompositeActor6"/>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.6/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/dt_pickstates_pickstates.elkg
+++ b/realworld/ptolemy/hierarchical/dt_pickstates_pickstates.elkg
@@ -1,0 +1,2660 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="97.0" text="Pulse keyframes"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="94.0" text="robotic arm view"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="77.0" text="ViewScreen2"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L4" height="15.0" width="55.0" text="robot arm"/>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.4" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N5" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="57.0" text="Scale3D5"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.12 //@children.1/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L6" height="15.0" width="73.0" text="lower limb12"/>
+        <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.6" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N7" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L7" height="15.0" width="107.0" text="CircularSweep3D0"/>
+          <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="8.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N8" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L8" height="15.0" width="107.0" text="CircularSweep3D1"/>
+          <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="8.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N9" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L9" height="15.0" width="46.0" text="Rotate2"/>
+          <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="8.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N10" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L10" height="15.0" width="31.0" text="Box6"/>
+          <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="8.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N11" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L11" height="15.0" width="77.0" text="Translate3D9"/>
+          <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="4"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N12" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L12" height="15.0" width="84.0" text="Translate3D14"/>
+          <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N13" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L13" height="15.0" width="107.0" text="CircularSweep3D6"/>
+          <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N14" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L14" height="15.0" width="107.0" text="CircularSweep3D2"/>
+          <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N15" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="31.0" text="Box3"/>
+          <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="46.0" text="Rotate4"/>
+          <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="77.0" text="Translate3D5"/>
+          <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="77.0" text="Translate3D6"/>
+          <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N19" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L19" height="15.0" width="77.0" text="Translate3D7"/>
+          <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.6 //@children.1/@children.1/@children.1/@containedEdges.10 //@children.1/@children.1/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N20" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L20" height="15.0" width="31.0" text="Box0"/>
+          <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N21" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L21" height="15.0" width="31.0" text="Box1"/>
+          <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N22" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L22" height="15.0" width="31.0" text="Box2"/>
+          <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N23" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L23" height="15.0" width="31.0" text="Box4"/>
+          <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N24" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L24" height="15.0" width="77.0" text="Translate3D8"/>
+          <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N25" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="84.0" text="Translate3D10"/>
+          <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N26" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="83.0" text="Translate3D11"/>
+          <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N27" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="84.0" text="Translate3D12"/>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="46.0" text="Rotate0"/>
+          <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.0 //@children.1/@children.1/@children.1/@containedEdges.4 //@children.1/@children.1/@children.1/@containedEdges.5 //@children.1/@children.1/@children.1/@containedEdges.12 //@children.1/@children.1/@children.1/@containedEdges.17 //@children.1/@children.1/@children.1/@containedEdges.18 //@children.1/@children.1/@children.1/@containedEdges.19 //@children.1/@children.1/@children.1/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P57" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N29" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="77.0" text="Translate3D0"/>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E45" sources="//@children.1/@children.1/@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E46" sources="//@children.1/@children.1/@children.1/@children.1/@ports.1" targets="//@children.1/@children.1/@children.1/@children.2/@ports.2"/>
+        <containedEdges identifier="E47" sources="//@children.1/@children.1/@children.1/@children.2/@ports.3" targets="//@children.1/@children.1/@children.1/@children.4/@ports.3"/>
+        <containedEdges identifier="E48" sources="//@children.1/@children.1/@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@children.1/@children.5/@ports.0"/>
+        <containedEdges identifier="E49" sources="//@children.1/@children.1/@children.1/@children.4/@ports.4" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E50" sources="//@children.1/@children.1/@children.1/@children.5/@ports.1" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E51" sources="//@children.1/@children.1/@children.1/@children.6/@ports.0" targets="//@children.1/@children.1/@children.1/@children.12/@ports.0"/>
+        <containedEdges identifier="E52" sources="//@children.1/@children.1/@children.1/@children.7/@ports.0" targets="//@children.1/@children.1/@children.1/@children.9/@ports.0"/>
+        <containedEdges identifier="E53" sources="//@children.1/@children.1/@children.1/@children.8/@ports.0" targets="//@children.1/@children.1/@children.1/@children.11/@ports.0"/>
+        <containedEdges identifier="E54" sources="//@children.1/@children.1/@children.1/@children.9/@ports.1" targets="//@children.1/@children.1/@children.1/@children.10/@ports.0"/>
+        <containedEdges identifier="E55" sources="//@children.1/@children.1/@children.1/@children.10/@ports.1" targets="//@children.1/@children.1/@children.1/@children.12/@ports.0"/>
+        <containedEdges identifier="E56" sources="//@children.1/@children.1/@children.1/@children.11/@ports.1" targets="//@children.1/@children.1/@children.1/@children.12/@ports.0"/>
+        <containedEdges identifier="E57" sources="//@children.1/@children.1/@children.1/@children.12/@ports.1" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E58" sources="//@children.1/@children.1/@children.1/@children.13/@ports.0" targets="//@children.1/@children.1/@children.1/@children.17/@ports.0"/>
+        <containedEdges identifier="E59" sources="//@children.1/@children.1/@children.1/@children.14/@ports.0" targets="//@children.1/@children.1/@children.1/@children.18/@ports.0"/>
+        <containedEdges identifier="E60" sources="//@children.1/@children.1/@children.1/@children.15/@ports.0" targets="//@children.1/@children.1/@children.1/@children.19/@ports.0"/>
+        <containedEdges identifier="E61" sources="//@children.1/@children.1/@children.1/@children.16/@ports.0" targets="//@children.1/@children.1/@children.1/@children.20/@ports.0"/>
+        <containedEdges identifier="E62" sources="//@children.1/@children.1/@children.1/@children.17/@ports.1" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E63" sources="//@children.1/@children.1/@children.1/@children.18/@ports.1" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E64" sources="//@children.1/@children.1/@children.1/@children.19/@ports.1" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E65" sources="//@children.1/@children.1/@children.1/@children.20/@ports.1" targets="//@children.1/@children.1/@children.1/@children.21/@ports.0"/>
+        <containedEdges identifier="E66" sources="//@children.1/@children.1/@children.1/@children.21/@ports.1" targets="//@children.1/@children.1/@children.1/@children.22/@ports.0"/>
+        <containedEdges identifier="E67" sources="//@children.1/@children.1/@children.1/@children.22/@ports.1" targets="//@children.1/@children.1/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N30" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="46.0" text="Rotate3"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@children.1/@containedEdges.7 //@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N32">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L32" height="15.0" width="68.0" text="upper limb0"/>
+        <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.9" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N33" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L33" height="15.0" width="31.0" text="Box1"/>
+          <ports identifier="P66" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N34" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L34" height="15.0" width="57.0" text="Scale3D0"/>
+          <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.0 //@children.1/@children.1/@children.4/@containedEdges.3 //@children.1/@children.1/@children.4/@containedEdges.6 //@children.1/@children.1/@children.4/@containedEdges.7 //@children.1/@children.1/@children.4/@containedEdges.8 //@children.1/@children.1/@children.4/@containedEdges.12 //@children.1/@children.1/@children.4/@containedEdges.13 //@children.1/@children.1/@children.4/@containedEdges.14 //@children.1/@children.1/@children.4/@containedEdges.17 //@children.1/@children.1/@children.4/@containedEdges.18 //@children.1/@children.1/@children.4/@containedEdges.22 //@children.1/@children.1/@children.4/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N35" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L35" height="15.0" width="31.0" text="Box4"/>
+          <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N36" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L36" height="15.0" width="77.0" text="Translate3D0"/>
+          <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N37" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L37" height="15.0" width="31.0" text="Box0"/>
+          <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N38" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L38" height="15.0" width="31.0" text="Box2"/>
+          <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N39" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L39" height="15.0" width="77.0" text="Translate3D3"/>
+          <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N40" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L40" height="15.0" width="77.0" text="Translate3D6"/>
+          <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N41" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L41" height="15.0" width="77.0" text="Translate3D1"/>
+          <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N42" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L42" height="15.0" width="31.0" text="Box3"/>
+          <ports identifier="P80" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N43" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L43" height="15.0" width="31.0" text="Box5"/>
+          <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N44" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L44" height="15.0" width="31.0" text="Box6"/>
+          <ports identifier="P82" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N45" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L45" height="15.0" width="84.0" text="Translate3D12"/>
+          <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N46" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L46" height="15.0" width="84.0" text="Translate3D15"/>
+          <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P86" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N47" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L47" height="15.0" width="84.0" text="Translate3D22"/>
+          <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P88" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N48" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L48" height="15.0" width="38.0" text="Box23"/>
+          <ports identifier="P89" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N49" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L49" height="15.0" width="31.0" text="Box7"/>
+          <ports identifier="P90" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N50" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L50" height="15.0" width="77.0" text="Translate3D2"/>
+          <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P92" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N51" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L51" height="15.0" width="77.0" text="Translate3D4"/>
+          <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P94" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N52" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L52" height="15.0" width="31.0" text="Box8"/>
+          <ports identifier="P95" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N53" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L53" height="15.0" width="31.0" text="Box9"/>
+          <ports identifier="P96" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N54" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L54" height="15.0" width="38.0" text="Box10"/>
+          <ports identifier="P97" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N55" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L55" height="15.0" width="83.0" text="Translate3D11"/>
+          <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.20 //@children.1/@children.1/@children.4/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N56" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L56" height="15.0" width="84.0" text="Translate3D13"/>
+          <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P101" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N57" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L57" height="15.0" width="55.0" text="Cylinder0"/>
+          <ports identifier="P102" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N58" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L58" height="15.0" width="77.0" text="Translate3D5"/>
+          <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P104" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N59" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="53.0" text="Rotate24"/>
+          <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.4/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P106" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.4/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E68" sources="//@children.1/@children.1/@children.4/@children.0/@ports.0" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E69" sources="//@children.1/@children.1/@children.4/@children.1/@ports.1" targets="//@children.1/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E70" sources="//@children.1/@children.1/@children.4/@children.2/@ports.0" targets="//@children.1/@children.1/@children.4/@children.3/@ports.0"/>
+        <containedEdges identifier="E71" sources="//@children.1/@children.1/@children.4/@children.3/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E72" sources="//@children.1/@children.1/@children.4/@children.4/@ports.0" targets="//@children.1/@children.1/@children.4/@children.6/@ports.0"/>
+        <containedEdges identifier="E73" sources="//@children.1/@children.1/@children.4/@children.5/@ports.0" targets="//@children.1/@children.1/@children.4/@children.7/@ports.0"/>
+        <containedEdges identifier="E74" sources="//@children.1/@children.1/@children.4/@children.6/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E75" sources="//@children.1/@children.1/@children.4/@children.7/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E76" sources="//@children.1/@children.1/@children.4/@children.8/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E77" sources="//@children.1/@children.1/@children.4/@children.9/@ports.0" targets="//@children.1/@children.1/@children.4/@children.8/@ports.0"/>
+        <containedEdges identifier="E78" sources="//@children.1/@children.1/@children.4/@children.10/@ports.0" targets="//@children.1/@children.1/@children.4/@children.12/@ports.0"/>
+        <containedEdges identifier="E79" sources="//@children.1/@children.1/@children.4/@children.11/@ports.0" targets="//@children.1/@children.1/@children.4/@children.13/@ports.0"/>
+        <containedEdges identifier="E80" sources="//@children.1/@children.1/@children.4/@children.12/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E81" sources="//@children.1/@children.1/@children.4/@children.13/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E82" sources="//@children.1/@children.1/@children.4/@children.14/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E83" sources="//@children.1/@children.1/@children.4/@children.15/@ports.0" targets="//@children.1/@children.1/@children.4/@children.14/@ports.0"/>
+        <containedEdges identifier="E84" sources="//@children.1/@children.1/@children.4/@children.16/@ports.0" targets="//@children.1/@children.1/@children.4/@children.17/@ports.0"/>
+        <containedEdges identifier="E85" sources="//@children.1/@children.1/@children.4/@children.17/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E86" sources="//@children.1/@children.1/@children.4/@children.18/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E87" sources="//@children.1/@children.1/@children.4/@children.19/@ports.0" targets="//@children.1/@children.1/@children.4/@children.18/@ports.0"/>
+        <containedEdges identifier="E88" sources="//@children.1/@children.1/@children.4/@children.20/@ports.0" targets="//@children.1/@children.1/@children.4/@children.22/@ports.0"/>
+        <containedEdges identifier="E89" sources="//@children.1/@children.1/@children.4/@children.21/@ports.0" targets="//@children.1/@children.1/@children.4/@children.23/@ports.0"/>
+        <containedEdges identifier="E90" sources="//@children.1/@children.1/@children.4/@children.22/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E91" sources="//@children.1/@children.1/@children.4/@children.23/@ports.1" targets="//@children.1/@children.1/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E92" sources="//@children.1/@children.1/@children.4/@children.24/@ports.0" targets="//@children.1/@children.1/@children.4/@children.26/@ports.0"/>
+        <containedEdges identifier="E93" sources="//@children.1/@children.1/@children.4/@children.25/@ports.1" targets="//@children.1/@children.1/@children.4/@children.22/@ports.0"/>
+        <containedEdges identifier="E94" sources="//@children.1/@children.1/@children.4/@children.26/@ports.1" targets="//@children.1/@children.1/@children.4/@children.25/@ports.0"/>
+      </children>
+      <children identifier="N60" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="46.0" text="Rotate2"/>
+        <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@children.1/@containedEdges.10 //@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P110" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N62" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L62" height="15.0" width="46.0" text="Rotate0"/>
+        <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@children.1/@containedEdges.8 //@children.1/@children.1/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N63" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L63" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.15 //@children.1/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N64" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L64" height="15.0" width="46.0" text="Rotate4"/>
+        <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N65">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L65" height="15.0" width="35.0" text="wrist0"/>
+        <ports identifier="P120" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.15" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N66" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L66" height="15.0" width="107.0" text="CircularSweep3D0"/>
+          <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N67" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L67" height="15.0" width="45.0" text="PolyCyl"/>
+          <ports identifier="P122" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N68" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="46.0" text="Rotate2"/>
+          <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P124" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="46.0" text="Rotate4"/>
+          <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P126" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="77.0" text="Translate3D2"/>
+          <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P128" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N71" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="46.0" text="Rotate8"/>
+          <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="107.0" text="CircularSweep3D1"/>
+          <ports identifier="P131" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N73" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="46.0" text="Rotate3"/>
+          <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P133" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N74" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="57.0" text="Scale3D4"/>
+          <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P135" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N75" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L75" height="15.0" width="103.0" text="PolyCylinder3D11"/>
+          <ports identifier="P136" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N76" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L76" height="15.0" width="53.0" text="Rotate12"/>
+          <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P138" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N77" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L77" height="15.0" width="53.0" text="Rotate13"/>
+          <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P140" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N78" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L78" height="15.0" width="84.0" text="Translate3D14"/>
+          <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P142" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N79" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L79" height="15.0" width="84.0" text="Translate3D15"/>
+          <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.8 //@children.1/@children.1/@children.10/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P144" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N80" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L80" height="15.0" width="38.0" text="Box28"/>
+          <ports identifier="P145" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N81" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L81" height="15.0" width="31.0" text="Box0"/>
+          <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N82" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L82" height="15.0" width="77.0" text="Translate3D1"/>
+          <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N83" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L83" height="15.0" width="77.0" text="Translate3D3"/>
+          <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P150" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N84" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L84" height="15.0" width="77.0" text="Translate3D4"/>
+          <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P152" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N85" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L85" height="15.0" width="46.0" text="Rotate9"/>
+          <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.4 //@children.1/@children.1/@children.10/@containedEdges.5 //@children.1/@children.1/@children.10/@containedEdges.13 //@children.1/@children.1/@children.10/@containedEdges.16 //@children.1/@children.1/@children.10/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P154" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N86" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L86" height="15.0" width="53.0" text="Rotate10"/>
+          <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N87" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L87" height="15.0" width="64.0" text="Scale3D15"/>
+          <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.18 //@children.1/@children.1/@children.10/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P158" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N88" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L88" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+          <ports identifier="P159" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N89" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L89" height="15.0" width="53.0" text="Rotate27"/>
+          <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P161" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N90" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L90" height="15.0" width="46.0" text="Rotate0"/>
+          <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P163" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N91" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L91" height="15.0" width="84.0" text="Translate3D22"/>
+          <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.10/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P165" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.10/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E95" sources="//@children.1/@children.1/@children.10/@children.0/@ports.0" targets="//@children.1/@children.1/@children.10/@children.5/@ports.0"/>
+        <containedEdges identifier="E96" sources="//@children.1/@children.1/@children.10/@children.1/@ports.0" targets="//@children.1/@children.1/@children.10/@children.2/@ports.0"/>
+        <containedEdges identifier="E97" sources="//@children.1/@children.1/@children.10/@children.2/@ports.1" targets="//@children.1/@children.1/@children.10/@children.3/@ports.0"/>
+        <containedEdges identifier="E98" sources="//@children.1/@children.1/@children.10/@children.3/@ports.1" targets="//@children.1/@children.1/@children.10/@children.4/@ports.0"/>
+        <containedEdges identifier="E99" sources="//@children.1/@children.1/@children.10/@children.4/@ports.1" targets="//@children.1/@children.1/@children.10/@children.19/@ports.0"/>
+        <containedEdges identifier="E100" sources="//@children.1/@children.1/@children.10/@children.5/@ports.1" targets="//@children.1/@children.1/@children.10/@children.19/@ports.0"/>
+        <containedEdges identifier="E101" sources="//@children.1/@children.1/@children.10/@children.6/@ports.0" targets="//@children.1/@children.1/@children.10/@children.7/@ports.0"/>
+        <containedEdges identifier="E102" sources="//@children.1/@children.1/@children.10/@children.7/@ports.1" targets="//@children.1/@children.1/@children.10/@children.8/@ports.0"/>
+        <containedEdges identifier="E103" sources="//@children.1/@children.1/@children.10/@children.8/@ports.1" targets="//@children.1/@children.1/@children.10/@children.13/@ports.0"/>
+        <containedEdges identifier="E104" sources="//@children.1/@children.1/@children.10/@children.9/@ports.0" targets="//@children.1/@children.1/@children.10/@children.10/@ports.0"/>
+        <containedEdges identifier="E105" sources="//@children.1/@children.1/@children.10/@children.10/@ports.1" targets="//@children.1/@children.1/@children.10/@children.11/@ports.0"/>
+        <containedEdges identifier="E106" sources="//@children.1/@children.1/@children.10/@children.11/@ports.1" targets="//@children.1/@children.1/@children.10/@children.12/@ports.0"/>
+        <containedEdges identifier="E107" sources="//@children.1/@children.1/@children.10/@children.12/@ports.1" targets="//@children.1/@children.1/@children.10/@children.13/@ports.0"/>
+        <containedEdges identifier="E108" sources="//@children.1/@children.1/@children.10/@children.13/@ports.1" targets="//@children.1/@children.1/@children.10/@children.19/@ports.0"/>
+        <containedEdges identifier="E109" sources="//@children.1/@children.1/@children.10/@children.14/@ports.0" targets="//@children.1/@children.1/@children.10/@children.16/@ports.0"/>
+        <containedEdges identifier="E110" sources="//@children.1/@children.1/@children.10/@children.15/@ports.0" targets="//@children.1/@children.1/@children.10/@children.17/@ports.0"/>
+        <containedEdges identifier="E111" sources="//@children.1/@children.1/@children.10/@children.16/@ports.1" targets="//@children.1/@children.1/@children.10/@children.19/@ports.0"/>
+        <containedEdges identifier="E112" sources="//@children.1/@children.1/@children.10/@children.17/@ports.1" targets="//@children.1/@children.1/@children.10/@children.19/@ports.0"/>
+        <containedEdges identifier="E113" sources="//@children.1/@children.1/@children.10/@children.18/@ports.1" targets="//@children.1/@children.1/@children.10/@children.21/@ports.0"/>
+        <containedEdges identifier="E114" sources="//@children.1/@children.1/@children.10/@children.19/@ports.1" targets="//@children.1/@children.1/@children.10/@children.20/@ports.0"/>
+        <containedEdges identifier="E115" sources="//@children.1/@children.1/@children.10/@children.20/@ports.1" targets="//@children.1/@children.1/@children.10/@children.18/@ports.0"/>
+        <containedEdges identifier="E116" sources="//@children.1/@children.1/@children.10/@children.21/@ports.1" targets="//@children.1/@children.1/@children.10/@ports.0"/>
+        <containedEdges identifier="E117" sources="//@children.1/@children.1/@children.10/@children.22/@ports.0" targets="//@children.1/@children.1/@children.10/@children.23/@ports.0"/>
+        <containedEdges identifier="E118" sources="//@children.1/@children.1/@children.10/@children.23/@ports.1" targets="//@children.1/@children.1/@children.10/@children.24/@ports.0"/>
+        <containedEdges identifier="E119" sources="//@children.1/@children.1/@children.10/@children.24/@ports.1" targets="//@children.1/@children.1/@children.10/@children.25/@ports.0"/>
+        <containedEdges identifier="E120" sources="//@children.1/@children.1/@children.10/@children.25/@ports.1" targets="//@children.1/@children.1/@children.10/@children.21/@ports.0"/>
+      </children>
+      <children identifier="N92">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L92" height="15.0" width="47.0" text="gripper0"/>
+        <ports identifier="P166" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.16" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N93" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+          <ports identifier="P167" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="45.0" text="PolyCyl"/>
+          <ports identifier="P168" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N95" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L95" height="15.0" width="77.0" text="Translate3D0"/>
+          <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P170" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N96" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L96" height="15.0" width="46.0" text="Rotate1"/>
+          <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.0 //@children.1/@children.1/@children.11/@containedEdges.8 //@children.1/@children.1/@children.11/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P172" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N97" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L97" height="15.0" width="46.0" text="Rotate6"/>
+          <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.1 //@children.1/@children.1/@children.11/@containedEdges.15 //@children.1/@children.1/@children.11/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P174" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N98" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L98" height="15.0" width="53.0" text="Rotate13"/>
+          <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P176" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N99" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L99" height="15.0" width="31.0" text="Box7"/>
+          <ports identifier="P177" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N100" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L100" height="15.0" width="84.0" text="Translate3D10"/>
+          <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.6 //@children.1/@children.1/@children.11/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P179" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N101" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L101" height="15.0" width="46.0" text="Rotate3"/>
+          <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P181" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N102" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L102" height="15.0" width="38.0" text="Box10"/>
+          <ports identifier="P182" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N103" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L103" height="15.0" width="77.0" text="Translate3D1"/>
+          <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P184" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N104" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L104" height="15.0" width="38.0" text="Box14"/>
+          <ports identifier="P185" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N105" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L105" height="15.0" width="31.0" text="Box0"/>
+          <ports identifier="P186" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N106" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L106" height="15.0" width="77.0" text="Translate3D2"/>
+          <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.11 //@children.1/@children.1/@children.11/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P188" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N107" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L107" height="15.0" width="77.0" text="Translate3D3"/>
+          <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P190" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N108" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L108" height="15.0" width="46.0" text="Rotate4"/>
+          <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P192" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N109" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L109" height="15.0" width="97.0" text="PolyCylinder3D1"/>
+          <ports identifier="P193" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N110" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L110" height="15.0" width="77.0" text="Translate3D4"/>
+          <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.16 //@children.1/@children.1/@children.11/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P195" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N111" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L111" height="15.0" width="46.0" text="Rotate5"/>
+          <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P197" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N112" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="97.0" text="PolyCylinder3D2"/>
+          <ports identifier="P198" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="77.0" text="Translate3D5"/>
+          <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P200" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N114" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L114" height="15.0" width="104.0" text="PolyCylinder3D24"/>
+          <ports identifier="P201" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N115" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L115" height="15.0" width="77.0" text="Translate3D6"/>
+          <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.21 //@children.1/@children.1/@children.11/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P203" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N116" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L116" height="15.0" width="46.0" text="Rotate7"/>
+          <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P205" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N117" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="104.0" text="PolyCylinder3D27"/>
+          <ports identifier="P206" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N118" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L118" height="15.0" width="77.0" text="Translate3D7"/>
+          <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P208" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N119" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="84.0" text="Translate3D28"/>
+          <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.2 //@children.1/@children.1/@children.11/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P210" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N120" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L120" height="15.0" width="53.0" text="Rotate14"/>
+          <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P212" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N121" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L121" height="15.0" width="53.0" text="Rotate30"/>
+          <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.11/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P214" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.11/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E121" sources="//@children.1/@children.1/@children.11/@children.0/@ports.0" targets="//@children.1/@children.1/@children.11/@children.3/@ports.0"/>
+        <containedEdges identifier="E122" sources="//@children.1/@children.1/@children.11/@children.1/@ports.0" targets="//@children.1/@children.1/@children.11/@children.4/@ports.0"/>
+        <containedEdges identifier="E123" sources="//@children.1/@children.1/@children.11/@children.2/@ports.1" targets="//@children.1/@children.1/@children.11/@children.26/@ports.0"/>
+        <containedEdges identifier="E124" sources="//@children.1/@children.1/@children.11/@children.3/@ports.1" targets="//@children.1/@children.1/@children.11/@children.26/@ports.0"/>
+        <containedEdges identifier="E125" sources="//@children.1/@children.1/@children.11/@children.4/@ports.1" targets="//@children.1/@children.1/@children.11/@children.5/@ports.0"/>
+        <containedEdges identifier="E126" sources="//@children.1/@children.1/@children.11/@children.5/@ports.1" targets="//@children.1/@children.1/@children.11/@children.2/@ports.0"/>
+        <containedEdges identifier="E127" sources="//@children.1/@children.1/@children.11/@children.6/@ports.0" targets="//@children.1/@children.1/@children.11/@children.7/@ports.0"/>
+        <containedEdges identifier="E128" sources="//@children.1/@children.1/@children.11/@children.7/@ports.1" targets="//@children.1/@children.1/@children.11/@children.8/@ports.0"/>
+        <containedEdges identifier="E129" sources="//@children.1/@children.1/@children.11/@children.8/@ports.1" targets="//@children.1/@children.1/@children.11/@children.3/@ports.0"/>
+        <containedEdges identifier="E130" sources="//@children.1/@children.1/@children.11/@children.9/@ports.0" targets="//@children.1/@children.1/@children.11/@children.10/@ports.0"/>
+        <containedEdges identifier="E131" sources="//@children.1/@children.1/@children.11/@children.10/@ports.1" targets="//@children.1/@children.1/@children.11/@children.7/@ports.0"/>
+        <containedEdges identifier="E132" sources="//@children.1/@children.1/@children.11/@children.11/@ports.0" targets="//@children.1/@children.1/@children.11/@children.13/@ports.0"/>
+        <containedEdges identifier="E133" sources="//@children.1/@children.1/@children.11/@children.12/@ports.0" targets="//@children.1/@children.1/@children.11/@children.14/@ports.0"/>
+        <containedEdges identifier="E134" sources="//@children.1/@children.1/@children.11/@children.13/@ports.1" targets="//@children.1/@children.1/@children.11/@children.15/@ports.0"/>
+        <containedEdges identifier="E135" sources="//@children.1/@children.1/@children.11/@children.14/@ports.1" targets="//@children.1/@children.1/@children.11/@children.13/@ports.0"/>
+        <containedEdges identifier="E136" sources="//@children.1/@children.1/@children.11/@children.15/@ports.1" targets="//@children.1/@children.1/@children.11/@children.4/@ports.0"/>
+        <containedEdges identifier="E137" sources="//@children.1/@children.1/@children.11/@children.16/@ports.0" targets="//@children.1/@children.1/@children.11/@children.17/@ports.0"/>
+        <containedEdges identifier="E138" sources="//@children.1/@children.1/@children.11/@children.17/@ports.1" targets="//@children.1/@children.1/@children.11/@children.18/@ports.0"/>
+        <containedEdges identifier="E139" sources="//@children.1/@children.1/@children.11/@children.18/@ports.1" targets="//@children.1/@children.1/@children.11/@children.3/@ports.0"/>
+        <containedEdges identifier="E140" sources="//@children.1/@children.1/@children.11/@children.19/@ports.0" targets="//@children.1/@children.1/@children.11/@children.20/@ports.0"/>
+        <containedEdges identifier="E141" sources="//@children.1/@children.1/@children.11/@children.20/@ports.1" targets="//@children.1/@children.1/@children.11/@children.17/@ports.0"/>
+        <containedEdges identifier="E142" sources="//@children.1/@children.1/@children.11/@children.21/@ports.0" targets="//@children.1/@children.1/@children.11/@children.22/@ports.0"/>
+        <containedEdges identifier="E143" sources="//@children.1/@children.1/@children.11/@children.22/@ports.1" targets="//@children.1/@children.1/@children.11/@children.23/@ports.0"/>
+        <containedEdges identifier="E144" sources="//@children.1/@children.1/@children.11/@children.23/@ports.1" targets="//@children.1/@children.1/@children.11/@children.4/@ports.0"/>
+        <containedEdges identifier="E145" sources="//@children.1/@children.1/@children.11/@children.24/@ports.0" targets="//@children.1/@children.1/@children.11/@children.25/@ports.0"/>
+        <containedEdges identifier="E146" sources="//@children.1/@children.1/@children.11/@children.25/@ports.1" targets="//@children.1/@children.1/@children.11/@children.22/@ports.0"/>
+        <containedEdges identifier="E147" sources="//@children.1/@children.1/@children.11/@children.26/@ports.1" targets="//@children.1/@children.1/@children.11/@children.27/@ports.0"/>
+        <containedEdges identifier="E148" sources="//@children.1/@children.1/@children.11/@children.27/@ports.1" targets="//@children.1/@children.1/@children.11/@children.28/@ports.0"/>
+        <containedEdges identifier="E149" sources="//@children.1/@children.1/@children.11/@children.28/@ports.1" targets="//@children.1/@children.1/@children.11/@ports.0"/>
+      </children>
+      <children identifier="N122" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L122" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.16 //@children.1/@children.1/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P216" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N123">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L123" height="15.0" width="40.0" text="stand0"/>
+        <ports identifier="P217" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.18" incomingEdges="//@children.1/@children.1/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N124" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L124" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+          <ports identifier="P218" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N125" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L125" height="15.0" width="97.0" text="PolyCylinder3D4"/>
+          <ports identifier="P219" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N126" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L126" height="15.0" width="77.0" text="Translate3D0"/>
+          <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.13/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P221" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N127" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L127" height="15.0" width="31.0" text="Box5"/>
+          <ports identifier="P222" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N128" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L128" height="15.0" width="77.0" text="Translate3D6"/>
+          <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.13/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P224" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N129" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L129" height="15.0" width="77.0" text="Translate3D8"/>
+          <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.13/@containedEdges.0 //@children.1/@children.1/@children.13/@containedEdges.2 //@children.1/@children.1/@children.13/@containedEdges.4 //@children.1/@children.1/@children.13/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P226" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N130" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L130" height="15.0" width="31.0" text="Box0"/>
+          <ports identifier="P227" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N131" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L131" height="15.0" width="77.0" text="Translate3D1"/>
+          <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.13/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P229" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.13/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E150" sources="//@children.1/@children.1/@children.13/@children.0/@ports.0" targets="//@children.1/@children.1/@children.13/@children.5/@ports.0"/>
+        <containedEdges identifier="E151" sources="//@children.1/@children.1/@children.13/@children.1/@ports.0" targets="//@children.1/@children.1/@children.13/@children.2/@ports.0"/>
+        <containedEdges identifier="E152" sources="//@children.1/@children.1/@children.13/@children.2/@ports.1" targets="//@children.1/@children.1/@children.13/@children.5/@ports.0"/>
+        <containedEdges identifier="E153" sources="//@children.1/@children.1/@children.13/@children.3/@ports.0" targets="//@children.1/@children.1/@children.13/@children.4/@ports.0"/>
+        <containedEdges identifier="E154" sources="//@children.1/@children.1/@children.13/@children.4/@ports.1" targets="//@children.1/@children.1/@children.13/@children.5/@ports.0"/>
+        <containedEdges identifier="E155" sources="//@children.1/@children.1/@children.13/@children.5/@ports.1" targets="//@children.1/@children.1/@children.13/@ports.0"/>
+        <containedEdges identifier="E156" sources="//@children.1/@children.1/@children.13/@children.6/@ports.0" targets="//@children.1/@children.1/@children.13/@children.7/@ports.0"/>
+        <containedEdges identifier="E157" sources="//@children.1/@children.1/@children.13/@children.7/@ports.1" targets="//@children.1/@children.1/@children.13/@children.5/@ports.0"/>
+      </children>
+      <children identifier="N132">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L132" height="15.0" width="89.0" text="shoulder base0"/>
+        <ports identifier="P230" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.19" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N133" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L133" height="15.0" width="104.0" text="PolyCylinder3D13"/>
+          <ports identifier="P231" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N134" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L134" height="15.0" width="77.0" text="Translate3D1"/>
+          <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P233" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N135" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L135" height="15.0" width="46.0" text="Rotate0"/>
+          <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P235" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N136" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L136" height="15.0" width="64.0" text="Scale3D10"/>
+          <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P237" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N137" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L137" height="15.0" width="84.0" text="Translate3D12"/>
+          <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P239" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N138" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L138" height="15.0" width="53.0" text="Rotate17"/>
+          <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P241" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N139" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L139" height="15.0" width="57.0" text="Scale3D0"/>
+          <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.5 //@children.1/@children.1/@children.14/@containedEdges.10 //@children.1/@children.1/@children.14/@containedEdges.12 //@children.1/@children.1/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P243" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N140" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L140" height="15.0" width="31.0" text="Box6"/>
+          <ports identifier="P244" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N141" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L141" height="15.0" width="31.0" text="Box0"/>
+          <ports identifier="P245" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N142" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L142" height="15.0" width="31.0" text="Box1"/>
+          <ports identifier="P246" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N143" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L143" height="15.0" width="77.0" text="Translate3D2"/>
+          <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.7 //@children.1/@children.1/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P248" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N144" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L144" height="15.0" width="77.0" text="Translate3D7"/>
+          <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P250" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N145" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L145" height="15.0" width="83.0" text="Translate3D11"/>
+          <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P252" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N146" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L146" height="15.0" width="47.0" text="Box3D0"/>
+          <ports identifier="P253" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N147" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L147" height="15.0" width="77.0" text="Translate3D6"/>
+          <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@children.14/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P255" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@children.14/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E158" sources="//@children.1/@children.1/@children.14/@children.0/@ports.0" targets="//@children.1/@children.1/@children.14/@children.1/@ports.0"/>
+        <containedEdges identifier="E159" sources="//@children.1/@children.1/@children.14/@children.1/@ports.1" targets="//@children.1/@children.1/@children.14/@children.3/@ports.0"/>
+        <containedEdges identifier="E160" sources="//@children.1/@children.1/@children.14/@children.2/@ports.1" targets="//@children.1/@children.1/@children.14/@children.4/@ports.0"/>
+        <containedEdges identifier="E161" sources="//@children.1/@children.1/@children.14/@children.3/@ports.1" targets="//@children.1/@children.1/@children.14/@children.2/@ports.0"/>
+        <containedEdges identifier="E162" sources="//@children.1/@children.1/@children.14/@children.4/@ports.1" targets="//@children.1/@children.1/@children.14/@children.5/@ports.0"/>
+        <containedEdges identifier="E163" sources="//@children.1/@children.1/@children.14/@children.5/@ports.1" targets="//@children.1/@children.1/@children.14/@children.6/@ports.0"/>
+        <containedEdges identifier="E164" sources="//@children.1/@children.1/@children.14/@children.6/@ports.1" targets="//@children.1/@children.1/@children.14/@ports.0"/>
+        <containedEdges identifier="E165" sources="//@children.1/@children.1/@children.14/@children.7/@ports.0" targets="//@children.1/@children.1/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E166" sources="//@children.1/@children.1/@children.14/@children.8/@ports.0" targets="//@children.1/@children.1/@children.14/@children.11/@ports.0"/>
+        <containedEdges identifier="E167" sources="//@children.1/@children.1/@children.14/@children.9/@ports.0" targets="//@children.1/@children.1/@children.14/@children.12/@ports.0"/>
+        <containedEdges identifier="E168" sources="//@children.1/@children.1/@children.14/@children.10/@ports.1" targets="//@children.1/@children.1/@children.14/@children.6/@ports.0"/>
+        <containedEdges identifier="E169" sources="//@children.1/@children.1/@children.14/@children.11/@ports.1" targets="//@children.1/@children.1/@children.14/@children.10/@ports.0"/>
+        <containedEdges identifier="E170" sources="//@children.1/@children.1/@children.14/@children.12/@ports.1" targets="//@children.1/@children.1/@children.14/@children.6/@ports.0"/>
+        <containedEdges identifier="E171" sources="//@children.1/@children.1/@children.14/@children.13/@ports.0" targets="//@children.1/@children.1/@children.14/@children.14/@ports.0"/>
+        <containedEdges identifier="E172" sources="//@children.1/@children.1/@children.14/@children.14/@ports.1" targets="//@children.1/@children.1/@children.14/@children.6/@ports.0"/>
+      </children>
+      <children identifier="N148" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L148" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P257" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E24" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.1/@children.7/@ports.2"/>
+      <containedEdges identifier="E25" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.1/@children.3/@ports.2"/>
+      <containedEdges identifier="E26" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.1/@children.6/@ports.2"/>
+      <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.4" targets="//@children.1/@children.1/@children.9/@ports.2"/>
+      <containedEdges identifier="E28" sources="//@children.1/@children.1/@ports.5" targets="//@children.1/@children.1/@children.15/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.1/@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.1/@children.1/@children.2/@ports.1" targets="//@children.1/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@children.7/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.1/@children.5/@ports.1" targets="//@children.1/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.1/@children.6/@ports.1" targets="//@children.1/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.1/@children.7/@ports.1" targets="//@children.1/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.1/@children.8/@ports.1" targets="//@children.1/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.1/@children.1/@children.9/@ports.1" targets="//@children.1/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.1/@children.10/@ports.0" targets="//@children.1/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.1/@children.11/@ports.0" targets="//@children.1/@children.1/@children.12/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.1/@children.12/@ports.1" targets="//@children.1/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.1/@children.13/@ports.0" targets="//@children.1/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.1/@children.14/@ports.0" targets="//@children.1/@children.1/@children.7/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.1/@children.15/@ports.1" targets="//@children.1/@children.1/@children.12/@ports.0"/>
+    </children>
+    <children identifier="N149" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L149" height="15.0" width="44.0" text="red ring"/>
+      <ports identifier="P258" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N150" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L150" height="15.0" width="58.0" text="green ring"/>
+      <ports identifier="P259" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N151" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L151" height="15.0" width="63.0" text="Switch3D1"/>
+      <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P261" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N152" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L152" height="15.0" width="64.0" text="Scale3D23"/>
+      <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P264" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N153">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L153" height="15.0" width="51.0" text="table top"/>
+      <ports identifier="P265" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.10" incomingEdges="//@children.1/@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P266" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P267" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P268" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N154" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L154" height="15.0" width="54.0" text="table_top"/>
+        <ports identifier="P269" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N155" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L155" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.3 //@children.1/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P271" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N156" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L156" height="15.0" width="61.0" text="slot_stand"/>
+        <ports identifier="P272" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N157" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L157" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.5 //@children.1/@children.6/@containedEdges.10 //@children.1/@children.6/@containedEdges.11 //@children.1/@children.6/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P274" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N158" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L158" height="15.0" width="68.0" text="slot1_stand"/>
+        <ports identifier="P275" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N159" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L159" height="15.0" width="68.0" text="slot2_stand"/>
+        <ports identifier="P276" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N160" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L160" height="15.0" width="68.0" text="slot3_stand"/>
+        <ports identifier="P277" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N161" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L161" height="15.0" width="84.0" text="Translate3D16"/>
+        <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.7 //@children.1/@children.6/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P279" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N162" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L162" height="15.0" width="84.0" text="Translate3D19"/>
+        <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.8 //@children.1/@children.6/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P281" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N163" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L163" height="15.0" width="84.0" text="Translate3D22"/>
+        <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.9 //@children.1/@children.6/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P283" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N164" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L164" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P285" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N165" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L165" height="15.0" width="84.0" text="Translate3D12"/>
+        <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P287" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N166" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L166" height="15.0" width="77.0" text="Translate3D9"/>
+        <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P289" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.6/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E173" sources="//@children.1/@children.6/@ports.3" targets="//@children.1/@children.6/@children.11/@ports.0"/>
+      <containedEdges identifier="E174" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.6/@children.10/@ports.0"/>
+      <containedEdges identifier="E175" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.6/@children.12/@ports.0"/>
+      <containedEdges identifier="E176" sources="//@children.1/@children.6/@children.0/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E177" sources="//@children.1/@children.6/@children.1/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E178" sources="//@children.1/@children.6/@children.2/@ports.0" targets="//@children.1/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E179" sources="//@children.1/@children.6/@children.3/@ports.1" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E180" sources="//@children.1/@children.6/@children.4/@ports.0" targets="//@children.1/@children.6/@children.7/@ports.0"/>
+      <containedEdges identifier="E181" sources="//@children.1/@children.6/@children.5/@ports.0" targets="//@children.1/@children.6/@children.8/@ports.0"/>
+      <containedEdges identifier="E182" sources="//@children.1/@children.6/@children.6/@ports.0" targets="//@children.1/@children.6/@children.9/@ports.0"/>
+      <containedEdges identifier="E183" sources="//@children.1/@children.6/@children.7/@ports.1" targets="//@children.1/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E184" sources="//@children.1/@children.6/@children.8/@ports.1" targets="//@children.1/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E185" sources="//@children.1/@children.6/@children.9/@ports.1" targets="//@children.1/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E186" sources="//@children.1/@children.6/@children.10/@ports.1" targets="//@children.1/@children.6/@children.8/@ports.0"/>
+      <containedEdges identifier="E187" sources="//@children.1/@children.6/@children.11/@ports.1" targets="//@children.1/@children.6/@children.9/@ports.0"/>
+      <containedEdges identifier="E188" sources="//@children.1/@children.6/@children.12/@ports.1" targets="//@children.1/@children.6/@children.7/@ports.0"/>
+    </children>
+    <children identifier="N167" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L167" height="15.0" width="62.0" text="Rotate3D1"/>
+      <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P291" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N168" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L168" height="15.0" width="63.0" text="Switch3D2"/>
+      <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P293" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.12 //@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N169" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L169" height="15.0" width="77.0" text="Translate3D0"/>
+      <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P296" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N170">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L170" height="15.0" width="117.0" text="key_input_controller"/>
+      <ports identifier="P297" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.15" incomingEdges="//@children.1/@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P298" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.17" incomingEdges="//@children.1/@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P299" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.16" incomingEdges="//@children.1/@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P300" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.18" incomingEdges="//@children.1/@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P301" height="8.0" width="8.0" incomingEdges="//@children.1/@children.10/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P302" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.10/@containedEdges.0 //@children.1/@children.10/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N171">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L171" height="15.0" width="109.0" text="get_motor_number"/>
+        <ports identifier="P303" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.10/@containedEdges.2" incomingEdges="//@children.1/@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P304" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.10/@children.0/@containedEdges.0" incomingEdges="//@children.1/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N172" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L172" height="15.0" width="119.0" text="FSM_motor_number"/>
+          <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.10/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P306" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.10/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E199" sources="//@children.1/@children.10/@children.0/@ports.1" targets="//@children.1/@children.10/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E200" sources="//@children.1/@children.10/@children.0/@children.0/@ports.1" targets="//@children.1/@children.10/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N173">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L173" height="15.0" width="75.0" text="get_direction"/>
+        <ports identifier="P307" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.10/@containedEdges.3" incomingEdges="//@children.1/@children.10/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P308" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.10/@children.1/@containedEdges.0" incomingEdges="//@children.1/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N174" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L174" height="15.0" width="119.0" text="FSM_motor_number"/>
+          <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.10/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P310" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.10/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E201" sources="//@children.1/@children.10/@children.1/@ports.1" targets="//@children.1/@children.10/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E202" sources="//@children.1/@children.10/@children.1/@children.0/@ports.1" targets="//@children.1/@children.10/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N175" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L175" height="15.0" width="41.0" text="Scale0"/>
+        <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P312" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N176" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L176" height="15.0" width="47.0" text="Switch1"/>
+        <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P314" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.5 //@children.1/@children.10/@containedEdges.6 //@children.1/@children.10/@containedEdges.7 //@children.1/@children.10/@containedEdges.8 //@children.1/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P315" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E189" sources="//@children.1/@children.10/@ports.5" targets="//@children.1/@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E190" sources="//@children.1/@children.10/@ports.5" targets="//@children.1/@children.10/@children.1/@ports.1"/>
+      <containedEdges identifier="E191" sources="//@children.1/@children.10/@children.0/@ports.0" targets="//@children.1/@children.10/@children.3/@ports.2"/>
+      <containedEdges identifier="E192" sources="//@children.1/@children.10/@children.1/@ports.0" targets="//@children.1/@children.10/@children.2/@ports.0"/>
+      <containedEdges identifier="E193" sources="//@children.1/@children.10/@children.2/@ports.1" targets="//@children.1/@children.10/@children.3/@ports.0"/>
+      <containedEdges identifier="E194" sources="//@children.1/@children.10/@children.3/@ports.1" targets="//@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E195" sources="//@children.1/@children.10/@children.3/@ports.1" targets="//@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E196" sources="//@children.1/@children.10/@children.3/@ports.1" targets="//@children.1/@children.10/@ports.2"/>
+      <containedEdges identifier="E197" sources="//@children.1/@children.10/@children.3/@ports.1" targets="//@children.1/@children.10/@ports.3"/>
+      <containedEdges identifier="E198" sources="//@children.1/@children.10/@children.3/@ports.1" targets="//@children.1/@children.10/@ports.4"/>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.10/@ports.5"/>
+    <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.1/@children.4/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.2" targets="//@children.1/@children.8/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.1/@ports.5"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@children.6/@ports.3"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.9/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.10/@ports.2" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.1/@ports.3"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.10/@ports.3" targets="//@children.1/@children.1/@ports.4"/>
+  </children>
+  <children identifier="N177">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L177" height="15.0" width="90.0" text="arm hold states"/>
+    <ports identifier="P316" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2 //@children.2/@containedEdges.3" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P317" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.2/@containedEdges.4 //@children.2/@containedEdges.6 //@children.2/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P318" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.7 //@children.2/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N178">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L178" height="15.0" width="44.0" text="state_1"/>
+      <ports identifier="P319" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0 //@children.2/@children.0/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P320" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.4" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P321" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.5" incomingEdges="//@children.2/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N179">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L179" height="15.0" width="91.0" text="red_block_FSM"/>
+        <ports identifier="P322" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@containedEdges.0 //@children.2/@children.0/@children.0/@containedEdges.1 //@children.2/@children.0/@children.0/@containedEdges.2 //@children.2/@children.0/@children.0/@containedEdges.3" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P323" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.2" incomingEdges="//@children.2/@children.0/@children.0/@containedEdges.4 //@children.2/@children.0/@children.0/@containedEdges.5 //@children.2/@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N180" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L180" height="15.0" width="92.0" text="red_refinements"/>
+          <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N181">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L181" height="15.0" width="73.0" text="center_state"/>
+          <ports identifier="P325" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@children.1/@containedEdges.0" incomingEdges="//@children.2/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P326" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@containedEdges.4" incomingEdges="//@children.2/@children.0/@children.0/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N182" height="25.0" width="29.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L182" height="15.0" width="42.0" text="Const1"/>
+            <ports identifier="P327" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.0/@children.1/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.0/@children.1/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E224" sources="//@children.2/@children.0/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@children.0/@children.1/@children.0/@ports.1"/>
+          <containedEdges identifier="E225" sources="//@children.2/@children.0/@children.0/@children.1/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.1/@ports.1"/>
+        </children>
+        <children identifier="N183">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L183" height="15.0" width="62.0" text="right_state"/>
+          <ports identifier="P329" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@children.2/@containedEdges.0" incomingEdges="//@children.2/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P330" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@containedEdges.5" incomingEdges="//@children.2/@children.0/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N184" height="25.0" width="29.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L184" height="15.0" width="42.0" text="Const1"/>
+            <ports identifier="P331" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.0/@children.2/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.0/@children.2/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E226" sources="//@children.2/@children.0/@children.0/@children.2/@ports.0" targets="//@children.2/@children.0/@children.0/@children.2/@children.0/@ports.1"/>
+          <containedEdges identifier="E227" sources="//@children.2/@children.0/@children.0/@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.2/@ports.1"/>
+        </children>
+        <children identifier="N185">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L185" height="15.0" width="54.0" text="left_state"/>
+          <ports identifier="P333" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@children.3/@containedEdges.0" incomingEdges="//@children.2/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P334" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@containedEdges.6" incomingEdges="//@children.2/@children.0/@children.0/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N186" height="25.0" width="29.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L186" height="15.0" width="42.0" text="Const1"/>
+            <ports identifier="P335" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.0/@children.3/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.0/@children.3/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E228" sources="//@children.2/@children.0/@children.0/@children.3/@ports.0" targets="//@children.2/@children.0/@children.0/@children.3/@children.0/@ports.1"/>
+          <containedEdges identifier="E229" sources="//@children.2/@children.0/@children.0/@children.3/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.3/@ports.1"/>
+        </children>
+        <containedEdges identifier="E217" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E218" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E219" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E220" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E221" sources="//@children.2/@children.0/@children.0/@children.1/@ports.1" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E222" sources="//@children.2/@children.0/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E223" sources="//@children.2/@children.0/@children.0/@children.3/@ports.1" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+      </children>
+      <children identifier="N187" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L187" height="15.0" width="42.0" text="Const5"/>
+        <ports identifier="P337" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E213" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E214" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E215" sources="//@children.2/@children.0/@children.0/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E216" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N188">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L188" height="15.0" width="44.0" text="state_2"/>
+      <ports identifier="P339" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.0 //@children.2/@children.1/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P340" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.6" incomingEdges="//@children.2/@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P341" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.7" incomingEdges="//@children.2/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N189" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L189" height="15.0" width="42.0" text="Const0"/>
+        <ports identifier="P342" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N190" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L190" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P344" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E230" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E231" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E232" sources="//@children.2/@children.1/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E233" sources="//@children.2/@children.1/@children.1/@ports.0" targets="//@children.2/@children.1/@ports.2"/>
+    </children>
+    <children identifier="N191" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L191" height="15.0" width="54.0" text="controller"/>
+      <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N192">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L192" height="15.0" width="44.0" text="state_3"/>
+      <ports identifier="P347" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.3/@containedEdges.0 //@children.2/@children.3/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P348" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.8" incomingEdges="//@children.2/@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P349" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.9" incomingEdges="//@children.2/@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N193" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L193" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P350" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N194" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L194" height="15.0" width="42.0" text="Const5"/>
+        <ports identifier="P352" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E234" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.3/@children.0/@ports.1"/>
+      <containedEdges identifier="E235" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.3/@children.1/@ports.1"/>
+      <containedEdges identifier="E236" sources="//@children.2/@children.3/@children.0/@ports.0" targets="//@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E237" sources="//@children.2/@children.3/@children.1/@ports.0" targets="//@children.2/@children.3/@ports.2"/>
+    </children>
+    <containedEdges identifier="E203" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E204" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E205" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E206" sources="//@children.2/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E207" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E208" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E209" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E210" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E211" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E212" sources="//@children.2/@children.3/@ports.2" targets="//@children.2/@ports.2"/>
+  </children>
+  <children identifier="N195" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L195" height="15.0" width="72.0" text="Current time"/>
+    <ports identifier="P354" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/g4ltl_numerical_Numerical.elkg
+++ b/realworld/ptolemy/hierarchical/g4ltl_numerical_Numerical.elkg
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Pulse"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="9.0" text="X"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="67.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="9.0" text="Y"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Expression3"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="8.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="94.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1 //@children.6/@containedEdges.2 //@children.6/@containedEdges.3" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.10" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.13" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.11" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.4 //@children.6/@containedEdges.5 //@children.6/@containedEdges.6 //@children.6/@containedEdges.7 //@children.6/@containedEdges.8 //@children.6/@containedEdges.9" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.12" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="91.0" text="Display Results"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="82.0" text="Display Inputs"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="42.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="73.0" text="Expression5"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.6 //@children.6/@containedEdges.14 //@children.6/@containedEdges.15 //@children.6/@containedEdges.17 //@children.6/@containedEdges.18 //@children.6/@containedEdges.19 //@children.6/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="35.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="35.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="84.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="45.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="45.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.6/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.6/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.6/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.6/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.21 //@children.6/@containedEdges.22 //@children.6/@containedEdges.23 //@children.6/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.6/@ports.0" targets="//@children.6/@children.3/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@ports.0" targets="//@children.6/@children.7/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.6/@ports.4" targets="//@children.6/@children.2/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.6/@ports.4" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.6/@ports.4" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.6/@ports.4" targets="//@children.6/@children.5/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.6/@ports.4" targets="//@children.6/@children.6/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.6/@ports.4" targets="//@children.6/@children.8/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.6/@ports.1" targets="//@children.6/@children.9/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.6/@ports.3" targets="//@children.6/@children.10/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.6/@ports.5" targets="//@children.6/@children.11/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.6/@ports.2" targets="//@children.6/@children.12/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.6/@children.4/@ports.2" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.6/@children.6/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.6/@children.7/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.6/@children.8/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.6/@children.9/@ports.1" targets="//@children.6/@children.13/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.6/@children.10/@ports.1" targets="//@children.6/@children.13/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.6/@children.11/@ports.1" targets="//@children.6/@children.13/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.6/@children.12/@ports.1" targets="//@children.6/@children.13/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.6/@children.13/@ports.2" targets="//@children.6/@children.0/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.4"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.3" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.2" targets="//@children.6/@ports.5"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.5/@ports.0" targets="//@children.6/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gr_inversekinematics_InverseKinematics.elkg
+++ b/realworld/ptolemy/hierarchical/gr_inversekinematics_InverseKinematics.elkg
@@ -1,0 +1,5174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="ViewScreen0"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="25.0" text="floor"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="Translate3D1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="Translate3D0"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="46.0" text="Rotate0"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="MouseInput"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="80.0" text="ComputeCCD"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1 //@children.6/@containedEdges.2 //@children.6/@containedEdges.3 //@children.6/@containedEdges.4 //@children.6/@containedEdges.5 //@children.6/@containedEdges.6" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.7 //@children.6/@containedEdges.8 //@children.6/@containedEdges.9 //@children.6/@containedEdges.10 //@children.6/@containedEdges.11" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.6/@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.6/@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.6/@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="81.0" text="applyshoulder"/>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.8 //@children.6/@children.0/@containedEdges.9" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.10 //@children.6/@children.0/@containedEdges.11" incomingEdges="//@children.6/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.12" incomingEdges="//@children.6/@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.13" incomingEdges="//@children.6/@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.68">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.72">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.2 //@children.6/@children.0/@containedEdges.3" incomingEdges="//@children.6/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.4 //@children.6/@children.0/@containedEdges.5" incomingEdges="//@children.6/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.12" incomingEdges="//@children.6/@containedEdges.33 //@children.6/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="-8"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.13" incomingEdges="//@children.6/@containedEdges.35 //@children.6/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="-9"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.6" incomingEdges="//@children.6/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-10"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.7" incomingEdges="//@children.6/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-11"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.14" incomingEdges="//@children.6/@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="12"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.15" incomingEdges="//@children.6/@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="13"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.16" incomingEdges="//@children.6/@children.0/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="14"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.17" incomingEdges="//@children.6/@children.0/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="15"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.18" incomingEdges="//@children.6/@children.0/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="16"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N9" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="88.0" text="shoulder_angle"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="44.0" text="Merge3"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.14 //@children.6/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="80.0" text="AddSubtract6"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.15 //@children.6/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="41.0" text="Delay7"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.0/@containedEdges.17 //@children.6/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="63.0" text="Sampler14"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N14">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L14" height="15.0" width="52.0" text="getAngle"/>
+        <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.1 //@children.6/@children.0/@children.5/@containedEdges.2" incomingEdges="//@children.6/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.3 //@children.6/@children.0/@children.5/@containedEdges.4" incomingEdges="//@children.6/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.7" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.6" incomingEdges="//@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.0" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.5" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.20 //@children.6/@children.0/@containedEdges.21 //@children.6/@children.0/@containedEdges.22 //@children.6/@children.0/@containedEdges.23" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N15" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="80.0" text="AddSubtract7"/>
+          <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.8 //@children.6/@children.0/@children.5/@containedEdges.9 //@children.6/@children.0/@children.5/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="80.0" text="AddSubtract8"/>
+          <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.11 //@children.6/@children.0/@children.5/@containedEdges.12 //@children.6/@children.0/@children.5/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="80.0" text="AddSubtract1"/>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.14 //@children.6/@children.0/@children.5/@containedEdges.15 //@children.6/@children.0/@children.5/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P63" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.17 //@children.6/@children.0/@children.5/@containedEdges.18 //@children.6/@children.0/@children.5/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N19" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L19" height="15.0" width="79.0" text="TrigFunction1"/>
+          <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P65" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N20" height="25.0" width="180.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L20" height="15.0" width="71.0" text="AxBx_AyBy"/>
+          <ports identifier="P66" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N21" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L21" height="15.0" width="72.0" text="Maximum10"/>
+          <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.23 //@children.6/@children.0/@children.5/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P74" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N22" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L22" height="15.0" width="67.0" text="Minimum11"/>
+          <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.21 //@children.6/@children.0/@children.5/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P77" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N23" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L23" height="15.0" width="49.0" text="Const12"/>
+          <ports identifier="P79" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N24" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L24" height="15.0" width="49.0" text="Const13"/>
+          <ports identifier="P81" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N25" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="106.0" text="CartesianToPolar1"/>
+          <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P85" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P86" height="8.0" width="8.0" x="31.0" y="18.0">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N26" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="106.0" text="CartesianToPolar2"/>
+          <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P89" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P90" height="8.0" width="8.0" x="31.0" y="18.0">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N27" height="25.0" width="101.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="68.0" text="AxBy-AyBx"/>
+          <ports identifier="P91" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="94.0" text="MultiplyDivide12"/>
+          <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.20 //@children.6/@children.0/@children.5/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N29" height="36.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="87.0" text="MathFunction1"/>
+          <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@children.0/@children.5/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P100" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@children.6/@children.0/@children.5/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E128" sources="//@children.6/@children.0/@children.5/@ports.4" targets="//@children.6/@children.0/@children.5/@children.0/@ports.0"/>
+        <containedEdges identifier="E129" sources="//@children.6/@children.0/@children.5/@ports.0" targets="//@children.6/@children.0/@children.5/@children.0/@ports.1"/>
+        <containedEdges identifier="E130" sources="//@children.6/@children.0/@children.5/@ports.0" targets="//@children.6/@children.0/@children.5/@children.2/@ports.1"/>
+        <containedEdges identifier="E131" sources="//@children.6/@children.0/@children.5/@ports.1" targets="//@children.6/@children.0/@children.5/@children.1/@ports.1"/>
+        <containedEdges identifier="E132" sources="//@children.6/@children.0/@children.5/@ports.1" targets="//@children.6/@children.0/@children.5/@children.3/@ports.1"/>
+        <containedEdges identifier="E133" sources="//@children.6/@children.0/@children.5/@ports.5" targets="//@children.6/@children.0/@children.5/@children.1/@ports.0"/>
+        <containedEdges identifier="E134" sources="//@children.6/@children.0/@children.5/@ports.3" targets="//@children.6/@children.0/@children.5/@children.3/@ports.0"/>
+        <containedEdges identifier="E135" sources="//@children.6/@children.0/@children.5/@ports.2" targets="//@children.6/@children.0/@children.5/@children.2/@ports.0"/>
+        <containedEdges identifier="E136" sources="//@children.6/@children.0/@children.5/@children.0/@ports.2" targets="//@children.6/@children.0/@children.5/@children.5/@ports.1"/>
+        <containedEdges identifier="E137" sources="//@children.6/@children.0/@children.5/@children.0/@ports.2" targets="//@children.6/@children.0/@children.5/@children.11/@ports.0"/>
+        <containedEdges identifier="E138" sources="//@children.6/@children.0/@children.5/@children.0/@ports.2" targets="//@children.6/@children.0/@children.5/@children.12/@ports.1"/>
+        <containedEdges identifier="E139" sources="//@children.6/@children.0/@children.5/@children.1/@ports.2" targets="//@children.6/@children.0/@children.5/@children.5/@ports.2"/>
+        <containedEdges identifier="E140" sources="//@children.6/@children.0/@children.5/@children.1/@ports.2" targets="//@children.6/@children.0/@children.5/@children.11/@ports.1"/>
+        <containedEdges identifier="E141" sources="//@children.6/@children.0/@children.5/@children.1/@ports.2" targets="//@children.6/@children.0/@children.5/@children.12/@ports.2"/>
+        <containedEdges identifier="E142" sources="//@children.6/@children.0/@children.5/@children.2/@ports.2" targets="//@children.6/@children.0/@children.5/@children.5/@ports.3"/>
+        <containedEdges identifier="E143" sources="//@children.6/@children.0/@children.5/@children.2/@ports.2" targets="//@children.6/@children.0/@children.5/@children.10/@ports.0"/>
+        <containedEdges identifier="E144" sources="//@children.6/@children.0/@children.5/@children.2/@ports.2" targets="//@children.6/@children.0/@children.5/@children.12/@ports.3"/>
+        <containedEdges identifier="E145" sources="//@children.6/@children.0/@children.5/@children.3/@ports.2" targets="//@children.6/@children.0/@children.5/@children.5/@ports.4"/>
+        <containedEdges identifier="E146" sources="//@children.6/@children.0/@children.5/@children.3/@ports.2" targets="//@children.6/@children.0/@children.5/@children.10/@ports.1"/>
+        <containedEdges identifier="E147" sources="//@children.6/@children.0/@children.5/@children.3/@ports.2" targets="//@children.6/@children.0/@children.5/@children.12/@ports.4"/>
+        <containedEdges identifier="E148" sources="//@children.6/@children.0/@children.5/@children.4/@ports.1" targets="//@children.6/@children.0/@children.5/@children.13/@ports.0"/>
+        <containedEdges identifier="E149" sources="//@children.6/@children.0/@children.5/@children.5/@ports.0" targets="//@children.6/@children.0/@children.5/@children.7/@ports.0"/>
+        <containedEdges identifier="E150" sources="//@children.6/@children.0/@children.5/@children.6/@ports.1" targets="//@children.6/@children.0/@children.5/@children.4/@ports.0"/>
+        <containedEdges identifier="E151" sources="//@children.6/@children.0/@children.5/@children.7/@ports.1" targets="//@children.6/@children.0/@children.5/@children.6/@ports.0"/>
+        <containedEdges identifier="E152" sources="//@children.6/@children.0/@children.5/@children.8/@ports.0" targets="//@children.6/@children.0/@children.5/@children.6/@ports.0"/>
+        <containedEdges identifier="E153" sources="//@children.6/@children.0/@children.5/@children.9/@ports.0" targets="//@children.6/@children.0/@children.5/@children.7/@ports.0"/>
+        <containedEdges identifier="E154" sources="//@children.6/@children.0/@children.5/@children.10/@ports.2" targets="//@children.6/@children.0/@children.5/@children.5/@ports.6"/>
+        <containedEdges identifier="E155" sources="//@children.6/@children.0/@children.5/@children.11/@ports.2" targets="//@children.6/@children.0/@children.5/@children.5/@ports.5"/>
+        <containedEdges identifier="E156" sources="//@children.6/@children.0/@children.5/@children.12/@ports.0" targets="//@children.6/@children.0/@children.5/@children.14/@ports.0"/>
+        <containedEdges identifier="E157" sources="//@children.6/@children.0/@children.5/@children.13/@ports.2" targets="//@children.6/@children.0/@children.5/@ports.6"/>
+        <containedEdges identifier="E158" sources="//@children.6/@children.0/@children.5/@children.14/@ports.1" targets="//@children.6/@children.0/@children.5/@children.13/@ports.0"/>
+      </children>
+      <children identifier="N30">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L30" height="15.0" width="66.0" text="rotator_end"/>
+        <ports identifier="P101" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.2 //@children.6/@children.0/@children.6/@containedEdges.3" incomingEdges="//@children.6/@children.0/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.4 //@children.6/@children.0/@children.6/@containedEdges.5" incomingEdges="//@children.6/@children.0/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.6 //@children.6/@children.0/@children.6/@containedEdges.7" incomingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.8 //@children.6/@children.0/@children.6/@containedEdges.9" incomingEdges="//@children.6/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.0 //@children.6/@children.0/@children.6/@containedEdges.1" incomingEdges="//@children.6/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.24" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P107" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.25" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N31" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L31" height="15.0" width="79.0" text="TrigFunction5"/>
+          <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P109" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.10 //@children.6/@children.0/@children.6/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N32" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L32" height="15.0" width="79.0" text="TrigFunction6"/>
+          <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P111" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.12 //@children.6/@children.0/@children.6/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N33" height="25.0" width="234.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L33" height="15.0" width="80.0" text="Expression15"/>
+          <ports identifier="P112" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N34" height="25.0" width="240.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L34" height="15.0" width="80.0" text="Expression16"/>
+          <ports identifier="P119" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.6/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.0/@children.6/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E159" sources="//@children.6/@children.0/@children.6/@ports.4" targets="//@children.6/@children.0/@children.6/@children.0/@ports.0"/>
+        <containedEdges identifier="E160" sources="//@children.6/@children.0/@children.6/@ports.4" targets="//@children.6/@children.0/@children.6/@children.1/@ports.0"/>
+        <containedEdges identifier="E161" sources="//@children.6/@children.0/@children.6/@ports.0" targets="//@children.6/@children.0/@children.6/@children.2/@ports.1"/>
+        <containedEdges identifier="E162" sources="//@children.6/@children.0/@children.6/@ports.0" targets="//@children.6/@children.0/@children.6/@children.3/@ports.1"/>
+        <containedEdges identifier="E163" sources="//@children.6/@children.0/@children.6/@ports.1" targets="//@children.6/@children.0/@children.6/@children.2/@ports.2"/>
+        <containedEdges identifier="E164" sources="//@children.6/@children.0/@children.6/@ports.1" targets="//@children.6/@children.0/@children.6/@children.3/@ports.2"/>
+        <containedEdges identifier="E165" sources="//@children.6/@children.0/@children.6/@ports.2" targets="//@children.6/@children.0/@children.6/@children.2/@ports.3"/>
+        <containedEdges identifier="E166" sources="//@children.6/@children.0/@children.6/@ports.2" targets="//@children.6/@children.0/@children.6/@children.3/@ports.3"/>
+        <containedEdges identifier="E167" sources="//@children.6/@children.0/@children.6/@ports.3" targets="//@children.6/@children.0/@children.6/@children.2/@ports.4"/>
+        <containedEdges identifier="E168" sources="//@children.6/@children.0/@children.6/@ports.3" targets="//@children.6/@children.0/@children.6/@children.3/@ports.4"/>
+        <containedEdges identifier="E169" sources="//@children.6/@children.0/@children.6/@children.0/@ports.1" targets="//@children.6/@children.0/@children.6/@children.2/@ports.5"/>
+        <containedEdges identifier="E170" sources="//@children.6/@children.0/@children.6/@children.0/@ports.1" targets="//@children.6/@children.0/@children.6/@children.3/@ports.5"/>
+        <containedEdges identifier="E171" sources="//@children.6/@children.0/@children.6/@children.1/@ports.1" targets="//@children.6/@children.0/@children.6/@children.2/@ports.6"/>
+        <containedEdges identifier="E172" sources="//@children.6/@children.0/@children.6/@children.1/@ports.1" targets="//@children.6/@children.0/@children.6/@children.3/@ports.6"/>
+        <containedEdges identifier="E173" sources="//@children.6/@children.0/@children.6/@children.2/@ports.0" targets="//@children.6/@children.0/@children.6/@ports.5"/>
+        <containedEdges identifier="E174" sources="//@children.6/@children.0/@children.6/@children.3/@ports.0" targets="//@children.6/@children.0/@children.6/@ports.6"/>
+      </children>
+      <children identifier="N35">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L35" height="15.0" width="71.0" text="rotator_wrist"/>
+        <ports identifier="P126" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.2 //@children.6/@children.0/@children.7/@containedEdges.3" incomingEdges="//@children.6/@children.0/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P127" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.4 //@children.6/@children.0/@children.7/@containedEdges.5" incomingEdges="//@children.6/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.6 //@children.6/@children.0/@children.7/@containedEdges.7" incomingEdges="//@children.6/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P129" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.8 //@children.6/@children.0/@children.7/@containedEdges.9" incomingEdges="//@children.6/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.0 //@children.6/@children.0/@children.7/@containedEdges.1" incomingEdges="//@children.6/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.26" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.27" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N36" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L36" height="15.0" width="79.0" text="TrigFunction5"/>
+          <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P134" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.10 //@children.6/@children.0/@children.7/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N37" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L37" height="15.0" width="79.0" text="TrigFunction6"/>
+          <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P136" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.12 //@children.6/@children.0/@children.7/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N38" height="25.0" width="234.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L38" height="15.0" width="80.0" text="Expression15"/>
+          <ports identifier="P137" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N39" height="25.0" width="240.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L39" height="15.0" width="80.0" text="Expression16"/>
+          <ports identifier="P144" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.7/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.0/@children.7/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E175" sources="//@children.6/@children.0/@children.7/@ports.4" targets="//@children.6/@children.0/@children.7/@children.0/@ports.0"/>
+        <containedEdges identifier="E176" sources="//@children.6/@children.0/@children.7/@ports.4" targets="//@children.6/@children.0/@children.7/@children.1/@ports.0"/>
+        <containedEdges identifier="E177" sources="//@children.6/@children.0/@children.7/@ports.0" targets="//@children.6/@children.0/@children.7/@children.2/@ports.1"/>
+        <containedEdges identifier="E178" sources="//@children.6/@children.0/@children.7/@ports.0" targets="//@children.6/@children.0/@children.7/@children.3/@ports.1"/>
+        <containedEdges identifier="E179" sources="//@children.6/@children.0/@children.7/@ports.1" targets="//@children.6/@children.0/@children.7/@children.2/@ports.2"/>
+        <containedEdges identifier="E180" sources="//@children.6/@children.0/@children.7/@ports.1" targets="//@children.6/@children.0/@children.7/@children.3/@ports.2"/>
+        <containedEdges identifier="E181" sources="//@children.6/@children.0/@children.7/@ports.2" targets="//@children.6/@children.0/@children.7/@children.2/@ports.3"/>
+        <containedEdges identifier="E182" sources="//@children.6/@children.0/@children.7/@ports.2" targets="//@children.6/@children.0/@children.7/@children.3/@ports.3"/>
+        <containedEdges identifier="E183" sources="//@children.6/@children.0/@children.7/@ports.3" targets="//@children.6/@children.0/@children.7/@children.2/@ports.4"/>
+        <containedEdges identifier="E184" sources="//@children.6/@children.0/@children.7/@ports.3" targets="//@children.6/@children.0/@children.7/@children.3/@ports.4"/>
+        <containedEdges identifier="E185" sources="//@children.6/@children.0/@children.7/@children.0/@ports.1" targets="//@children.6/@children.0/@children.7/@children.2/@ports.5"/>
+        <containedEdges identifier="E186" sources="//@children.6/@children.0/@children.7/@children.0/@ports.1" targets="//@children.6/@children.0/@children.7/@children.3/@ports.5"/>
+        <containedEdges identifier="E187" sources="//@children.6/@children.0/@children.7/@children.1/@ports.1" targets="//@children.6/@children.0/@children.7/@children.2/@ports.6"/>
+        <containedEdges identifier="E188" sources="//@children.6/@children.0/@children.7/@children.1/@ports.1" targets="//@children.6/@children.0/@children.7/@children.3/@ports.6"/>
+        <containedEdges identifier="E189" sources="//@children.6/@children.0/@children.7/@children.2/@ports.0" targets="//@children.6/@children.0/@children.7/@ports.5"/>
+        <containedEdges identifier="E190" sources="//@children.6/@children.0/@children.7/@children.3/@ports.0" targets="//@children.6/@children.0/@children.7/@ports.6"/>
+      </children>
+      <children identifier="N40" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="44.0" text="Merge1"/>
+        <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.9 //@children.6/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P152" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.28 //@children.6/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="25.0" width="36.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="32.0" text="zerox"/>
+        <ports identifier="P153" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.30 //@children.6/@children.0/@containedEdges.31 //@children.6/@children.0/@containedEdges.32 //@children.6/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="32.0" text="zeroy"/>
+        <ports identifier="P155" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.34 //@children.6/@children.0/@containedEdges.35 //@children.6/@children.0/@containedEdges.36 //@children.6/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N43">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L43" height="15.0" width="78.0" text="rotator_elbow"/>
+        <ports identifier="P157" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.2 //@children.6/@children.0/@children.11/@containedEdges.3" incomingEdges="//@children.6/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P158" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.4 //@children.6/@children.0/@children.11/@containedEdges.5" incomingEdges="//@children.6/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P159" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.6 //@children.6/@children.0/@children.11/@containedEdges.7" incomingEdges="//@children.6/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P160" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.8 //@children.6/@children.0/@children.11/@containedEdges.9" incomingEdges="//@children.6/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P161" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.0 //@children.6/@children.0/@children.11/@containedEdges.1" incomingEdges="//@children.6/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P162" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.38" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P163" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.39" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N44" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L44" height="15.0" width="79.0" text="TrigFunction5"/>
+          <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P165" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.10 //@children.6/@children.0/@children.11/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N45" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L45" height="15.0" width="79.0" text="TrigFunction6"/>
+          <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P167" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.12 //@children.6/@children.0/@children.11/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N46" height="25.0" width="234.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L46" height="15.0" width="80.0" text="Expression15"/>
+          <ports identifier="P168" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N47" height="25.0" width="240.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L47" height="15.0" width="80.0" text="Expression16"/>
+          <ports identifier="P175" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@children.6/@children.0/@children.11/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.0/@children.11/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E191" sources="//@children.6/@children.0/@children.11/@ports.4" targets="//@children.6/@children.0/@children.11/@children.0/@ports.0"/>
+        <containedEdges identifier="E192" sources="//@children.6/@children.0/@children.11/@ports.4" targets="//@children.6/@children.0/@children.11/@children.1/@ports.0"/>
+        <containedEdges identifier="E193" sources="//@children.6/@children.0/@children.11/@ports.0" targets="//@children.6/@children.0/@children.11/@children.2/@ports.1"/>
+        <containedEdges identifier="E194" sources="//@children.6/@children.0/@children.11/@ports.0" targets="//@children.6/@children.0/@children.11/@children.3/@ports.1"/>
+        <containedEdges identifier="E195" sources="//@children.6/@children.0/@children.11/@ports.1" targets="//@children.6/@children.0/@children.11/@children.2/@ports.2"/>
+        <containedEdges identifier="E196" sources="//@children.6/@children.0/@children.11/@ports.1" targets="//@children.6/@children.0/@children.11/@children.3/@ports.2"/>
+        <containedEdges identifier="E197" sources="//@children.6/@children.0/@children.11/@ports.2" targets="//@children.6/@children.0/@children.11/@children.2/@ports.3"/>
+        <containedEdges identifier="E198" sources="//@children.6/@children.0/@children.11/@ports.2" targets="//@children.6/@children.0/@children.11/@children.3/@ports.3"/>
+        <containedEdges identifier="E199" sources="//@children.6/@children.0/@children.11/@ports.3" targets="//@children.6/@children.0/@children.11/@children.2/@ports.4"/>
+        <containedEdges identifier="E200" sources="//@children.6/@children.0/@children.11/@ports.3" targets="//@children.6/@children.0/@children.11/@children.3/@ports.4"/>
+        <containedEdges identifier="E201" sources="//@children.6/@children.0/@children.11/@children.0/@ports.1" targets="//@children.6/@children.0/@children.11/@children.2/@ports.5"/>
+        <containedEdges identifier="E202" sources="//@children.6/@children.0/@children.11/@children.0/@ports.1" targets="//@children.6/@children.0/@children.11/@children.3/@ports.5"/>
+        <containedEdges identifier="E203" sources="//@children.6/@children.0/@children.11/@children.1/@ports.1" targets="//@children.6/@children.0/@children.11/@children.2/@ports.6"/>
+        <containedEdges identifier="E204" sources="//@children.6/@children.0/@children.11/@children.1/@ports.1" targets="//@children.6/@children.0/@children.11/@children.3/@ports.6"/>
+        <containedEdges identifier="E205" sources="//@children.6/@children.0/@children.11/@children.2/@ports.0" targets="//@children.6/@children.0/@children.11/@ports.5"/>
+        <containedEdges identifier="E206" sources="//@children.6/@children.0/@children.11/@children.3/@ports.0" targets="//@children.6/@children.0/@children.11/@ports.6"/>
+      </children>
+      <children identifier="N48" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="41.0" text="Scale0"/>
+        <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E87" sources="//@children.6/@children.0/@ports.4" targets="//@children.6/@children.0/@children.5/@ports.4"/>
+      <containedEdges identifier="E88" sources="//@children.6/@children.0/@ports.5" targets="//@children.6/@children.0/@children.5/@ports.5"/>
+      <containedEdges identifier="E89" sources="//@children.6/@children.0/@ports.6" targets="//@children.6/@children.0/@children.5/@ports.2"/>
+      <containedEdges identifier="E90" sources="//@children.6/@children.0/@ports.6" targets="//@children.6/@children.0/@children.6/@ports.2"/>
+      <containedEdges identifier="E91" sources="//@children.6/@children.0/@ports.7" targets="//@children.6/@children.0/@children.5/@ports.3"/>
+      <containedEdges identifier="E92" sources="//@children.6/@children.0/@ports.7" targets="//@children.6/@children.0/@children.6/@ports.3"/>
+      <containedEdges identifier="E93" sources="//@children.6/@children.0/@ports.10" targets="//@children.6/@children.0/@children.7/@ports.2"/>
+      <containedEdges identifier="E94" sources="//@children.6/@children.0/@ports.11" targets="//@children.6/@children.0/@children.7/@ports.3"/>
+      <containedEdges identifier="E95" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E96" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.0/@children.4/@ports.2"/>
+      <containedEdges identifier="E98" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.6/@children.0/@ports.8" targets="//@children.6/@children.0/@children.11/@ports.2"/>
+      <containedEdges identifier="E100" sources="//@children.6/@children.0/@ports.9" targets="//@children.6/@children.0/@children.11/@ports.3"/>
+      <containedEdges identifier="E101" sources="//@children.6/@children.0/@children.0/@ports.0" targets="//@children.6/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.6/@children.0/@children.1/@ports.1" targets="//@children.6/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.6/@children.0/@children.2/@ports.2" targets="//@children.6/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.6/@children.0/@children.3/@ports.1" targets="//@children.6/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.6/@children.0/@children.3/@ports.1" targets="//@children.6/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.6/@children.0/@children.4/@ports.1" targets="//@children.6/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E107" sources="//@children.6/@children.0/@children.5/@ports.6" targets="//@children.6/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E108" sources="//@children.6/@children.0/@children.5/@ports.6" targets="//@children.6/@children.0/@children.6/@ports.4"/>
+      <containedEdges identifier="E109" sources="//@children.6/@children.0/@children.5/@ports.6" targets="//@children.6/@children.0/@children.7/@ports.4"/>
+      <containedEdges identifier="E110" sources="//@children.6/@children.0/@children.5/@ports.6" targets="//@children.6/@children.0/@children.11/@ports.4"/>
+      <containedEdges identifier="E111" sources="//@children.6/@children.0/@children.6/@ports.5" targets="//@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E112" sources="//@children.6/@children.0/@children.6/@ports.6" targets="//@children.6/@children.0/@ports.3"/>
+      <containedEdges identifier="E113" sources="//@children.6/@children.0/@children.7/@ports.5" targets="//@children.6/@children.0/@ports.12"/>
+      <containedEdges identifier="E114" sources="//@children.6/@children.0/@children.7/@ports.6" targets="//@children.6/@children.0/@ports.13"/>
+      <containedEdges identifier="E115" sources="//@children.6/@children.0/@children.8/@ports.1" targets="//@children.6/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E116" sources="//@children.6/@children.0/@children.8/@ports.1" targets="//@children.6/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E117" sources="//@children.6/@children.0/@children.9/@ports.0" targets="//@children.6/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E118" sources="//@children.6/@children.0/@children.9/@ports.0" targets="//@children.6/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E119" sources="//@children.6/@children.0/@children.9/@ports.0" targets="//@children.6/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.6/@children.0/@children.9/@ports.0" targets="//@children.6/@children.0/@children.11/@ports.0"/>
+      <containedEdges identifier="E121" sources="//@children.6/@children.0/@children.10/@ports.0" targets="//@children.6/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E122" sources="//@children.6/@children.0/@children.10/@ports.0" targets="//@children.6/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E123" sources="//@children.6/@children.0/@children.10/@ports.0" targets="//@children.6/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E124" sources="//@children.6/@children.0/@children.10/@ports.0" targets="//@children.6/@children.0/@children.11/@ports.1"/>
+      <containedEdges identifier="E125" sources="//@children.6/@children.0/@children.11/@ports.5" targets="//@children.6/@children.0/@ports.14"/>
+      <containedEdges identifier="E126" sources="//@children.6/@children.0/@children.11/@ports.6" targets="//@children.6/@children.0/@ports.15"/>
+      <containedEdges identifier="E127" sources="//@children.6/@children.0/@children.12/@ports.1" targets="//@children.6/@children.0/@ports.16"/>
+    </children>
+    <children identifier="N49">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L49" height="15.0" width="65.0" text="applyelbow"/>
+      <ports identifier="P184" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P185" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.54">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P186" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.19" incomingEdges="//@children.6/@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P187" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.20" incomingEdges="//@children.6/@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P188" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.2" incomingEdges="//@children.6/@containedEdges.69">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P189" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.3" incomingEdges="//@children.6/@containedEdges.73">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P190" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.10 //@children.6/@children.1/@containedEdges.11" incomingEdges="//@children.6/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P191" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.12 //@children.6/@children.1/@containedEdges.13" incomingEdges="//@children.6/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P192" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.4 //@children.6/@children.1/@containedEdges.5 //@children.6/@children.1/@containedEdges.6" incomingEdges="//@children.6/@containedEdges.34 //@children.6/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="-8"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P193" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.7 //@children.6/@children.1/@containedEdges.8 //@children.6/@children.1/@containedEdges.9" incomingEdges="//@children.6/@containedEdges.36 //@children.6/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="-9"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P194" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.14" incomingEdges="//@children.6/@containedEdges.29 //@children.6/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="-10"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P195" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.15" incomingEdges="//@children.6/@containedEdges.31 //@children.6/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="-11"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P196" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.21" incomingEdges="//@children.6/@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="12"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P197" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.22" incomingEdges="//@children.6/@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="13"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P198" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.23" incomingEdges="//@children.6/@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="14"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N50">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L50" height="15.0" width="36.0" text="clamp"/>
+        <ports identifier="P199" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.4" incomingEdges="//@children.6/@children.1/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P200" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.0 //@children.6/@children.1/@children.0/@containedEdges.1 //@children.6/@children.1/@children.0/@containedEdges.2 //@children.6/@children.1/@children.0/@containedEdges.3" incomingEdges="//@children.6/@children.1/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P201" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.16 //@children.6/@children.1/@containedEdges.17 //@children.6/@children.1/@containedEdges.18" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N51" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L51" height="15.0" width="61.0" text="Minimum3"/>
+          <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.8 //@children.6/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P203" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P204" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N52" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L52" height="15.0" width="80.0" text="AddSubtract4"/>
+          <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P207" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N53" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L53" height="15.0" width="22.0" text="min"/>
+          <ports identifier="P208" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N54" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L54" height="15.0" width="72.0" text="Maximum21"/>
+          <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.4 //@children.6/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P211" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P212" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N55" height="25.0" width="34.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L55" height="15.0" width="25.0" text="max"/>
+          <ports identifier="P213" height="8.0" width="8.0" x="34.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N56" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L56" height="15.0" width="87.0" text="AddSubtract27"/>
+          <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P217" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E239" sources="//@children.6/@children.1/@children.0/@ports.1" targets="//@children.6/@children.1/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E240" sources="//@children.6/@children.1/@children.0/@ports.1" targets="//@children.6/@children.1/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E241" sources="//@children.6/@children.1/@children.0/@ports.1" targets="//@children.6/@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E242" sources="//@children.6/@children.1/@children.0/@ports.1" targets="//@children.6/@children.1/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E243" sources="//@children.6/@children.1/@children.0/@ports.0" targets="//@children.6/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E244" sources="//@children.6/@children.1/@children.0/@children.0/@ports.1" targets="//@children.6/@children.1/@children.0/@ports.2"/>
+        <containedEdges identifier="E245" sources="//@children.6/@children.1/@children.0/@children.1/@ports.2" targets="//@children.6/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E246" sources="//@children.6/@children.1/@children.0/@children.2/@ports.0" targets="//@children.6/@children.1/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E247" sources="//@children.6/@children.1/@children.0/@children.3/@ports.1" targets="//@children.6/@children.1/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E248" sources="//@children.6/@children.1/@children.0/@children.4/@ports.0" targets="//@children.6/@children.1/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E249" sources="//@children.6/@children.1/@children.0/@children.5/@ports.2" targets="//@children.6/@children.1/@children.0/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N57" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="72.0" text="elbow_angle"/>
+        <ports identifier="P218" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="44.0" text="Merge3"/>
+        <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.19 //@children.6/@children.1/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P221" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.20 //@children.6/@children.1/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="80.0" text="AddSubtract6"/>
+        <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.16 //@children.6/@children.1/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P224" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="41.0" text="Delay7"/>
+        <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P226" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.1/@containedEdges.23 //@children.6/@children.1/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="63.0" text="Sampler14"/>
+        <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P228" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P229" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N62">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L62" height="15.0" width="52.0" text="getAngle"/>
+        <ports identifier="P230" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.1 //@children.6/@children.1/@children.6/@containedEdges.2" incomingEdges="//@children.6/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P231" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.3 //@children.6/@children.1/@children.6/@containedEdges.4" incomingEdges="//@children.6/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P232" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.7" incomingEdges="//@children.6/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P233" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.6" incomingEdges="//@children.6/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P234" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.0" incomingEdges="//@children.6/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P235" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.5" incomingEdges="//@children.6/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P236" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.26" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N63" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L63" height="15.0" width="80.0" text="AddSubtract7"/>
+          <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P239" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.8 //@children.6/@children.1/@children.6/@containedEdges.9 //@children.6/@children.1/@children.6/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N64" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L64" height="15.0" width="80.0" text="AddSubtract8"/>
+          <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P242" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.11 //@children.6/@children.1/@children.6/@containedEdges.12 //@children.6/@children.1/@children.6/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N65" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L65" height="15.0" width="80.0" text="AddSubtract1"/>
+          <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P245" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.14 //@children.6/@children.1/@children.6/@containedEdges.15 //@children.6/@children.1/@children.6/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N66" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L66" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P248" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.17 //@children.6/@children.1/@children.6/@containedEdges.18 //@children.6/@children.1/@children.6/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N67" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L67" height="15.0" width="79.0" text="TrigFunction1"/>
+          <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P250" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N68" height="25.0" width="180.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="71.0" text="AxBx_AyBy"/>
+          <ports identifier="P251" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="72.0" text="Maximum10"/>
+          <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.23 //@children.6/@children.1/@children.6/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P259" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P260" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="67.0" text="Minimum11"/>
+          <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.21 //@children.6/@children.1/@children.6/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P262" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P263" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N71" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="49.0" text="Const12"/>
+          <ports identifier="P264" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="49.0" text="Const13"/>
+          <ports identifier="P266" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N73" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="106.0" text="CartesianToPolar1"/>
+          <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P270" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P271" height="8.0" width="8.0" x="31.0" y="18.0">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N74" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="106.0" text="CartesianToPolar2"/>
+          <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P274" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P275" height="8.0" width="8.0" x="31.0" y="18.0">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N75" height="25.0" width="101.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L75" height="15.0" width="68.0" text="AxBy-AyBx"/>
+          <ports identifier="P276" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N76" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L76" height="15.0" width="94.0" text="MultiplyDivide12"/>
+          <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.20 //@children.6/@children.1/@children.6/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P283" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N77" height="36.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L77" height="15.0" width="87.0" text="MathFunction1"/>
+          <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@children.1/@children.6/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P285" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@children.6/@children.1/@children.6/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E250" sources="//@children.6/@children.1/@children.6/@ports.4" targets="//@children.6/@children.1/@children.6/@children.0/@ports.0"/>
+        <containedEdges identifier="E251" sources="//@children.6/@children.1/@children.6/@ports.0" targets="//@children.6/@children.1/@children.6/@children.0/@ports.1"/>
+        <containedEdges identifier="E252" sources="//@children.6/@children.1/@children.6/@ports.0" targets="//@children.6/@children.1/@children.6/@children.2/@ports.1"/>
+        <containedEdges identifier="E253" sources="//@children.6/@children.1/@children.6/@ports.1" targets="//@children.6/@children.1/@children.6/@children.1/@ports.1"/>
+        <containedEdges identifier="E254" sources="//@children.6/@children.1/@children.6/@ports.1" targets="//@children.6/@children.1/@children.6/@children.3/@ports.1"/>
+        <containedEdges identifier="E255" sources="//@children.6/@children.1/@children.6/@ports.5" targets="//@children.6/@children.1/@children.6/@children.1/@ports.0"/>
+        <containedEdges identifier="E256" sources="//@children.6/@children.1/@children.6/@ports.3" targets="//@children.6/@children.1/@children.6/@children.3/@ports.0"/>
+        <containedEdges identifier="E257" sources="//@children.6/@children.1/@children.6/@ports.2" targets="//@children.6/@children.1/@children.6/@children.2/@ports.0"/>
+        <containedEdges identifier="E258" sources="//@children.6/@children.1/@children.6/@children.0/@ports.2" targets="//@children.6/@children.1/@children.6/@children.5/@ports.1"/>
+        <containedEdges identifier="E259" sources="//@children.6/@children.1/@children.6/@children.0/@ports.2" targets="//@children.6/@children.1/@children.6/@children.11/@ports.0"/>
+        <containedEdges identifier="E260" sources="//@children.6/@children.1/@children.6/@children.0/@ports.2" targets="//@children.6/@children.1/@children.6/@children.12/@ports.1"/>
+        <containedEdges identifier="E261" sources="//@children.6/@children.1/@children.6/@children.1/@ports.2" targets="//@children.6/@children.1/@children.6/@children.5/@ports.2"/>
+        <containedEdges identifier="E262" sources="//@children.6/@children.1/@children.6/@children.1/@ports.2" targets="//@children.6/@children.1/@children.6/@children.11/@ports.1"/>
+        <containedEdges identifier="E263" sources="//@children.6/@children.1/@children.6/@children.1/@ports.2" targets="//@children.6/@children.1/@children.6/@children.12/@ports.2"/>
+        <containedEdges identifier="E264" sources="//@children.6/@children.1/@children.6/@children.2/@ports.2" targets="//@children.6/@children.1/@children.6/@children.5/@ports.3"/>
+        <containedEdges identifier="E265" sources="//@children.6/@children.1/@children.6/@children.2/@ports.2" targets="//@children.6/@children.1/@children.6/@children.10/@ports.0"/>
+        <containedEdges identifier="E266" sources="//@children.6/@children.1/@children.6/@children.2/@ports.2" targets="//@children.6/@children.1/@children.6/@children.12/@ports.3"/>
+        <containedEdges identifier="E267" sources="//@children.6/@children.1/@children.6/@children.3/@ports.2" targets="//@children.6/@children.1/@children.6/@children.5/@ports.4"/>
+        <containedEdges identifier="E268" sources="//@children.6/@children.1/@children.6/@children.3/@ports.2" targets="//@children.6/@children.1/@children.6/@children.10/@ports.1"/>
+        <containedEdges identifier="E269" sources="//@children.6/@children.1/@children.6/@children.3/@ports.2" targets="//@children.6/@children.1/@children.6/@children.12/@ports.4"/>
+        <containedEdges identifier="E270" sources="//@children.6/@children.1/@children.6/@children.4/@ports.1" targets="//@children.6/@children.1/@children.6/@children.13/@ports.0"/>
+        <containedEdges identifier="E271" sources="//@children.6/@children.1/@children.6/@children.5/@ports.0" targets="//@children.6/@children.1/@children.6/@children.7/@ports.0"/>
+        <containedEdges identifier="E272" sources="//@children.6/@children.1/@children.6/@children.6/@ports.1" targets="//@children.6/@children.1/@children.6/@children.4/@ports.0"/>
+        <containedEdges identifier="E273" sources="//@children.6/@children.1/@children.6/@children.7/@ports.1" targets="//@children.6/@children.1/@children.6/@children.6/@ports.0"/>
+        <containedEdges identifier="E274" sources="//@children.6/@children.1/@children.6/@children.8/@ports.0" targets="//@children.6/@children.1/@children.6/@children.6/@ports.0"/>
+        <containedEdges identifier="E275" sources="//@children.6/@children.1/@children.6/@children.9/@ports.0" targets="//@children.6/@children.1/@children.6/@children.7/@ports.0"/>
+        <containedEdges identifier="E276" sources="//@children.6/@children.1/@children.6/@children.10/@ports.2" targets="//@children.6/@children.1/@children.6/@children.5/@ports.6"/>
+        <containedEdges identifier="E277" sources="//@children.6/@children.1/@children.6/@children.11/@ports.2" targets="//@children.6/@children.1/@children.6/@children.5/@ports.5"/>
+        <containedEdges identifier="E278" sources="//@children.6/@children.1/@children.6/@children.12/@ports.0" targets="//@children.6/@children.1/@children.6/@children.14/@ports.0"/>
+        <containedEdges identifier="E279" sources="//@children.6/@children.1/@children.6/@children.13/@ports.2" targets="//@children.6/@children.1/@children.6/@ports.6"/>
+        <containedEdges identifier="E280" sources="//@children.6/@children.1/@children.6/@children.14/@ports.1" targets="//@children.6/@children.1/@children.6/@children.13/@ports.0"/>
+      </children>
+      <children identifier="N78">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L78" height="15.0" width="66.0" text="rotator_end"/>
+        <ports identifier="P286" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.2 //@children.6/@children.1/@children.7/@containedEdges.3" incomingEdges="//@children.6/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P287" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.4 //@children.6/@children.1/@children.7/@containedEdges.5" incomingEdges="//@children.6/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P288" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.6 //@children.6/@children.1/@children.7/@containedEdges.7" incomingEdges="//@children.6/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P289" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.8 //@children.6/@children.1/@children.7/@containedEdges.9" incomingEdges="//@children.6/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P290" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.0 //@children.6/@children.1/@children.7/@containedEdges.1" incomingEdges="//@children.6/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P291" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.27" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P292" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.28" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N79" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L79" height="15.0" width="79.0" text="TrigFunction5"/>
+          <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P294" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.10 //@children.6/@children.1/@children.7/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N80" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L80" height="15.0" width="79.0" text="TrigFunction6"/>
+          <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P296" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.12 //@children.6/@children.1/@children.7/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N81" height="25.0" width="234.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L81" height="15.0" width="80.0" text="Expression15"/>
+          <ports identifier="P297" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N82" height="25.0" width="240.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L82" height="15.0" width="80.0" text="Expression16"/>
+          <ports identifier="P304" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.7/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.1/@children.7/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E281" sources="//@children.6/@children.1/@children.7/@ports.4" targets="//@children.6/@children.1/@children.7/@children.0/@ports.0"/>
+        <containedEdges identifier="E282" sources="//@children.6/@children.1/@children.7/@ports.4" targets="//@children.6/@children.1/@children.7/@children.1/@ports.0"/>
+        <containedEdges identifier="E283" sources="//@children.6/@children.1/@children.7/@ports.0" targets="//@children.6/@children.1/@children.7/@children.2/@ports.1"/>
+        <containedEdges identifier="E284" sources="//@children.6/@children.1/@children.7/@ports.0" targets="//@children.6/@children.1/@children.7/@children.3/@ports.1"/>
+        <containedEdges identifier="E285" sources="//@children.6/@children.1/@children.7/@ports.1" targets="//@children.6/@children.1/@children.7/@children.2/@ports.2"/>
+        <containedEdges identifier="E286" sources="//@children.6/@children.1/@children.7/@ports.1" targets="//@children.6/@children.1/@children.7/@children.3/@ports.2"/>
+        <containedEdges identifier="E287" sources="//@children.6/@children.1/@children.7/@ports.2" targets="//@children.6/@children.1/@children.7/@children.2/@ports.3"/>
+        <containedEdges identifier="E288" sources="//@children.6/@children.1/@children.7/@ports.2" targets="//@children.6/@children.1/@children.7/@children.3/@ports.3"/>
+        <containedEdges identifier="E289" sources="//@children.6/@children.1/@children.7/@ports.3" targets="//@children.6/@children.1/@children.7/@children.2/@ports.4"/>
+        <containedEdges identifier="E290" sources="//@children.6/@children.1/@children.7/@ports.3" targets="//@children.6/@children.1/@children.7/@children.3/@ports.4"/>
+        <containedEdges identifier="E291" sources="//@children.6/@children.1/@children.7/@children.0/@ports.1" targets="//@children.6/@children.1/@children.7/@children.2/@ports.5"/>
+        <containedEdges identifier="E292" sources="//@children.6/@children.1/@children.7/@children.0/@ports.1" targets="//@children.6/@children.1/@children.7/@children.3/@ports.5"/>
+        <containedEdges identifier="E293" sources="//@children.6/@children.1/@children.7/@children.1/@ports.1" targets="//@children.6/@children.1/@children.7/@children.2/@ports.6"/>
+        <containedEdges identifier="E294" sources="//@children.6/@children.1/@children.7/@children.1/@ports.1" targets="//@children.6/@children.1/@children.7/@children.3/@ports.6"/>
+        <containedEdges identifier="E295" sources="//@children.6/@children.1/@children.7/@children.2/@ports.0" targets="//@children.6/@children.1/@children.7/@ports.5"/>
+        <containedEdges identifier="E296" sources="//@children.6/@children.1/@children.7/@children.3/@ports.0" targets="//@children.6/@children.1/@children.7/@ports.6"/>
+      </children>
+      <children identifier="N83">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L83" height="15.0" width="71.0" text="rotator_wrist"/>
+        <ports identifier="P311" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.2 //@children.6/@children.1/@children.8/@containedEdges.3" incomingEdges="//@children.6/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P312" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.4 //@children.6/@children.1/@children.8/@containedEdges.5" incomingEdges="//@children.6/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P313" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.6 //@children.6/@children.1/@children.8/@containedEdges.7" incomingEdges="//@children.6/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P314" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.8 //@children.6/@children.1/@children.8/@containedEdges.9" incomingEdges="//@children.6/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P315" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.0 //@children.6/@children.1/@children.8/@containedEdges.1" incomingEdges="//@children.6/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P316" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.29" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P317" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.30" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N84" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L84" height="15.0" width="79.0" text="TrigFunction5"/>
+          <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P319" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.10 //@children.6/@children.1/@children.8/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N85" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L85" height="15.0" width="79.0" text="TrigFunction6"/>
+          <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P321" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.12 //@children.6/@children.1/@children.8/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N86" height="25.0" width="234.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L86" height="15.0" width="80.0" text="Expression15"/>
+          <ports identifier="P322" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N87" height="25.0" width="240.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L87" height="15.0" width="80.0" text="Expression16"/>
+          <ports identifier="P329" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@children.6/@children.1/@children.8/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.1/@children.8/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E297" sources="//@children.6/@children.1/@children.8/@ports.4" targets="//@children.6/@children.1/@children.8/@children.0/@ports.0"/>
+        <containedEdges identifier="E298" sources="//@children.6/@children.1/@children.8/@ports.4" targets="//@children.6/@children.1/@children.8/@children.1/@ports.0"/>
+        <containedEdges identifier="E299" sources="//@children.6/@children.1/@children.8/@ports.0" targets="//@children.6/@children.1/@children.8/@children.2/@ports.1"/>
+        <containedEdges identifier="E300" sources="//@children.6/@children.1/@children.8/@ports.0" targets="//@children.6/@children.1/@children.8/@children.3/@ports.1"/>
+        <containedEdges identifier="E301" sources="//@children.6/@children.1/@children.8/@ports.1" targets="//@children.6/@children.1/@children.8/@children.2/@ports.2"/>
+        <containedEdges identifier="E302" sources="//@children.6/@children.1/@children.8/@ports.1" targets="//@children.6/@children.1/@children.8/@children.3/@ports.2"/>
+        <containedEdges identifier="E303" sources="//@children.6/@children.1/@children.8/@ports.2" targets="//@children.6/@children.1/@children.8/@children.2/@ports.3"/>
+        <containedEdges identifier="E304" sources="//@children.6/@children.1/@children.8/@ports.2" targets="//@children.6/@children.1/@children.8/@children.3/@ports.3"/>
+        <containedEdges identifier="E305" sources="//@children.6/@children.1/@children.8/@ports.3" targets="//@children.6/@children.1/@children.8/@children.2/@ports.4"/>
+        <containedEdges identifier="E306" sources="//@children.6/@children.1/@children.8/@ports.3" targets="//@children.6/@children.1/@children.8/@children.3/@ports.4"/>
+        <containedEdges identifier="E307" sources="//@children.6/@children.1/@children.8/@children.0/@ports.1" targets="//@children.6/@children.1/@children.8/@children.2/@ports.5"/>
+        <containedEdges identifier="E308" sources="//@children.6/@children.1/@children.8/@children.0/@ports.1" targets="//@children.6/@children.1/@children.8/@children.3/@ports.5"/>
+        <containedEdges identifier="E309" sources="//@children.6/@children.1/@children.8/@children.1/@ports.1" targets="//@children.6/@children.1/@children.8/@children.2/@ports.6"/>
+        <containedEdges identifier="E310" sources="//@children.6/@children.1/@children.8/@children.1/@ports.1" targets="//@children.6/@children.1/@children.8/@children.3/@ports.6"/>
+        <containedEdges identifier="E311" sources="//@children.6/@children.1/@children.8/@children.2/@ports.0" targets="//@children.6/@children.1/@children.8/@ports.5"/>
+        <containedEdges identifier="E312" sources="//@children.6/@children.1/@children.8/@children.3/@ports.0" targets="//@children.6/@children.1/@children.8/@ports.6"/>
+      </children>
+      <children identifier="N88" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L88" height="15.0" width="41.0" text="Scale1"/>
+        <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P337" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.1/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E207" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.1/@children.5/@ports.2"/>
+      <containedEdges identifier="E208" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E209" sources="//@children.6/@children.1/@ports.4" targets="//@children.6/@children.1/@children.6/@ports.4"/>
+      <containedEdges identifier="E210" sources="//@children.6/@children.1/@ports.5" targets="//@children.6/@children.1/@children.6/@ports.5"/>
+      <containedEdges identifier="E211" sources="//@children.6/@children.1/@ports.8" targets="//@children.6/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E212" sources="//@children.6/@children.1/@ports.8" targets="//@children.6/@children.1/@children.7/@ports.0"/>
+      <containedEdges identifier="E213" sources="//@children.6/@children.1/@ports.8" targets="//@children.6/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E214" sources="//@children.6/@children.1/@ports.9" targets="//@children.6/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E215" sources="//@children.6/@children.1/@ports.9" targets="//@children.6/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E216" sources="//@children.6/@children.1/@ports.9" targets="//@children.6/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E217" sources="//@children.6/@children.1/@ports.6" targets="//@children.6/@children.1/@children.6/@ports.2"/>
+      <containedEdges identifier="E218" sources="//@children.6/@children.1/@ports.6" targets="//@children.6/@children.1/@children.7/@ports.2"/>
+      <containedEdges identifier="E219" sources="//@children.6/@children.1/@ports.7" targets="//@children.6/@children.1/@children.6/@ports.3"/>
+      <containedEdges identifier="E220" sources="//@children.6/@children.1/@ports.7" targets="//@children.6/@children.1/@children.7/@ports.3"/>
+      <containedEdges identifier="E221" sources="//@children.6/@children.1/@ports.10" targets="//@children.6/@children.1/@children.8/@ports.2"/>
+      <containedEdges identifier="E222" sources="//@children.6/@children.1/@ports.11" targets="//@children.6/@children.1/@children.8/@ports.3"/>
+      <containedEdges identifier="E223" sources="//@children.6/@children.1/@children.0/@ports.2" targets="//@children.6/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E224" sources="//@children.6/@children.1/@children.0/@ports.2" targets="//@children.6/@children.1/@children.7/@ports.4"/>
+      <containedEdges identifier="E225" sources="//@children.6/@children.1/@children.0/@ports.2" targets="//@children.6/@children.1/@children.8/@ports.4"/>
+      <containedEdges identifier="E226" sources="//@children.6/@children.1/@children.1/@ports.0" targets="//@children.6/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E227" sources="//@children.6/@children.1/@children.2/@ports.1" targets="//@children.6/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E228" sources="//@children.6/@children.1/@children.2/@ports.1" targets="//@children.6/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E229" sources="//@children.6/@children.1/@children.3/@ports.2" targets="//@children.6/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E230" sources="//@children.6/@children.1/@children.4/@ports.1" targets="//@children.6/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E231" sources="//@children.6/@children.1/@children.4/@ports.1" targets="//@children.6/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E232" sources="//@children.6/@children.1/@children.5/@ports.1" targets="//@children.6/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E233" sources="//@children.6/@children.1/@children.6/@ports.6" targets="//@children.6/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E234" sources="//@children.6/@children.1/@children.7/@ports.5" targets="//@children.6/@children.1/@ports.2"/>
+      <containedEdges identifier="E235" sources="//@children.6/@children.1/@children.7/@ports.6" targets="//@children.6/@children.1/@ports.3"/>
+      <containedEdges identifier="E236" sources="//@children.6/@children.1/@children.8/@ports.5" targets="//@children.6/@children.1/@ports.12"/>
+      <containedEdges identifier="E237" sources="//@children.6/@children.1/@children.8/@ports.6" targets="//@children.6/@children.1/@ports.13"/>
+      <containedEdges identifier="E238" sources="//@children.6/@children.1/@children.9/@ports.1" targets="//@children.6/@children.1/@ports.14"/>
+    </children>
+    <children identifier="N89">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L89" height="15.0" width="58.0" text="applywrist"/>
+      <ports identifier="P338" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P339" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P340" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.24" incomingEdges="//@children.6/@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P341" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.25" incomingEdges="//@children.6/@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P342" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.11" incomingEdges="//@children.6/@containedEdges.70">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P343" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.2" incomingEdges="//@children.6/@containedEdges.74">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P344" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.7 //@children.6/@children.2/@containedEdges.8" incomingEdges="//@children.6/@containedEdges.27 //@children.6/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P345" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.9 //@children.6/@children.2/@containedEdges.10" incomingEdges="//@children.6/@containedEdges.28 //@children.6/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P346" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.3 //@children.6/@children.2/@containedEdges.4" incomingEdges="//@children.6/@containedEdges.30 //@children.6/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="-8"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P347" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.5 //@children.6/@children.2/@containedEdges.6" incomingEdges="//@children.6/@containedEdges.32 //@children.6/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="-9"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P348" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.26" incomingEdges="//@children.6/@children.2/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="10"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N90">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L90" height="15.0" width="36.0" text="clamp"/>
+        <ports identifier="P349" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.4" incomingEdges="//@children.6/@children.2/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P350" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.0 //@children.6/@children.2/@children.0/@containedEdges.1 //@children.6/@children.2/@children.0/@containedEdges.2 //@children.6/@children.2/@children.0/@containedEdges.3" incomingEdges="//@children.6/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P351" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.12 //@children.6/@children.2/@containedEdges.13" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N91" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L91" height="15.0" width="61.0" text="Minimum3"/>
+          <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.8 //@children.6/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P353" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P354" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N92" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L92" height="15.0" width="80.0" text="AddSubtract4"/>
+          <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P356" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P357" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N93" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="22.0" text="min"/>
+          <ports identifier="P358" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="72.0" text="Maximum21"/>
+          <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.4 //@children.6/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P361" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P362" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N95" height="25.0" width="34.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L95" height="15.0" width="25.0" text="max"/>
+          <ports identifier="P363" height="8.0" width="8.0" x="34.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N96" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L96" height="15.0" width="87.0" text="AddSubtract27"/>
+          <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.2/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P367" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E338" sources="//@children.6/@children.2/@children.0/@ports.1" targets="//@children.6/@children.2/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E339" sources="//@children.6/@children.2/@children.0/@ports.1" targets="//@children.6/@children.2/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E340" sources="//@children.6/@children.2/@children.0/@ports.1" targets="//@children.6/@children.2/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E341" sources="//@children.6/@children.2/@children.0/@ports.1" targets="//@children.6/@children.2/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E342" sources="//@children.6/@children.2/@children.0/@ports.0" targets="//@children.6/@children.2/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E343" sources="//@children.6/@children.2/@children.0/@children.0/@ports.1" targets="//@children.6/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E344" sources="//@children.6/@children.2/@children.0/@children.1/@ports.2" targets="//@children.6/@children.2/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E345" sources="//@children.6/@children.2/@children.0/@children.2/@ports.0" targets="//@children.6/@children.2/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E346" sources="//@children.6/@children.2/@children.0/@children.3/@ports.1" targets="//@children.6/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E347" sources="//@children.6/@children.2/@children.0/@children.4/@ports.0" targets="//@children.6/@children.2/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E348" sources="//@children.6/@children.2/@children.0/@children.5/@ports.2" targets="//@children.6/@children.2/@children.0/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N97" height="25.0" width="34.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L97" height="15.0" width="66.0" text="wrist_angle"/>
+        <ports identifier="P368" height="8.0" width="8.0" x="34.0" y="8.5" outgoingEdges="//@children.6/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N98" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L98" height="15.0" width="44.0" text="Merge3"/>
+        <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@containedEdges.14 //@children.6/@children.2/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P371" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@children.2/@containedEdges.15 //@children.6/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N99" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="80.0" text="AddSubtract6"/>
+        <ports identifier="P372" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@containedEdges.12 //@children.6/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P374" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N100" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L100" height="15.0" width="41.0" text="Delay7"/>
+        <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P376" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.2/@containedEdges.18 //@children.6/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N101" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L101" height="15.0" width="63.0" text="Sampler14"/>
+        <ports identifier="P377" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P378" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.2/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P379" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N102">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L102" height="15.0" width="52.0" text="getAngle"/>
+        <ports identifier="P380" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.1 //@children.6/@children.2/@children.6/@containedEdges.2" incomingEdges="//@children.6/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P381" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.3 //@children.6/@children.2/@children.6/@containedEdges.4" incomingEdges="//@children.6/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P382" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.7" incomingEdges="//@children.6/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P383" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.6" incomingEdges="//@children.6/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P384" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.0" incomingEdges="//@children.6/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P385" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.5" incomingEdges="//@children.6/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P386" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.21" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N103" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L103" height="15.0" width="80.0" text="AddSubtract7"/>
+          <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P388" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P389" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.8 //@children.6/@children.2/@children.6/@containedEdges.9 //@children.6/@children.2/@children.6/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N104" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L104" height="15.0" width="80.0" text="AddSubtract8"/>
+          <ports identifier="P390" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P392" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.11 //@children.6/@children.2/@children.6/@containedEdges.12 //@children.6/@children.2/@children.6/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N105" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L105" height="15.0" width="80.0" text="AddSubtract1"/>
+          <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P395" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.14 //@children.6/@children.2/@children.6/@containedEdges.15 //@children.6/@children.2/@children.6/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N106" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L106" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P396" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P398" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.17 //@children.6/@children.2/@children.6/@containedEdges.18 //@children.6/@children.2/@children.6/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N107" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L107" height="15.0" width="79.0" text="TrigFunction1"/>
+          <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P400" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N108" height="25.0" width="180.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L108" height="15.0" width="71.0" text="AxBx_AyBy"/>
+          <ports identifier="P401" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P404" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P406" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N109" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L109" height="15.0" width="72.0" text="Maximum10"/>
+          <ports identifier="P408" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.23 //@children.6/@children.2/@children.6/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P409" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P410" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N110" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L110" height="15.0" width="67.0" text="Minimum11"/>
+          <ports identifier="P411" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.21 //@children.6/@children.2/@children.6/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P412" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P413" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N111" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L111" height="15.0" width="49.0" text="Const12"/>
+          <ports identifier="P414" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P415" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N112" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="49.0" text="Const13"/>
+          <ports identifier="P416" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="106.0" text="CartesianToPolar1"/>
+          <ports identifier="P418" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P420" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P421" height="8.0" width="8.0" x="31.0" y="18.0">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N114" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L114" height="15.0" width="106.0" text="CartesianToPolar2"/>
+          <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P424" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P425" height="8.0" width="8.0" x="31.0" y="18.0">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N115" height="25.0" width="101.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L115" height="15.0" width="68.0" text="AxBy-AyBx"/>
+          <ports identifier="P426" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P427" height="8.0" width="8.0" x="-8.0" y="-1.399999976158142" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="5.199999809265137" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="11.800000190734863" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P430" height="8.0" width="8.0" x="-8.0" y="18.399999618530273" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N116" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L116" height="15.0" width="94.0" text="MultiplyDivide12"/>
+          <ports identifier="P431" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.20 //@children.6/@children.2/@children.6/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P433" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N117" height="36.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="87.0" text="MathFunction1"/>
+          <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@children.2/@children.6/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P435" height="8.0" width="8.0" x="66.0" y="14.0" outgoingEdges="//@children.6/@children.2/@children.6/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E349" sources="//@children.6/@children.2/@children.6/@ports.4" targets="//@children.6/@children.2/@children.6/@children.0/@ports.0"/>
+        <containedEdges identifier="E350" sources="//@children.6/@children.2/@children.6/@ports.0" targets="//@children.6/@children.2/@children.6/@children.0/@ports.1"/>
+        <containedEdges identifier="E351" sources="//@children.6/@children.2/@children.6/@ports.0" targets="//@children.6/@children.2/@children.6/@children.2/@ports.1"/>
+        <containedEdges identifier="E352" sources="//@children.6/@children.2/@children.6/@ports.1" targets="//@children.6/@children.2/@children.6/@children.1/@ports.1"/>
+        <containedEdges identifier="E353" sources="//@children.6/@children.2/@children.6/@ports.1" targets="//@children.6/@children.2/@children.6/@children.3/@ports.1"/>
+        <containedEdges identifier="E354" sources="//@children.6/@children.2/@children.6/@ports.5" targets="//@children.6/@children.2/@children.6/@children.1/@ports.0"/>
+        <containedEdges identifier="E355" sources="//@children.6/@children.2/@children.6/@ports.3" targets="//@children.6/@children.2/@children.6/@children.3/@ports.0"/>
+        <containedEdges identifier="E356" sources="//@children.6/@children.2/@children.6/@ports.2" targets="//@children.6/@children.2/@children.6/@children.2/@ports.0"/>
+        <containedEdges identifier="E357" sources="//@children.6/@children.2/@children.6/@children.0/@ports.2" targets="//@children.6/@children.2/@children.6/@children.5/@ports.1"/>
+        <containedEdges identifier="E358" sources="//@children.6/@children.2/@children.6/@children.0/@ports.2" targets="//@children.6/@children.2/@children.6/@children.11/@ports.0"/>
+        <containedEdges identifier="E359" sources="//@children.6/@children.2/@children.6/@children.0/@ports.2" targets="//@children.6/@children.2/@children.6/@children.12/@ports.1"/>
+        <containedEdges identifier="E360" sources="//@children.6/@children.2/@children.6/@children.1/@ports.2" targets="//@children.6/@children.2/@children.6/@children.5/@ports.2"/>
+        <containedEdges identifier="E361" sources="//@children.6/@children.2/@children.6/@children.1/@ports.2" targets="//@children.6/@children.2/@children.6/@children.11/@ports.1"/>
+        <containedEdges identifier="E362" sources="//@children.6/@children.2/@children.6/@children.1/@ports.2" targets="//@children.6/@children.2/@children.6/@children.12/@ports.2"/>
+        <containedEdges identifier="E363" sources="//@children.6/@children.2/@children.6/@children.2/@ports.2" targets="//@children.6/@children.2/@children.6/@children.5/@ports.3"/>
+        <containedEdges identifier="E364" sources="//@children.6/@children.2/@children.6/@children.2/@ports.2" targets="//@children.6/@children.2/@children.6/@children.10/@ports.0"/>
+        <containedEdges identifier="E365" sources="//@children.6/@children.2/@children.6/@children.2/@ports.2" targets="//@children.6/@children.2/@children.6/@children.12/@ports.3"/>
+        <containedEdges identifier="E366" sources="//@children.6/@children.2/@children.6/@children.3/@ports.2" targets="//@children.6/@children.2/@children.6/@children.5/@ports.4"/>
+        <containedEdges identifier="E367" sources="//@children.6/@children.2/@children.6/@children.3/@ports.2" targets="//@children.6/@children.2/@children.6/@children.10/@ports.1"/>
+        <containedEdges identifier="E368" sources="//@children.6/@children.2/@children.6/@children.3/@ports.2" targets="//@children.6/@children.2/@children.6/@children.12/@ports.4"/>
+        <containedEdges identifier="E369" sources="//@children.6/@children.2/@children.6/@children.4/@ports.1" targets="//@children.6/@children.2/@children.6/@children.13/@ports.0"/>
+        <containedEdges identifier="E370" sources="//@children.6/@children.2/@children.6/@children.5/@ports.0" targets="//@children.6/@children.2/@children.6/@children.7/@ports.0"/>
+        <containedEdges identifier="E371" sources="//@children.6/@children.2/@children.6/@children.6/@ports.1" targets="//@children.6/@children.2/@children.6/@children.4/@ports.0"/>
+        <containedEdges identifier="E372" sources="//@children.6/@children.2/@children.6/@children.7/@ports.1" targets="//@children.6/@children.2/@children.6/@children.6/@ports.0"/>
+        <containedEdges identifier="E373" sources="//@children.6/@children.2/@children.6/@children.8/@ports.0" targets="//@children.6/@children.2/@children.6/@children.6/@ports.0"/>
+        <containedEdges identifier="E374" sources="//@children.6/@children.2/@children.6/@children.9/@ports.0" targets="//@children.6/@children.2/@children.6/@children.7/@ports.0"/>
+        <containedEdges identifier="E375" sources="//@children.6/@children.2/@children.6/@children.10/@ports.2" targets="//@children.6/@children.2/@children.6/@children.5/@ports.6"/>
+        <containedEdges identifier="E376" sources="//@children.6/@children.2/@children.6/@children.11/@ports.2" targets="//@children.6/@children.2/@children.6/@children.5/@ports.5"/>
+        <containedEdges identifier="E377" sources="//@children.6/@children.2/@children.6/@children.12/@ports.0" targets="//@children.6/@children.2/@children.6/@children.14/@ports.0"/>
+        <containedEdges identifier="E378" sources="//@children.6/@children.2/@children.6/@children.13/@ports.2" targets="//@children.6/@children.2/@children.6/@ports.6"/>
+        <containedEdges identifier="E379" sources="//@children.6/@children.2/@children.6/@children.14/@ports.1" targets="//@children.6/@children.2/@children.6/@children.13/@ports.0"/>
+      </children>
+      <children identifier="N118">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L118" height="15.0" width="38.0" text="rotator"/>
+        <ports identifier="P436" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.2 //@children.6/@children.2/@children.7/@containedEdges.3" incomingEdges="//@children.6/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P437" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.4 //@children.6/@children.2/@children.7/@containedEdges.5" incomingEdges="//@children.6/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P438" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.6 //@children.6/@children.2/@children.7/@containedEdges.7" incomingEdges="//@children.6/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P439" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.8 //@children.6/@children.2/@children.7/@containedEdges.9" incomingEdges="//@children.6/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P440" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.0 //@children.6/@children.2/@children.7/@containedEdges.1" incomingEdges="//@children.6/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P441" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.22" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P442" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.23" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N119" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="79.0" text="TrigFunction5"/>
+          <ports identifier="P443" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P444" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.10 //@children.6/@children.2/@children.7/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N120" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L120" height="15.0" width="79.0" text="TrigFunction6"/>
+          <ports identifier="P445" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P446" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.12 //@children.6/@children.2/@children.7/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N121" height="25.0" width="234.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L121" height="15.0" width="80.0" text="Expression15"/>
+          <ports identifier="P447" height="8.0" width="8.0" x="234.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P448" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P450" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P451" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P453" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N122" height="25.0" width="240.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L122" height="15.0" width="80.0" text="Expression16"/>
+          <ports identifier="P454" height="8.0" width="8.0" x="240.0" y="8.5" outgoingEdges="//@children.6/@children.2/@children.7/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="-3.2857143878936768" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="1.4285714626312256" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="6.142857074737549" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="10.857142448425293" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P459" height="8.0" width="8.0" x="-8.0" y="15.571428298950195" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-5"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="20.285715103149414" incomingEdges="//@children.6/@children.2/@children.7/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E380" sources="//@children.6/@children.2/@children.7/@ports.4" targets="//@children.6/@children.2/@children.7/@children.0/@ports.0"/>
+        <containedEdges identifier="E381" sources="//@children.6/@children.2/@children.7/@ports.4" targets="//@children.6/@children.2/@children.7/@children.1/@ports.0"/>
+        <containedEdges identifier="E382" sources="//@children.6/@children.2/@children.7/@ports.0" targets="//@children.6/@children.2/@children.7/@children.2/@ports.1"/>
+        <containedEdges identifier="E383" sources="//@children.6/@children.2/@children.7/@ports.0" targets="//@children.6/@children.2/@children.7/@children.3/@ports.1"/>
+        <containedEdges identifier="E384" sources="//@children.6/@children.2/@children.7/@ports.1" targets="//@children.6/@children.2/@children.7/@children.2/@ports.2"/>
+        <containedEdges identifier="E385" sources="//@children.6/@children.2/@children.7/@ports.1" targets="//@children.6/@children.2/@children.7/@children.3/@ports.2"/>
+        <containedEdges identifier="E386" sources="//@children.6/@children.2/@children.7/@ports.2" targets="//@children.6/@children.2/@children.7/@children.2/@ports.3"/>
+        <containedEdges identifier="E387" sources="//@children.6/@children.2/@children.7/@ports.2" targets="//@children.6/@children.2/@children.7/@children.3/@ports.3"/>
+        <containedEdges identifier="E388" sources="//@children.6/@children.2/@children.7/@ports.3" targets="//@children.6/@children.2/@children.7/@children.2/@ports.4"/>
+        <containedEdges identifier="E389" sources="//@children.6/@children.2/@children.7/@ports.3" targets="//@children.6/@children.2/@children.7/@children.3/@ports.4"/>
+        <containedEdges identifier="E390" sources="//@children.6/@children.2/@children.7/@children.0/@ports.1" targets="//@children.6/@children.2/@children.7/@children.2/@ports.5"/>
+        <containedEdges identifier="E391" sources="//@children.6/@children.2/@children.7/@children.0/@ports.1" targets="//@children.6/@children.2/@children.7/@children.3/@ports.5"/>
+        <containedEdges identifier="E392" sources="//@children.6/@children.2/@children.7/@children.1/@ports.1" targets="//@children.6/@children.2/@children.7/@children.2/@ports.6"/>
+        <containedEdges identifier="E393" sources="//@children.6/@children.2/@children.7/@children.1/@ports.1" targets="//@children.6/@children.2/@children.7/@children.3/@ports.6"/>
+        <containedEdges identifier="E394" sources="//@children.6/@children.2/@children.7/@children.2/@ports.0" targets="//@children.6/@children.2/@children.7/@ports.5"/>
+        <containedEdges identifier="E395" sources="//@children.6/@children.2/@children.7/@children.3/@ports.0" targets="//@children.6/@children.2/@children.7/@ports.6"/>
+      </children>
+      <children identifier="N123" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L123" height="15.0" width="41.0" text="Scale0"/>
+        <ports identifier="P461" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P462" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.2/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E313" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.2/@children.5/@ports.2"/>
+      <containedEdges identifier="E314" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E315" sources="//@children.6/@children.2/@ports.5" targets="//@children.6/@children.2/@children.6/@ports.5"/>
+      <containedEdges identifier="E316" sources="//@children.6/@children.2/@ports.8" targets="//@children.6/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E317" sources="//@children.6/@children.2/@ports.8" targets="//@children.6/@children.2/@children.7/@ports.0"/>
+      <containedEdges identifier="E318" sources="//@children.6/@children.2/@ports.9" targets="//@children.6/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E319" sources="//@children.6/@children.2/@ports.9" targets="//@children.6/@children.2/@children.7/@ports.1"/>
+      <containedEdges identifier="E320" sources="//@children.6/@children.2/@ports.6" targets="//@children.6/@children.2/@children.6/@ports.2"/>
+      <containedEdges identifier="E321" sources="//@children.6/@children.2/@ports.6" targets="//@children.6/@children.2/@children.7/@ports.2"/>
+      <containedEdges identifier="E322" sources="//@children.6/@children.2/@ports.7" targets="//@children.6/@children.2/@children.6/@ports.3"/>
+      <containedEdges identifier="E323" sources="//@children.6/@children.2/@ports.7" targets="//@children.6/@children.2/@children.7/@ports.3"/>
+      <containedEdges identifier="E324" sources="//@children.6/@children.2/@ports.4" targets="//@children.6/@children.2/@children.6/@ports.4"/>
+      <containedEdges identifier="E325" sources="//@children.6/@children.2/@children.0/@ports.2" targets="//@children.6/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E326" sources="//@children.6/@children.2/@children.0/@ports.2" targets="//@children.6/@children.2/@children.7/@ports.4"/>
+      <containedEdges identifier="E327" sources="//@children.6/@children.2/@children.1/@ports.0" targets="//@children.6/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E328" sources="//@children.6/@children.2/@children.2/@ports.1" targets="//@children.6/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E329" sources="//@children.6/@children.2/@children.2/@ports.1" targets="//@children.6/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E330" sources="//@children.6/@children.2/@children.3/@ports.2" targets="//@children.6/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E331" sources="//@children.6/@children.2/@children.4/@ports.1" targets="//@children.6/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E332" sources="//@children.6/@children.2/@children.4/@ports.1" targets="//@children.6/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E333" sources="//@children.6/@children.2/@children.5/@ports.1" targets="//@children.6/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E334" sources="//@children.6/@children.2/@children.6/@ports.6" targets="//@children.6/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E335" sources="//@children.6/@children.2/@children.7/@ports.5" targets="//@children.6/@children.2/@ports.2"/>
+      <containedEdges identifier="E336" sources="//@children.6/@children.2/@children.7/@ports.6" targets="//@children.6/@children.2/@ports.3"/>
+      <containedEdges identifier="E337" sources="//@children.6/@children.2/@children.8/@ports.1" targets="//@children.6/@children.2/@ports.10"/>
+    </children>
+    <children identifier="N124" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L124" height="15.0" width="56.0" text="orig_endx"/>
+      <ports identifier="P463" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N125" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L125" height="15.0" width="56.0" text="orig_endy"/>
+      <ports identifier="P465" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P466" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N126" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L126" height="15.0" width="62.0" text="orig_wristx"/>
+      <ports identifier="P467" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.29 //@children.6/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N127" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L127" height="15.0" width="62.0" text="orig_wristy"/>
+      <ports identifier="P469" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.31 //@children.6/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N128" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L128" height="15.0" width="68.0" text="orig_elbowx"/>
+      <ports identifier="P471" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.33 //@children.6/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P472" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N129" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L129" height="15.0" width="68.0" text="orig_elbowy"/>
+      <ports identifier="P473" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.35 //@children.6/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N130" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L130" height="15.0" width="48.0" text="Delay46"/>
+      <ports identifier="P475" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P476" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N131" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L131" height="15.0" width="48.0" text="Delay47"/>
+      <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P478" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N132" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L132" height="15.0" width="48.0" text="Delay48"/>
+      <ports identifier="P479" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P480" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N133" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L133" height="15.0" width="48.0" text="Delay49"/>
+      <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P482" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N134" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L134" height="15.0" width="48.0" text="Delay50"/>
+      <ports identifier="P483" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P484" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N135" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L135" height="15.0" width="48.0" text="Delay51"/>
+      <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P486" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N136" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L136" height="15.0" width="63.0" text="Sampler64"/>
+      <ports identifier="P487" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P488" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P489" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.56">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N137" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L137" height="15.0" width="63.0" text="Sampler65"/>
+      <ports identifier="P490" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P491" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P492" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.57">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N138" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L138" height="15.0" width="63.0" text="Sampler66"/>
+      <ports identifier="P493" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P494" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.45 //@children.6/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P495" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.58">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N139" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L139" height="15.0" width="63.0" text="Sampler67"/>
+      <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P497" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.47 //@children.6/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P498" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.59">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N140" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L140" height="15.0" width="63.0" text="Sampler68"/>
+      <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P500" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.49 //@children.6/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P501" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.60">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N141" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L141" height="15.0" width="63.0" text="Sampler69"/>
+      <ports identifier="P502" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P503" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.51 //@children.6/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P504" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.61">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N142">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L142" height="15.0" width="107.0" text="countdown to zero"/>
+      <ports identifier="P505" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.21/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P506" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.53 //@children.6/@containedEdges.54 //@children.6/@containedEdges.55 //@children.6/@containedEdges.56 //@children.6/@containedEdges.57 //@children.6/@containedEdges.58 //@children.6/@containedEdges.59 //@children.6/@containedEdges.60 //@children.6/@containedEdges.61 //@children.6/@containedEdges.62 //@children.6/@containedEdges.63" incomingEdges="//@children.6/@children.21/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N143" height="25.0" width="25.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="42.0" text="Const1"/>
+        <ports identifier="P507" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.6/@children.21/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P508" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.21/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N144" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L144" height="15.0" width="44.0" text="Merge2"/>
+        <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.21/@containedEdges.1 //@children.6/@children.21/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P510" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@children.21/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N145" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L145" height="15.0" width="41.0" text="Delay5"/>
+        <ports identifier="P511" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.21/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P512" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.21/@containedEdges.3 //@children.6/@children.21/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N146" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L146" height="15.0" width="41.0" text="Scale0"/>
+        <ports identifier="P513" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.21/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P514" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.21/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N147" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L147" height="15.0" width="165.0" text="decrement and check if Zero"/>
+        <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.21/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P516" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.21/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E396" sources="//@children.6/@children.21/@ports.0" targets="//@children.6/@children.21/@children.0/@ports.1"/>
+      <containedEdges identifier="E397" sources="//@children.6/@children.21/@children.0/@ports.0" targets="//@children.6/@children.21/@children.1/@ports.0"/>
+      <containedEdges identifier="E398" sources="//@children.6/@children.21/@children.1/@ports.1" targets="//@children.6/@children.21/@children.4/@ports.0"/>
+      <containedEdges identifier="E399" sources="//@children.6/@children.21/@children.2/@ports.1" targets="//@children.6/@children.21/@children.1/@ports.0"/>
+      <containedEdges identifier="E400" sources="//@children.6/@children.21/@children.2/@ports.1" targets="//@children.6/@children.21/@children.3/@ports.0"/>
+      <containedEdges identifier="E401" sources="//@children.6/@children.21/@children.3/@ports.1" targets="//@children.6/@children.21/@ports.1"/>
+      <containedEdges identifier="E402" sources="//@children.6/@children.21/@children.4/@ports.1" targets="//@children.6/@children.21/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N148" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L148" height="15.0" width="41.0" text="Delay0"/>
+      <ports identifier="P517" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.71">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P518" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.64">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N149" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L149" height="15.0" width="41.0" text="Delay1"/>
+      <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.75">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P520" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.65">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N150" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L150" height="15.0" width="56.0" text="Sampler2"/>
+      <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.64">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P522" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.66">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P523" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.62">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N151" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L151" height="15.0" width="56.0" text="Sampler3"/>
+      <ports identifier="P524" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.65">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P525" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.67">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P526" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.63">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N152" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L152" height="15.0" width="51.0" text="Merge20"/>
+      <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.6 //@children.6/@containedEdges.66">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P528" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.68 //@children.6/@containedEdges.69 //@children.6/@containedEdges.70 //@children.6/@containedEdges.71">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N153" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L153" height="15.0" width="51.0" text="Merge21"/>
+      <ports identifier="P529" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.11 //@children.6/@containedEdges.67">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P530" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.72 //@children.6/@containedEdges.73 //@children.6/@containedEdges.74 //@children.6/@containedEdges.75">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.6/@children.4/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.6/@ports.0" targets="//@children.6/@children.5/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.6/@ports.0" targets="//@children.6/@children.6/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.6/@ports.0" targets="//@children.6/@children.7/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.6/@ports.0" targets="//@children.6/@children.8/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.6/@children.26/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.6/@ports.1" targets="//@children.6/@children.21/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.6/@ports.1" targets="//@children.6/@children.27/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.9/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.6/@children.0/@ports.3" targets="//@children.6/@children.10/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.6/@children.0/@ports.12" targets="//@children.6/@children.11/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.6/@children.0/@ports.13" targets="//@children.6/@children.12/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.6/@children.0/@ports.14" targets="//@children.6/@children.13/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.6/@children.0/@ports.15" targets="//@children.6/@children.14/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.6/@children.0/@ports.16" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.0/@ports.6"/>
+    <containedEdges identifier="E31" sources="//@children.6/@children.1/@ports.3" targets="//@children.6/@children.0/@ports.7"/>
+    <containedEdges identifier="E32" sources="//@children.6/@children.1/@ports.12" targets="//@children.6/@children.0/@ports.10"/>
+    <containedEdges identifier="E33" sources="//@children.6/@children.1/@ports.13" targets="//@children.6/@children.0/@ports.11"/>
+    <containedEdges identifier="E34" sources="//@children.6/@children.1/@ports.14" targets="//@children.6/@ports.3"/>
+    <containedEdges identifier="E35" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.1/@ports.6"/>
+    <containedEdges identifier="E36" sources="//@children.6/@children.2/@ports.3" targets="//@children.6/@children.1/@ports.7"/>
+    <containedEdges identifier="E37" sources="//@children.6/@children.2/@ports.10" targets="//@children.6/@ports.4"/>
+    <containedEdges identifier="E38" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.2/@ports.6"/>
+    <containedEdges identifier="E39" sources="//@children.6/@children.4/@ports.0" targets="//@children.6/@children.2/@ports.7"/>
+    <containedEdges identifier="E40" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@children.1/@ports.10"/>
+    <containedEdges identifier="E41" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@children.2/@ports.8"/>
+    <containedEdges identifier="E42" sources="//@children.6/@children.6/@ports.0" targets="//@children.6/@children.1/@ports.11"/>
+    <containedEdges identifier="E43" sources="//@children.6/@children.6/@ports.0" targets="//@children.6/@children.2/@ports.9"/>
+    <containedEdges identifier="E44" sources="//@children.6/@children.7/@ports.0" targets="//@children.6/@children.0/@ports.8"/>
+    <containedEdges identifier="E45" sources="//@children.6/@children.7/@ports.0" targets="//@children.6/@children.1/@ports.8"/>
+    <containedEdges identifier="E46" sources="//@children.6/@children.8/@ports.0" targets="//@children.6/@children.0/@ports.9"/>
+    <containedEdges identifier="E47" sources="//@children.6/@children.8/@ports.0" targets="//@children.6/@children.1/@ports.9"/>
+    <containedEdges identifier="E48" sources="//@children.6/@children.9/@ports.1" targets="//@children.6/@children.15/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.6/@children.10/@ports.1" targets="//@children.6/@children.16/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.6/@children.11/@ports.1" targets="//@children.6/@children.17/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.6/@children.12/@ports.1" targets="//@children.6/@children.18/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.6/@children.13/@ports.1" targets="//@children.6/@children.19/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.6/@children.14/@ports.1" targets="//@children.6/@children.20/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.6/@children.15/@ports.1" targets="//@children.6/@children.2/@ports.6"/>
+    <containedEdges identifier="E55" sources="//@children.6/@children.16/@ports.1" targets="//@children.6/@children.2/@ports.7"/>
+    <containedEdges identifier="E56" sources="//@children.6/@children.17/@ports.1" targets="//@children.6/@children.1/@ports.10"/>
+    <containedEdges identifier="E57" sources="//@children.6/@children.17/@ports.1" targets="//@children.6/@children.2/@ports.8"/>
+    <containedEdges identifier="E58" sources="//@children.6/@children.18/@ports.1" targets="//@children.6/@children.1/@ports.11"/>
+    <containedEdges identifier="E59" sources="//@children.6/@children.18/@ports.1" targets="//@children.6/@children.2/@ports.9"/>
+    <containedEdges identifier="E60" sources="//@children.6/@children.19/@ports.1" targets="//@children.6/@children.0/@ports.8"/>
+    <containedEdges identifier="E61" sources="//@children.6/@children.19/@ports.1" targets="//@children.6/@children.1/@ports.8"/>
+    <containedEdges identifier="E62" sources="//@children.6/@children.20/@ports.1" targets="//@children.6/@children.0/@ports.9"/>
+    <containedEdges identifier="E63" sources="//@children.6/@children.20/@ports.1" targets="//@children.6/@children.1/@ports.9"/>
+    <containedEdges identifier="E64" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E65" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E66" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.2/@ports.1"/>
+    <containedEdges identifier="E67" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.15/@ports.2"/>
+    <containedEdges identifier="E68" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.16/@ports.2"/>
+    <containedEdges identifier="E69" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.17/@ports.2"/>
+    <containedEdges identifier="E70" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.18/@ports.2"/>
+    <containedEdges identifier="E71" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.19/@ports.2"/>
+    <containedEdges identifier="E72" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.20/@ports.2"/>
+    <containedEdges identifier="E73" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.24/@ports.2"/>
+    <containedEdges identifier="E74" sources="//@children.6/@children.21/@ports.1" targets="//@children.6/@children.25/@ports.2"/>
+    <containedEdges identifier="E75" sources="//@children.6/@children.22/@ports.1" targets="//@children.6/@children.24/@ports.0"/>
+    <containedEdges identifier="E76" sources="//@children.6/@children.23/@ports.1" targets="//@children.6/@children.25/@ports.0"/>
+    <containedEdges identifier="E77" sources="//@children.6/@children.24/@ports.1" targets="//@children.6/@children.26/@ports.0"/>
+    <containedEdges identifier="E78" sources="//@children.6/@children.25/@ports.1" targets="//@children.6/@children.27/@ports.0"/>
+    <containedEdges identifier="E79" sources="//@children.6/@children.26/@ports.1" targets="//@children.6/@children.0/@ports.4"/>
+    <containedEdges identifier="E80" sources="//@children.6/@children.26/@ports.1" targets="//@children.6/@children.1/@ports.4"/>
+    <containedEdges identifier="E81" sources="//@children.6/@children.26/@ports.1" targets="//@children.6/@children.2/@ports.4"/>
+    <containedEdges identifier="E82" sources="//@children.6/@children.26/@ports.1" targets="//@children.6/@children.22/@ports.0"/>
+    <containedEdges identifier="E83" sources="//@children.6/@children.27/@ports.1" targets="//@children.6/@children.0/@ports.5"/>
+    <containedEdges identifier="E84" sources="//@children.6/@children.27/@ports.1" targets="//@children.6/@children.1/@ports.5"/>
+    <containedEdges identifier="E85" sources="//@children.6/@children.27/@ports.1" targets="//@children.6/@children.2/@ports.5"/>
+    <containedEdges identifier="E86" sources="//@children.6/@children.27/@ports.1" targets="//@children.6/@children.23/@ports.0"/>
+  </children>
+  <children identifier="N154">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L154" height="15.0" width="55.0" text="robot arm"/>
+    <ports identifier="P531" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.7/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P532" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P533" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P534" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P535" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.3" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N155" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L155" height="15.0" width="57.0" text="Scale3D5"/>
+      <ports identifier="P536" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.11 //@children.7/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P537" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N156">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L156" height="15.0" width="59.0" text="lower limb"/>
+      <ports identifier="P538" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.5" incomingEdges="//@children.7/@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N157" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L157" height="15.0" width="107.0" text="CircularSweep3D0"/>
+        <ports identifier="P539" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P540" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.7/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N158" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L158" height="15.0" width="107.0" text="CircularSweep3D1"/>
+        <ports identifier="P541" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P542" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.7/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N159" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L159" height="15.0" width="46.0" text="Rotate2"/>
+        <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P544" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.7/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P546" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.7/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N160" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L160" height="15.0" width="31.0" text="Box6"/>
+        <ports identifier="P547" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P548" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.7/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N161" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L161" height="15.0" width="77.0" text="Translate3D9"/>
+        <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.7/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P553" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N162" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L162" height="15.0" width="84.0" text="Translate3D14"/>
+        <ports identifier="P554" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P555" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N163" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L163" height="15.0" width="107.0" text="CircularSweep3D6"/>
+        <ports identifier="P556" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N164" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L164" height="15.0" width="107.0" text="CircularSweep3D2"/>
+        <ports identifier="P557" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N165" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L165" height="15.0" width="31.0" text="Box3"/>
+        <ports identifier="P558" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N166" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L166" height="15.0" width="46.0" text="Rotate4"/>
+        <ports identifier="P559" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P560" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N167" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L167" height="15.0" width="77.0" text="Translate3D5"/>
+        <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P562" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N168" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L168" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P563" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P564" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N169" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L169" height="15.0" width="77.0" text="Translate3D7"/>
+        <ports identifier="P565" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.6 //@children.7/@children.1/@containedEdges.10 //@children.7/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P566" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N170" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L170" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P567" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N171" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L171" height="15.0" width="31.0" text="Box1"/>
+        <ports identifier="P568" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N172" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L172" height="15.0" width="31.0" text="Box2"/>
+        <ports identifier="P569" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N173" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L173" height="15.0" width="31.0" text="Box4"/>
+        <ports identifier="P570" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N174" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L174" height="15.0" width="77.0" text="Translate3D8"/>
+        <ports identifier="P571" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P572" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N175" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L175" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P574" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N176" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L176" height="15.0" width="83.0" text="Translate3D11"/>
+        <ports identifier="P575" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P576" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N177" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L177" height="15.0" width="84.0" text="Translate3D12"/>
+        <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P578" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N178" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L178" height="15.0" width="46.0" text="Rotate0"/>
+        <ports identifier="P579" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.0 //@children.7/@children.1/@containedEdges.4 //@children.7/@children.1/@containedEdges.5 //@children.7/@children.1/@containedEdges.12 //@children.7/@children.1/@containedEdges.17 //@children.7/@children.1/@containedEdges.18 //@children.7/@children.1/@containedEdges.19 //@children.7/@children.1/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P580" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N179" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L179" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P581" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.1/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P582" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.1/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E422" sources="//@children.7/@children.1/@children.0/@ports.1" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E423" sources="//@children.7/@children.1/@children.1/@ports.1" targets="//@children.7/@children.1/@children.2/@ports.2"/>
+      <containedEdges identifier="E424" sources="//@children.7/@children.1/@children.2/@ports.3" targets="//@children.7/@children.1/@children.4/@ports.3"/>
+      <containedEdges identifier="E425" sources="//@children.7/@children.1/@children.3/@ports.1" targets="//@children.7/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E426" sources="//@children.7/@children.1/@children.4/@ports.4" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E427" sources="//@children.7/@children.1/@children.5/@ports.1" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E428" sources="//@children.7/@children.1/@children.6/@ports.0" targets="//@children.7/@children.1/@children.12/@ports.0"/>
+      <containedEdges identifier="E429" sources="//@children.7/@children.1/@children.7/@ports.0" targets="//@children.7/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E430" sources="//@children.7/@children.1/@children.8/@ports.0" targets="//@children.7/@children.1/@children.11/@ports.0"/>
+      <containedEdges identifier="E431" sources="//@children.7/@children.1/@children.9/@ports.1" targets="//@children.7/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E432" sources="//@children.7/@children.1/@children.10/@ports.1" targets="//@children.7/@children.1/@children.12/@ports.0"/>
+      <containedEdges identifier="E433" sources="//@children.7/@children.1/@children.11/@ports.1" targets="//@children.7/@children.1/@children.12/@ports.0"/>
+      <containedEdges identifier="E434" sources="//@children.7/@children.1/@children.12/@ports.1" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E435" sources="//@children.7/@children.1/@children.13/@ports.0" targets="//@children.7/@children.1/@children.17/@ports.0"/>
+      <containedEdges identifier="E436" sources="//@children.7/@children.1/@children.14/@ports.0" targets="//@children.7/@children.1/@children.18/@ports.0"/>
+      <containedEdges identifier="E437" sources="//@children.7/@children.1/@children.15/@ports.0" targets="//@children.7/@children.1/@children.19/@ports.0"/>
+      <containedEdges identifier="E438" sources="//@children.7/@children.1/@children.16/@ports.0" targets="//@children.7/@children.1/@children.20/@ports.0"/>
+      <containedEdges identifier="E439" sources="//@children.7/@children.1/@children.17/@ports.1" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E440" sources="//@children.7/@children.1/@children.18/@ports.1" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E441" sources="//@children.7/@children.1/@children.19/@ports.1" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E442" sources="//@children.7/@children.1/@children.20/@ports.1" targets="//@children.7/@children.1/@children.21/@ports.0"/>
+      <containedEdges identifier="E443" sources="//@children.7/@children.1/@children.21/@ports.1" targets="//@children.7/@children.1/@children.22/@ports.0"/>
+      <containedEdges identifier="E444" sources="//@children.7/@children.1/@children.22/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N180" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L180" height="15.0" width="77.0" text="Translate3D0"/>
+      <ports identifier="P583" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P584" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N181" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L181" height="15.0" width="46.0" text="Rotate3"/>
+      <ports identifier="P585" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.7/@containedEdges.6 //@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P586" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P587" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N182">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L182" height="15.0" width="61.0" text="upper limb"/>
+      <ports identifier="P588" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.8" incomingEdges="//@children.7/@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N183" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L183" height="15.0" width="31.0" text="Box1"/>
+        <ports identifier="P589" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N184" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L184" height="15.0" width="57.0" text="Scale3D0"/>
+        <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.0 //@children.7/@children.4/@containedEdges.3 //@children.7/@children.4/@containedEdges.6 //@children.7/@children.4/@containedEdges.7 //@children.7/@children.4/@containedEdges.8 //@children.7/@children.4/@containedEdges.12 //@children.7/@children.4/@containedEdges.13 //@children.7/@children.4/@containedEdges.14 //@children.7/@children.4/@containedEdges.17 //@children.7/@children.4/@containedEdges.18 //@children.7/@children.4/@containedEdges.22 //@children.7/@children.4/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P591" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N185" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L185" height="15.0" width="31.0" text="Box4"/>
+        <ports identifier="P592" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N186" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L186" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P594" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N187" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L187" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P595" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N188" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L188" height="15.0" width="31.0" text="Box2"/>
+        <ports identifier="P596" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N189" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L189" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P597" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P598" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N190" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L190" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P600" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N191" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L191" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P602" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N192" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L192" height="15.0" width="31.0" text="Box3"/>
+        <ports identifier="P603" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N193" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L193" height="15.0" width="31.0" text="Box5"/>
+        <ports identifier="P604" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N194" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L194" height="15.0" width="31.0" text="Box6"/>
+        <ports identifier="P605" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N195" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L195" height="15.0" width="84.0" text="Translate3D12"/>
+        <ports identifier="P606" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P607" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N196" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L196" height="15.0" width="84.0" text="Translate3D15"/>
+        <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P609" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N197" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L197" height="15.0" width="84.0" text="Translate3D22"/>
+        <ports identifier="P610" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P611" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N198" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L198" height="15.0" width="38.0" text="Box23"/>
+        <ports identifier="P612" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N199" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L199" height="15.0" width="31.0" text="Box7"/>
+        <ports identifier="P613" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N200" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L200" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P614" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P615" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N201" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L201" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P616" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P617" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N202" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L202" height="15.0" width="31.0" text="Box8"/>
+        <ports identifier="P618" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N203" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L203" height="15.0" width="31.0" text="Box9"/>
+        <ports identifier="P619" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N204" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L204" height="15.0" width="38.0" text="Box10"/>
+        <ports identifier="P620" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N205" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L205" height="15.0" width="83.0" text="Translate3D11"/>
+        <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.20 //@children.7/@children.4/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P622" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N206" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L206" height="15.0" width="84.0" text="Translate3D13"/>
+        <ports identifier="P623" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P624" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N207" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L207" height="15.0" width="55.0" text="Cylinder0"/>
+        <ports identifier="P625" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N208" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L208" height="15.0" width="77.0" text="Translate3D5"/>
+        <ports identifier="P626" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P627" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N209" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L209" height="15.0" width="53.0" text="Rotate24"/>
+        <ports identifier="P628" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.4/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P629" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.4/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E445" sources="//@children.7/@children.4/@children.0/@ports.0" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E446" sources="//@children.7/@children.4/@children.1/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+      <containedEdges identifier="E447" sources="//@children.7/@children.4/@children.2/@ports.0" targets="//@children.7/@children.4/@children.3/@ports.0"/>
+      <containedEdges identifier="E448" sources="//@children.7/@children.4/@children.3/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E449" sources="//@children.7/@children.4/@children.4/@ports.0" targets="//@children.7/@children.4/@children.6/@ports.0"/>
+      <containedEdges identifier="E450" sources="//@children.7/@children.4/@children.5/@ports.0" targets="//@children.7/@children.4/@children.7/@ports.0"/>
+      <containedEdges identifier="E451" sources="//@children.7/@children.4/@children.6/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E452" sources="//@children.7/@children.4/@children.7/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E453" sources="//@children.7/@children.4/@children.8/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E454" sources="//@children.7/@children.4/@children.9/@ports.0" targets="//@children.7/@children.4/@children.8/@ports.0"/>
+      <containedEdges identifier="E455" sources="//@children.7/@children.4/@children.10/@ports.0" targets="//@children.7/@children.4/@children.12/@ports.0"/>
+      <containedEdges identifier="E456" sources="//@children.7/@children.4/@children.11/@ports.0" targets="//@children.7/@children.4/@children.13/@ports.0"/>
+      <containedEdges identifier="E457" sources="//@children.7/@children.4/@children.12/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E458" sources="//@children.7/@children.4/@children.13/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E459" sources="//@children.7/@children.4/@children.14/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E460" sources="//@children.7/@children.4/@children.15/@ports.0" targets="//@children.7/@children.4/@children.14/@ports.0"/>
+      <containedEdges identifier="E461" sources="//@children.7/@children.4/@children.16/@ports.0" targets="//@children.7/@children.4/@children.17/@ports.0"/>
+      <containedEdges identifier="E462" sources="//@children.7/@children.4/@children.17/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E463" sources="//@children.7/@children.4/@children.18/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E464" sources="//@children.7/@children.4/@children.19/@ports.0" targets="//@children.7/@children.4/@children.18/@ports.0"/>
+      <containedEdges identifier="E465" sources="//@children.7/@children.4/@children.20/@ports.0" targets="//@children.7/@children.4/@children.22/@ports.0"/>
+      <containedEdges identifier="E466" sources="//@children.7/@children.4/@children.21/@ports.0" targets="//@children.7/@children.4/@children.23/@ports.0"/>
+      <containedEdges identifier="E467" sources="//@children.7/@children.4/@children.22/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E468" sources="//@children.7/@children.4/@children.23/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E469" sources="//@children.7/@children.4/@children.24/@ports.0" targets="//@children.7/@children.4/@children.26/@ports.0"/>
+      <containedEdges identifier="E470" sources="//@children.7/@children.4/@children.25/@ports.1" targets="//@children.7/@children.4/@children.22/@ports.0"/>
+      <containedEdges identifier="E471" sources="//@children.7/@children.4/@children.26/@ports.1" targets="//@children.7/@children.4/@children.25/@ports.0"/>
+    </children>
+    <children identifier="N210" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L210" height="15.0" width="77.0" text="Translate3D1"/>
+      <ports identifier="P630" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P631" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N211" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L211" height="15.0" width="46.0" text="Rotate2"/>
+      <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.7/@containedEdges.9 //@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P633" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P634" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N212" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L212" height="15.0" width="46.0" text="Rotate0"/>
+      <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.7/@containedEdges.7 //@children.7/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P636" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P637" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N213" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L213" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P638" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.14 //@children.7/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P639" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N214" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L214" height="15.0" width="46.0" text="Rotate4"/>
+      <ports identifier="P640" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P641" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P642" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N215">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L215" height="15.0" width="27.0" text="wrist"/>
+      <ports identifier="P643" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.14" incomingEdges="//@children.7/@children.10/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N216" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L216" height="15.0" width="107.0" text="CircularSweep3D0"/>
+        <ports identifier="P644" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N217" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L217" height="15.0" width="45.0" text="PolyCyl"/>
+        <ports identifier="P645" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N218" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L218" height="15.0" width="46.0" text="Rotate2"/>
+        <ports identifier="P646" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P647" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N219" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L219" height="15.0" width="46.0" text="Rotate4"/>
+        <ports identifier="P648" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P649" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N220" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L220" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P650" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P651" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N221" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L221" height="15.0" width="46.0" text="Rotate8"/>
+        <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P653" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N222" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L222" height="15.0" width="107.0" text="CircularSweep3D1"/>
+        <ports identifier="P654" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N223" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L223" height="15.0" width="46.0" text="Rotate3"/>
+        <ports identifier="P655" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P656" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N224" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L224" height="15.0" width="57.0" text="Scale3D4"/>
+        <ports identifier="P657" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P658" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N225" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L225" height="15.0" width="103.0" text="PolyCylinder3D11"/>
+        <ports identifier="P659" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N226" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L226" height="15.0" width="53.0" text="Rotate12"/>
+        <ports identifier="P660" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P661" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N227" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L227" height="15.0" width="53.0" text="Rotate13"/>
+        <ports identifier="P662" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P663" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N228" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L228" height="15.0" width="84.0" text="Translate3D14"/>
+        <ports identifier="P664" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P665" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N229" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L229" height="15.0" width="84.0" text="Translate3D15"/>
+        <ports identifier="P666" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.8 //@children.7/@children.10/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P667" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N230" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L230" height="15.0" width="38.0" text="Box28"/>
+        <ports identifier="P668" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N231" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L231" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P669" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N232" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L232" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P670" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P671" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N233" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L233" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P672" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P673" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N234" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L234" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P674" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P675" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N235" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L235" height="15.0" width="46.0" text="Rotate9"/>
+        <ports identifier="P676" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.4 //@children.7/@children.10/@containedEdges.5 //@children.7/@children.10/@containedEdges.13 //@children.7/@children.10/@containedEdges.16 //@children.7/@children.10/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P677" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N236" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L236" height="15.0" width="53.0" text="Rotate10"/>
+        <ports identifier="P678" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P679" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N237" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L237" height="15.0" width="64.0" text="Scale3D15"/>
+        <ports identifier="P680" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.18 //@children.7/@children.10/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P681" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N238" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L238" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+        <ports identifier="P682" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N239" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L239" height="15.0" width="53.0" text="Rotate27"/>
+        <ports identifier="P683" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P684" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N240" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L240" height="15.0" width="46.0" text="Rotate0"/>
+        <ports identifier="P685" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P686" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N241" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L241" height="15.0" width="84.0" text="Translate3D22"/>
+        <ports identifier="P687" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.10/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P688" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.10/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E472" sources="//@children.7/@children.10/@children.0/@ports.0" targets="//@children.7/@children.10/@children.5/@ports.0"/>
+      <containedEdges identifier="E473" sources="//@children.7/@children.10/@children.1/@ports.0" targets="//@children.7/@children.10/@children.2/@ports.0"/>
+      <containedEdges identifier="E474" sources="//@children.7/@children.10/@children.2/@ports.1" targets="//@children.7/@children.10/@children.3/@ports.0"/>
+      <containedEdges identifier="E475" sources="//@children.7/@children.10/@children.3/@ports.1" targets="//@children.7/@children.10/@children.4/@ports.0"/>
+      <containedEdges identifier="E476" sources="//@children.7/@children.10/@children.4/@ports.1" targets="//@children.7/@children.10/@children.19/@ports.0"/>
+      <containedEdges identifier="E477" sources="//@children.7/@children.10/@children.5/@ports.1" targets="//@children.7/@children.10/@children.19/@ports.0"/>
+      <containedEdges identifier="E478" sources="//@children.7/@children.10/@children.6/@ports.0" targets="//@children.7/@children.10/@children.7/@ports.0"/>
+      <containedEdges identifier="E479" sources="//@children.7/@children.10/@children.7/@ports.1" targets="//@children.7/@children.10/@children.8/@ports.0"/>
+      <containedEdges identifier="E480" sources="//@children.7/@children.10/@children.8/@ports.1" targets="//@children.7/@children.10/@children.13/@ports.0"/>
+      <containedEdges identifier="E481" sources="//@children.7/@children.10/@children.9/@ports.0" targets="//@children.7/@children.10/@children.10/@ports.0"/>
+      <containedEdges identifier="E482" sources="//@children.7/@children.10/@children.10/@ports.1" targets="//@children.7/@children.10/@children.11/@ports.0"/>
+      <containedEdges identifier="E483" sources="//@children.7/@children.10/@children.11/@ports.1" targets="//@children.7/@children.10/@children.12/@ports.0"/>
+      <containedEdges identifier="E484" sources="//@children.7/@children.10/@children.12/@ports.1" targets="//@children.7/@children.10/@children.13/@ports.0"/>
+      <containedEdges identifier="E485" sources="//@children.7/@children.10/@children.13/@ports.1" targets="//@children.7/@children.10/@children.19/@ports.0"/>
+      <containedEdges identifier="E486" sources="//@children.7/@children.10/@children.14/@ports.0" targets="//@children.7/@children.10/@children.16/@ports.0"/>
+      <containedEdges identifier="E487" sources="//@children.7/@children.10/@children.15/@ports.0" targets="//@children.7/@children.10/@children.17/@ports.0"/>
+      <containedEdges identifier="E488" sources="//@children.7/@children.10/@children.16/@ports.1" targets="//@children.7/@children.10/@children.19/@ports.0"/>
+      <containedEdges identifier="E489" sources="//@children.7/@children.10/@children.17/@ports.1" targets="//@children.7/@children.10/@children.19/@ports.0"/>
+      <containedEdges identifier="E490" sources="//@children.7/@children.10/@children.18/@ports.1" targets="//@children.7/@children.10/@children.21/@ports.0"/>
+      <containedEdges identifier="E491" sources="//@children.7/@children.10/@children.19/@ports.1" targets="//@children.7/@children.10/@children.20/@ports.0"/>
+      <containedEdges identifier="E492" sources="//@children.7/@children.10/@children.20/@ports.1" targets="//@children.7/@children.10/@children.18/@ports.0"/>
+      <containedEdges identifier="E493" sources="//@children.7/@children.10/@children.21/@ports.1" targets="//@children.7/@children.10/@ports.0"/>
+      <containedEdges identifier="E494" sources="//@children.7/@children.10/@children.22/@ports.0" targets="//@children.7/@children.10/@children.23/@ports.0"/>
+      <containedEdges identifier="E495" sources="//@children.7/@children.10/@children.23/@ports.1" targets="//@children.7/@children.10/@children.24/@ports.0"/>
+      <containedEdges identifier="E496" sources="//@children.7/@children.10/@children.24/@ports.1" targets="//@children.7/@children.10/@children.25/@ports.0"/>
+      <containedEdges identifier="E497" sources="//@children.7/@children.10/@children.25/@ports.1" targets="//@children.7/@children.10/@children.21/@ports.0"/>
+    </children>
+    <children identifier="N242">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L242" height="15.0" width="40.0" text="gripper"/>
+      <ports identifier="P689" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.15" incomingEdges="//@children.7/@children.11/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N243" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L243" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+        <ports identifier="P690" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N244" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L244" height="15.0" width="45.0" text="PolyCyl"/>
+        <ports identifier="P691" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N245" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L245" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P692" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P693" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N246" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L246" height="15.0" width="46.0" text="Rotate1"/>
+        <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.0 //@children.7/@children.11/@containedEdges.8 //@children.7/@children.11/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P695" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N247" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L247" height="15.0" width="46.0" text="Rotate6"/>
+        <ports identifier="P696" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.1 //@children.7/@children.11/@containedEdges.15 //@children.7/@children.11/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P697" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N248" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L248" height="15.0" width="53.0" text="Rotate13"/>
+        <ports identifier="P698" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P699" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N249" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L249" height="15.0" width="31.0" text="Box7"/>
+        <ports identifier="P700" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N250" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L250" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P701" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.6 //@children.7/@children.11/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P702" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N251" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L251" height="15.0" width="46.0" text="Rotate3"/>
+        <ports identifier="P703" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P704" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N252" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L252" height="15.0" width="38.0" text="Box10"/>
+        <ports identifier="P705" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N253" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L253" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P706" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P707" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N254" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L254" height="15.0" width="38.0" text="Box14"/>
+        <ports identifier="P708" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N255" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L255" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P709" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N256" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L256" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P710" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.11 //@children.7/@children.11/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P711" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N257" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L257" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P712" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P713" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N258" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L258" height="15.0" width="46.0" text="Rotate4"/>
+        <ports identifier="P714" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P715" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N259" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L259" height="15.0" width="97.0" text="PolyCylinder3D1"/>
+        <ports identifier="P716" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N260" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L260" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P717" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.16 //@children.7/@children.11/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P718" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N261" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L261" height="15.0" width="46.0" text="Rotate5"/>
+        <ports identifier="P719" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P720" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N262" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L262" height="15.0" width="97.0" text="PolyCylinder3D2"/>
+        <ports identifier="P721" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N263" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L263" height="15.0" width="77.0" text="Translate3D5"/>
+        <ports identifier="P722" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P723" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N264" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L264" height="15.0" width="104.0" text="PolyCylinder3D24"/>
+        <ports identifier="P724" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N265" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L265" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P725" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.21 //@children.7/@children.11/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P726" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N266" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L266" height="15.0" width="46.0" text="Rotate7"/>
+        <ports identifier="P727" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P728" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N267" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L267" height="15.0" width="104.0" text="PolyCylinder3D27"/>
+        <ports identifier="P729" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N268" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L268" height="15.0" width="77.0" text="Translate3D7"/>
+        <ports identifier="P730" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P731" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N269" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L269" height="15.0" width="84.0" text="Translate3D28"/>
+        <ports identifier="P732" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.2 //@children.7/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P733" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N270" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L270" height="15.0" width="53.0" text="Rotate14"/>
+        <ports identifier="P734" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P735" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N271" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L271" height="15.0" width="53.0" text="Rotate30"/>
+        <ports identifier="P736" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.11/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P737" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.11/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E498" sources="//@children.7/@children.11/@children.0/@ports.0" targets="//@children.7/@children.11/@children.3/@ports.0"/>
+      <containedEdges identifier="E499" sources="//@children.7/@children.11/@children.1/@ports.0" targets="//@children.7/@children.11/@children.4/@ports.0"/>
+      <containedEdges identifier="E500" sources="//@children.7/@children.11/@children.2/@ports.1" targets="//@children.7/@children.11/@children.26/@ports.0"/>
+      <containedEdges identifier="E501" sources="//@children.7/@children.11/@children.3/@ports.1" targets="//@children.7/@children.11/@children.26/@ports.0"/>
+      <containedEdges identifier="E502" sources="//@children.7/@children.11/@children.4/@ports.1" targets="//@children.7/@children.11/@children.5/@ports.0"/>
+      <containedEdges identifier="E503" sources="//@children.7/@children.11/@children.5/@ports.1" targets="//@children.7/@children.11/@children.2/@ports.0"/>
+      <containedEdges identifier="E504" sources="//@children.7/@children.11/@children.6/@ports.0" targets="//@children.7/@children.11/@children.7/@ports.0"/>
+      <containedEdges identifier="E505" sources="//@children.7/@children.11/@children.7/@ports.1" targets="//@children.7/@children.11/@children.8/@ports.0"/>
+      <containedEdges identifier="E506" sources="//@children.7/@children.11/@children.8/@ports.1" targets="//@children.7/@children.11/@children.3/@ports.0"/>
+      <containedEdges identifier="E507" sources="//@children.7/@children.11/@children.9/@ports.0" targets="//@children.7/@children.11/@children.10/@ports.0"/>
+      <containedEdges identifier="E508" sources="//@children.7/@children.11/@children.10/@ports.1" targets="//@children.7/@children.11/@children.7/@ports.0"/>
+      <containedEdges identifier="E509" sources="//@children.7/@children.11/@children.11/@ports.0" targets="//@children.7/@children.11/@children.13/@ports.0"/>
+      <containedEdges identifier="E510" sources="//@children.7/@children.11/@children.12/@ports.0" targets="//@children.7/@children.11/@children.14/@ports.0"/>
+      <containedEdges identifier="E511" sources="//@children.7/@children.11/@children.13/@ports.1" targets="//@children.7/@children.11/@children.15/@ports.0"/>
+      <containedEdges identifier="E512" sources="//@children.7/@children.11/@children.14/@ports.1" targets="//@children.7/@children.11/@children.13/@ports.0"/>
+      <containedEdges identifier="E513" sources="//@children.7/@children.11/@children.15/@ports.1" targets="//@children.7/@children.11/@children.4/@ports.0"/>
+      <containedEdges identifier="E514" sources="//@children.7/@children.11/@children.16/@ports.0" targets="//@children.7/@children.11/@children.17/@ports.0"/>
+      <containedEdges identifier="E515" sources="//@children.7/@children.11/@children.17/@ports.1" targets="//@children.7/@children.11/@children.18/@ports.0"/>
+      <containedEdges identifier="E516" sources="//@children.7/@children.11/@children.18/@ports.1" targets="//@children.7/@children.11/@children.3/@ports.0"/>
+      <containedEdges identifier="E517" sources="//@children.7/@children.11/@children.19/@ports.0" targets="//@children.7/@children.11/@children.20/@ports.0"/>
+      <containedEdges identifier="E518" sources="//@children.7/@children.11/@children.20/@ports.1" targets="//@children.7/@children.11/@children.17/@ports.0"/>
+      <containedEdges identifier="E519" sources="//@children.7/@children.11/@children.21/@ports.0" targets="//@children.7/@children.11/@children.22/@ports.0"/>
+      <containedEdges identifier="E520" sources="//@children.7/@children.11/@children.22/@ports.1" targets="//@children.7/@children.11/@children.23/@ports.0"/>
+      <containedEdges identifier="E521" sources="//@children.7/@children.11/@children.23/@ports.1" targets="//@children.7/@children.11/@children.4/@ports.0"/>
+      <containedEdges identifier="E522" sources="//@children.7/@children.11/@children.24/@ports.0" targets="//@children.7/@children.11/@children.25/@ports.0"/>
+      <containedEdges identifier="E523" sources="//@children.7/@children.11/@children.25/@ports.1" targets="//@children.7/@children.11/@children.22/@ports.0"/>
+      <containedEdges identifier="E524" sources="//@children.7/@children.11/@children.26/@ports.1" targets="//@children.7/@children.11/@children.27/@ports.0"/>
+      <containedEdges identifier="E525" sources="//@children.7/@children.11/@children.27/@ports.1" targets="//@children.7/@children.11/@children.28/@ports.0"/>
+      <containedEdges identifier="E526" sources="//@children.7/@children.11/@children.28/@ports.1" targets="//@children.7/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N272" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L272" height="15.0" width="77.0" text="Translate3D3"/>
+      <ports identifier="P738" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P739" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N273">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L273" height="15.0" width="33.0" text="stand"/>
+      <ports identifier="P740" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.17" incomingEdges="//@children.7/@children.13/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N274" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L274" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+        <ports identifier="P741" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N275" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L275" height="15.0" width="97.0" text="PolyCylinder3D4"/>
+        <ports identifier="P742" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N276" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L276" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P743" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P744" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N277" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L277" height="15.0" width="31.0" text="Box5"/>
+        <ports identifier="P745" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N278" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L278" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P746" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P747" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N279" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L279" height="15.0" width="77.0" text="Translate3D8"/>
+        <ports identifier="P748" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.13/@containedEdges.0 //@children.7/@children.13/@containedEdges.2 //@children.7/@children.13/@containedEdges.4 //@children.7/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P749" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N280" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L280" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P750" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N281" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L281" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P751" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P752" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E527" sources="//@children.7/@children.13/@children.0/@ports.0" targets="//@children.7/@children.13/@children.5/@ports.0"/>
+      <containedEdges identifier="E528" sources="//@children.7/@children.13/@children.1/@ports.0" targets="//@children.7/@children.13/@children.2/@ports.0"/>
+      <containedEdges identifier="E529" sources="//@children.7/@children.13/@children.2/@ports.1" targets="//@children.7/@children.13/@children.5/@ports.0"/>
+      <containedEdges identifier="E530" sources="//@children.7/@children.13/@children.3/@ports.0" targets="//@children.7/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E531" sources="//@children.7/@children.13/@children.4/@ports.1" targets="//@children.7/@children.13/@children.5/@ports.0"/>
+      <containedEdges identifier="E532" sources="//@children.7/@children.13/@children.5/@ports.1" targets="//@children.7/@children.13/@ports.0"/>
+      <containedEdges identifier="E533" sources="//@children.7/@children.13/@children.6/@ports.0" targets="//@children.7/@children.13/@children.7/@ports.0"/>
+      <containedEdges identifier="E534" sources="//@children.7/@children.13/@children.7/@ports.1" targets="//@children.7/@children.13/@children.5/@ports.0"/>
+    </children>
+    <children identifier="N282">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L282" height="15.0" width="82.0" text="shoulder base"/>
+      <ports identifier="P753" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.18" incomingEdges="//@children.7/@children.14/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N283" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L283" height="15.0" width="104.0" text="PolyCylinder3D13"/>
+        <ports identifier="P754" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N284" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L284" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P755" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P756" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N285" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L285" height="15.0" width="46.0" text="Rotate0"/>
+        <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P758" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N286" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L286" height="15.0" width="64.0" text="Scale3D10"/>
+        <ports identifier="P759" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P760" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N287" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L287" height="15.0" width="84.0" text="Translate3D12"/>
+        <ports identifier="P761" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P762" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N288" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L288" height="15.0" width="53.0" text="Rotate17"/>
+        <ports identifier="P763" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P764" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N289" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L289" height="15.0" width="57.0" text="Scale3D0"/>
+        <ports identifier="P765" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.5 //@children.7/@children.14/@containedEdges.10 //@children.7/@children.14/@containedEdges.12 //@children.7/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P766" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N290" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L290" height="15.0" width="31.0" text="Box6"/>
+        <ports identifier="P767" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N291" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L291" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P768" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N292" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L292" height="15.0" width="31.0" text="Box1"/>
+        <ports identifier="P769" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N293" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L293" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P770" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.7 //@children.7/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P771" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N294" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L294" height="15.0" width="77.0" text="Translate3D7"/>
+        <ports identifier="P772" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P773" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N295" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L295" height="15.0" width="83.0" text="Translate3D11"/>
+        <ports identifier="P774" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P775" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N296" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L296" height="15.0" width="47.0" text="Box3D0"/>
+        <ports identifier="P776" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N297" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L297" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P777" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P778" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E535" sources="//@children.7/@children.14/@children.0/@ports.0" targets="//@children.7/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E536" sources="//@children.7/@children.14/@children.1/@ports.1" targets="//@children.7/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E537" sources="//@children.7/@children.14/@children.2/@ports.1" targets="//@children.7/@children.14/@children.4/@ports.0"/>
+      <containedEdges identifier="E538" sources="//@children.7/@children.14/@children.3/@ports.1" targets="//@children.7/@children.14/@children.2/@ports.0"/>
+      <containedEdges identifier="E539" sources="//@children.7/@children.14/@children.4/@ports.1" targets="//@children.7/@children.14/@children.5/@ports.0"/>
+      <containedEdges identifier="E540" sources="//@children.7/@children.14/@children.5/@ports.1" targets="//@children.7/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E541" sources="//@children.7/@children.14/@children.6/@ports.1" targets="//@children.7/@children.14/@ports.0"/>
+      <containedEdges identifier="E542" sources="//@children.7/@children.14/@children.7/@ports.0" targets="//@children.7/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E543" sources="//@children.7/@children.14/@children.8/@ports.0" targets="//@children.7/@children.14/@children.11/@ports.0"/>
+      <containedEdges identifier="E544" sources="//@children.7/@children.14/@children.9/@ports.0" targets="//@children.7/@children.14/@children.12/@ports.0"/>
+      <containedEdges identifier="E545" sources="//@children.7/@children.14/@children.10/@ports.1" targets="//@children.7/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E546" sources="//@children.7/@children.14/@children.11/@ports.1" targets="//@children.7/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E547" sources="//@children.7/@children.14/@children.12/@ports.1" targets="//@children.7/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E548" sources="//@children.7/@children.14/@children.13/@ports.0" targets="//@children.7/@children.14/@children.14/@ports.0"/>
+      <containedEdges identifier="E549" sources="//@children.7/@children.14/@children.14/@ports.1" targets="//@children.7/@children.14/@children.6/@ports.0"/>
+    </children>
+    <containedEdges identifier="E403" sources="//@children.7/@ports.1" targets="//@children.7/@children.7/@ports.2"/>
+    <containedEdges identifier="E404" sources="//@children.7/@ports.2" targets="//@children.7/@children.3/@ports.2"/>
+    <containedEdges identifier="E405" sources="//@children.7/@ports.3" targets="//@children.7/@children.6/@ports.2"/>
+    <containedEdges identifier="E406" sources="//@children.7/@ports.4" targets="//@children.7/@children.9/@ports.2"/>
+    <containedEdges identifier="E407" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@ports.0"/>
+    <containedEdges identifier="E408" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E409" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E410" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E411" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E412" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E413" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E414" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E415" sources="//@children.7/@children.8/@ports.1" targets="//@children.7/@children.9/@ports.0"/>
+    <containedEdges identifier="E416" sources="//@children.7/@children.9/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E417" sources="//@children.7/@children.10/@ports.0" targets="//@children.7/@children.8/@ports.0"/>
+    <containedEdges identifier="E418" sources="//@children.7/@children.11/@ports.0" targets="//@children.7/@children.12/@ports.0"/>
+    <containedEdges identifier="E419" sources="//@children.7/@children.12/@ports.1" targets="//@children.7/@children.8/@ports.0"/>
+    <containedEdges identifier="E420" sources="//@children.7/@children.13/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E421" sources="//@children.7/@children.14/@ports.0" targets="//@children.7/@children.7/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.4" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.3" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gr_microwave_microwave.elkg
+++ b/realworld/ptolemy/hierarchical/gr_microwave_microwave.elkg
@@ -1,0 +1,1850 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="92.0" text="Microwave body"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="40.0" text="Box3D"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="70.0" text="Translate3D"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3 //@containedEdges.7 //@containedEdges.13 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="55.0" text="Rotate3D"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="93.0" text="microwave_door"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="84.0" text="Translate3D13"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="64.0" text="Scale3D16"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="64.0" text="close open"/>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.9/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Pulse"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.9/@children.0/@ports.0" targets="//@children.9/@ports.1"/>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="76.0" text="back_texture"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="32.0" text="scale"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="62.0" text="Rotate3D9"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="84.0" text="Translate3D12"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="41.0" text="texture"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="57.0" text="Scale3D2"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="69.0" text="Rotate3D10"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="77.0" text="Translate3D2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L20" height="15.0" width="50.0" text="image3d"/>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@containedEdges.18" incomingEdges="//@children.18/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="8.0" text="1"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="50.0" text="Scale3D"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.0 //@children.18/@containedEdges.5 //@children.18/@containedEdges.8 //@children.18/@containedEdges.15 //@children.18/@containedEdges.16 //@children.18/@containedEdges.17 //@children.18/@containedEdges.18 //@children.18/@containedEdges.19 //@children.18/@containedEdges.20 //@children.18/@containedEdges.37 //@children.18/@containedEdges.38 //@children.18/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="8.0" text="2"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="8.0" text="3"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="77.0" text="Translate3D6"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="8.0" text="6"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="8.0" text="4"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="8.0" text="5"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="77.0" text="Translate3D8"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="77.0" text="Translate3D7"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="77.0" text="Translate3D5"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="84.0" text="Translate3D13"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="84.0" text="Translate3D14"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="84.0" text="Translate3D15"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="8.0" text="7"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="8.0" text="9"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="8.0" text="8"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.18/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.18/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L39" height="15.0" width="125.0" text="7_segment_controller"/>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.0" incomingEdges="//@children.18/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.1" incomingEdges="//@children.18/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.2" incomingEdges="//@children.18/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.3" incomingEdges="//@children.18/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.4" incomingEdges="//@children.18/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.5" incomingEdges="//@children.18/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.6" incomingEdges="//@children.18/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.7" incomingEdges="//@children.18/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.18/@containedEdges.8" incomingEdges="//@children.18/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-8"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.27" incomingEdges="//@children.18/@children.18/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="9"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.28" incomingEdges="//@children.18/@children.18/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="10"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.29" incomingEdges="//@children.18/@children.18/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="11"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.30" incomingEdges="//@children.18/@children.18/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="12"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.31" incomingEdges="//@children.18/@children.18/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="13"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.32" incomingEdges="//@children.18/@children.18/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="14"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.33" incomingEdges="//@children.18/@children.18/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="15"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N40" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P94" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="42.0" text="Const5"/>
+        <ports identifier="P96" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="42.0" text="Const6"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="49.0" text="Const12"/>
+        <ports identifier="P100" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="49.0" text="Const14"/>
+        <ports identifier="P102" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="49.0" text="Const16"/>
+        <ports identifier="P104" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.18/@children.18/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.18/@children.18/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="55.0" text="fsm actor"/>
+        <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@children.18/@children.18/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@children.18/@children.18/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@children.18/@children.18/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.18/@children.18/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P110" height="8.0" width="8.0" x="61.0" y="22.625" outgoingEdges="//@children.18/@children.18/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@children.18/@children.18/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="61.0" y="34.875" outgoingEdges="//@children.18/@children.18/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.18/@children.18/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-7"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.18/@children.18/@containedEdges.9 //@children.18/@children.18/@containedEdges.10 //@children.18/@children.18/@containedEdges.11 //@children.18/@children.18/@containedEdges.12 //@children.18/@children.18/@containedEdges.13 //@children.18/@children.18/@containedEdges.14 //@children.18/@children.18/@containedEdges.15 //@children.18/@children.18/@containedEdges.16 //@children.18/@children.18/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.18/@children.18/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E66" sources="//@children.18/@children.18/@ports.0" targets="//@children.18/@children.18/@children.0/@ports.1"/>
+      <containedEdges identifier="E67" sources="//@children.18/@children.18/@ports.1" targets="//@children.18/@children.18/@children.1/@ports.1"/>
+      <containedEdges identifier="E68" sources="//@children.18/@children.18/@ports.2" targets="//@children.18/@children.18/@children.2/@ports.1"/>
+      <containedEdges identifier="E69" sources="//@children.18/@children.18/@ports.3" targets="//@children.18/@children.18/@children.3/@ports.1"/>
+      <containedEdges identifier="E70" sources="//@children.18/@children.18/@ports.4" targets="//@children.18/@children.18/@children.4/@ports.1"/>
+      <containedEdges identifier="E71" sources="//@children.18/@children.18/@ports.5" targets="//@children.18/@children.18/@children.5/@ports.1"/>
+      <containedEdges identifier="E72" sources="//@children.18/@children.18/@ports.6" targets="//@children.18/@children.18/@children.6/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.18/@children.18/@ports.7" targets="//@children.18/@children.18/@children.7/@ports.1"/>
+      <containedEdges identifier="E74" sources="//@children.18/@children.18/@ports.8" targets="//@children.18/@children.18/@children.8/@ports.1"/>
+      <containedEdges identifier="E75" sources="//@children.18/@children.18/@children.0/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.18/@children.18/@children.1/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E77" sources="//@children.18/@children.18/@children.2/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.18/@children.18/@children.3/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.18/@children.18/@children.4/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.18/@children.18/@children.5/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.18/@children.18/@children.6/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.18/@children.18/@children.7/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.18/@children.18/@children.8/@ports.0" targets="//@children.18/@children.18/@children.10/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.18/@children.18/@children.9/@ports.0" targets="//@children.18/@children.18/@ports.9"/>
+      <containedEdges identifier="E85" sources="//@children.18/@children.18/@children.9/@ports.1" targets="//@children.18/@children.18/@ports.10"/>
+      <containedEdges identifier="E86" sources="//@children.18/@children.18/@children.9/@ports.2" targets="//@children.18/@children.18/@ports.11"/>
+      <containedEdges identifier="E87" sources="//@children.18/@children.18/@children.9/@ports.3" targets="//@children.18/@children.18/@ports.12"/>
+      <containedEdges identifier="E88" sources="//@children.18/@children.18/@children.9/@ports.4" targets="//@children.18/@children.18/@ports.13"/>
+      <containedEdges identifier="E89" sources="//@children.18/@children.18/@children.9/@ports.5" targets="//@children.18/@children.18/@ports.14"/>
+      <containedEdges identifier="E90" sources="//@children.18/@children.18/@children.9/@ports.6" targets="//@children.18/@children.18/@ports.15"/>
+      <containedEdges identifier="E91" sources="//@children.18/@children.18/@children.10/@ports.1" targets="//@children.18/@children.18/@children.9/@ports.7"/>
+    </children>
+    <children identifier="N51">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L51" height="15.0" width="106.0" text="7 segment display"/>
+      <ports identifier="P116" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.19/@containedEdges.0" incomingEdges="//@children.18/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.19/@containedEdges.4" incomingEdges="//@children.18/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.19/@containedEdges.3" incomingEdges="//@children.18/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.19/@containedEdges.5" incomingEdges="//@children.18/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.19/@containedEdges.2" incomingEdges="//@children.18/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.19/@containedEdges.1" incomingEdges="//@children.18/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.19/@containedEdges.6" incomingEdges="//@children.18/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.34" incomingEdges="//@children.18/@children.19/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N52" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="125.0" text="Copy1:Translate3D54"/>
+        <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P125" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="110.0" text="Copy1:Rotate3D31"/>
+        <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P127" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N54" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L54" height="15.0" width="9.0" text="A"/>
+        <ports identifier="P128" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N55" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L55" height="15.0" width="125.0" text="Copy1:Translate3D49"/>
+        <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N56" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L56" height="15.0" width="110.0" text="Copy1:Rotate3D36"/>
+        <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P133" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N57" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="11.0" text="G"/>
+        <ports identifier="P134" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="9.0" text="E"/>
+        <ports identifier="P136" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="125.0" text="Copy1:Translate3D43"/>
+        <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="10.0" text="D"/>
+        <ports identifier="P140" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="125.0" text="Copy1:Translate3D30"/>
+        <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N62" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L62" height="15.0" width="103.0" text="Copy1:Rotate3D2"/>
+        <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P145" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N63" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L63" height="15.0" width="10.0" text="C"/>
+        <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N64" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L64" height="15.0" width="125.0" text="Copy1:Translate3D45"/>
+        <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P149" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N65" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L65" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+        <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P151" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N66" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L66" height="15.0" width="9.0" text="B"/>
+        <ports identifier="P152" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N67" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L67" height="15.0" width="125.0" text="Copy1:Translate3D52"/>
+        <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P155" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N68" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="8.0" text="F"/>
+        <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="125.0" text="Copy1:Translate3D35"/>
+        <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P159" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N70" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L70" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.19/@containedEdges.7 //@children.18/@children.19/@containedEdges.10 //@children.18/@children.19/@containedEdges.14 //@children.18/@children.19/@containedEdges.16 //@children.18/@children.19/@containedEdges.19 //@children.18/@children.19/@containedEdges.22 //@children.18/@children.19/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P161" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.19/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E92" sources="//@children.18/@children.19/@ports.0" targets="//@children.18/@children.19/@children.2/@ports.1"/>
+      <containedEdges identifier="E93" sources="//@children.18/@children.19/@ports.5" targets="//@children.18/@children.19/@children.16/@ports.1"/>
+      <containedEdges identifier="E94" sources="//@children.18/@children.19/@ports.4" targets="//@children.18/@children.19/@children.6/@ports.1"/>
+      <containedEdges identifier="E95" sources="//@children.18/@children.19/@ports.2" targets="//@children.18/@children.19/@children.11/@ports.1"/>
+      <containedEdges identifier="E96" sources="//@children.18/@children.19/@ports.1" targets="//@children.18/@children.19/@children.14/@ports.1"/>
+      <containedEdges identifier="E97" sources="//@children.18/@children.19/@ports.3" targets="//@children.18/@children.19/@children.8/@ports.1"/>
+      <containedEdges identifier="E98" sources="//@children.18/@children.19/@ports.6" targets="//@children.18/@children.19/@children.5/@ports.1"/>
+      <containedEdges identifier="E99" sources="//@children.18/@children.19/@children.0/@ports.1" targets="//@children.18/@children.19/@children.18/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.18/@children.19/@children.1/@ports.1" targets="//@children.18/@children.19/@children.15/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.18/@children.19/@children.2/@ports.0" targets="//@children.18/@children.19/@children.9/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.18/@children.19/@children.3/@ports.1" targets="//@children.18/@children.19/@children.18/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.18/@children.19/@children.4/@ports.1" targets="//@children.18/@children.19/@children.0/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.18/@children.19/@children.5/@ports.0" targets="//@children.18/@children.19/@children.7/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.18/@children.19/@children.6/@ports.0" targets="//@children.18/@children.19/@children.10/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.18/@children.19/@children.7/@ports.1" targets="//@children.18/@children.19/@children.18/@ports.0"/>
+      <containedEdges identifier="E107" sources="//@children.18/@children.19/@children.8/@ports.0" targets="//@children.18/@children.19/@children.17/@ports.0"/>
+      <containedEdges identifier="E108" sources="//@children.18/@children.19/@children.9/@ports.1" targets="//@children.18/@children.19/@children.18/@ports.0"/>
+      <containedEdges identifier="E109" sources="//@children.18/@children.19/@children.10/@ports.1" targets="//@children.18/@children.19/@children.3/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.18/@children.19/@children.11/@ports.0" targets="//@children.18/@children.19/@children.13/@ports.0"/>
+      <containedEdges identifier="E111" sources="//@children.18/@children.19/@children.12/@ports.1" targets="//@children.18/@children.19/@children.18/@ports.0"/>
+      <containedEdges identifier="E112" sources="//@children.18/@children.19/@children.13/@ports.1" targets="//@children.18/@children.19/@children.12/@ports.0"/>
+      <containedEdges identifier="E113" sources="//@children.18/@children.19/@children.14/@ports.0" targets="//@children.18/@children.19/@children.1/@ports.0"/>
+      <containedEdges identifier="E114" sources="//@children.18/@children.19/@children.15/@ports.1" targets="//@children.18/@children.19/@children.18/@ports.0"/>
+      <containedEdges identifier="E115" sources="//@children.18/@children.19/@children.16/@ports.0" targets="//@children.18/@children.19/@children.4/@ports.0"/>
+      <containedEdges identifier="E116" sources="//@children.18/@children.19/@children.17/@ports.1" targets="//@children.18/@children.19/@children.18/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.18/@children.19/@children.18/@ports.1" targets="//@children.18/@children.19/@ports.7"/>
+    </children>
+    <children identifier="N71">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L71" height="15.0" width="147.0" text="Copy1:7 segment display"/>
+      <ports identifier="P162" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.20/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P163" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.20/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P164" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.20/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P165" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.20/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.20/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P167" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.20/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P168" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.20/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P169" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.35" incomingEdges="//@children.18/@children.20/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N72" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="125.0" text="Copy1:Translate3D54"/>
+        <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P171" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N73" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="110.0" text="Copy1:Rotate3D31"/>
+        <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P173" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N74" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L74" height="15.0" width="9.0" text="A"/>
+        <ports identifier="P174" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N75" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L75" height="15.0" width="125.0" text="Copy1:Translate3D49"/>
+        <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P177" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N76" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L76" height="15.0" width="110.0" text="Copy1:Rotate3D36"/>
+        <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P179" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N77" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L77" height="15.0" width="11.0" text="G"/>
+        <ports identifier="P180" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N78" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L78" height="15.0" width="9.0" text="E"/>
+        <ports identifier="P182" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N79" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="125.0" text="Copy1:Translate3D43"/>
+        <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P185" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="10.0" text="D"/>
+        <ports identifier="P186" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="125.0" text="Copy1:Translate3D30"/>
+        <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P189" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="103.0" text="Copy1:Rotate3D2"/>
+        <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P191" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="10.0" text="C"/>
+        <ports identifier="P192" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="125.0" text="Copy1:Translate3D45"/>
+        <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P195" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N85" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L85" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+        <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P197" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N86" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L86" height="15.0" width="9.0" text="B"/>
+        <ports identifier="P198" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N87" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L87" height="15.0" width="125.0" text="Copy1:Translate3D52"/>
+        <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P201" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N88" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L88" height="15.0" width="8.0" text="F"/>
+        <ports identifier="P202" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N89" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L89" height="15.0" width="125.0" text="Copy1:Translate3D35"/>
+        <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P205" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N90" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L90" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.20/@containedEdges.7 //@children.18/@children.20/@containedEdges.10 //@children.18/@children.20/@containedEdges.14 //@children.18/@children.20/@containedEdges.16 //@children.18/@children.20/@containedEdges.19 //@children.18/@children.20/@containedEdges.22 //@children.18/@children.20/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P207" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.20/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E118" sources="//@children.18/@children.20/@ports.0" targets="//@children.18/@children.20/@children.2/@ports.1"/>
+      <containedEdges identifier="E119" sources="//@children.18/@children.20/@ports.5" targets="//@children.18/@children.20/@children.16/@ports.1"/>
+      <containedEdges identifier="E120" sources="//@children.18/@children.20/@ports.4" targets="//@children.18/@children.20/@children.6/@ports.1"/>
+      <containedEdges identifier="E121" sources="//@children.18/@children.20/@ports.2" targets="//@children.18/@children.20/@children.11/@ports.1"/>
+      <containedEdges identifier="E122" sources="//@children.18/@children.20/@ports.1" targets="//@children.18/@children.20/@children.14/@ports.1"/>
+      <containedEdges identifier="E123" sources="//@children.18/@children.20/@ports.3" targets="//@children.18/@children.20/@children.8/@ports.1"/>
+      <containedEdges identifier="E124" sources="//@children.18/@children.20/@ports.6" targets="//@children.18/@children.20/@children.5/@ports.1"/>
+      <containedEdges identifier="E125" sources="//@children.18/@children.20/@children.0/@ports.1" targets="//@children.18/@children.20/@children.18/@ports.0"/>
+      <containedEdges identifier="E126" sources="//@children.18/@children.20/@children.1/@ports.1" targets="//@children.18/@children.20/@children.15/@ports.0"/>
+      <containedEdges identifier="E127" sources="//@children.18/@children.20/@children.2/@ports.0" targets="//@children.18/@children.20/@children.9/@ports.0"/>
+      <containedEdges identifier="E128" sources="//@children.18/@children.20/@children.3/@ports.1" targets="//@children.18/@children.20/@children.18/@ports.0"/>
+      <containedEdges identifier="E129" sources="//@children.18/@children.20/@children.4/@ports.1" targets="//@children.18/@children.20/@children.0/@ports.0"/>
+      <containedEdges identifier="E130" sources="//@children.18/@children.20/@children.5/@ports.0" targets="//@children.18/@children.20/@children.7/@ports.0"/>
+      <containedEdges identifier="E131" sources="//@children.18/@children.20/@children.6/@ports.0" targets="//@children.18/@children.20/@children.10/@ports.0"/>
+      <containedEdges identifier="E132" sources="//@children.18/@children.20/@children.7/@ports.1" targets="//@children.18/@children.20/@children.18/@ports.0"/>
+      <containedEdges identifier="E133" sources="//@children.18/@children.20/@children.8/@ports.0" targets="//@children.18/@children.20/@children.17/@ports.0"/>
+      <containedEdges identifier="E134" sources="//@children.18/@children.20/@children.9/@ports.1" targets="//@children.18/@children.20/@children.18/@ports.0"/>
+      <containedEdges identifier="E135" sources="//@children.18/@children.20/@children.10/@ports.1" targets="//@children.18/@children.20/@children.3/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.18/@children.20/@children.11/@ports.0" targets="//@children.18/@children.20/@children.13/@ports.0"/>
+      <containedEdges identifier="E137" sources="//@children.18/@children.20/@children.12/@ports.1" targets="//@children.18/@children.20/@children.18/@ports.0"/>
+      <containedEdges identifier="E138" sources="//@children.18/@children.20/@children.13/@ports.1" targets="//@children.18/@children.20/@children.12/@ports.0"/>
+      <containedEdges identifier="E139" sources="//@children.18/@children.20/@children.14/@ports.0" targets="//@children.18/@children.20/@children.1/@ports.0"/>
+      <containedEdges identifier="E140" sources="//@children.18/@children.20/@children.15/@ports.1" targets="//@children.18/@children.20/@children.18/@ports.0"/>
+      <containedEdges identifier="E141" sources="//@children.18/@children.20/@children.16/@ports.0" targets="//@children.18/@children.20/@children.4/@ports.0"/>
+      <containedEdges identifier="E142" sources="//@children.18/@children.20/@children.17/@ports.1" targets="//@children.18/@children.20/@children.18/@ports.0"/>
+      <containedEdges identifier="E143" sources="//@children.18/@children.20/@children.18/@ports.1" targets="//@children.18/@children.20/@ports.7"/>
+    </children>
+    <children identifier="N91">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L91" height="15.0" width="147.0" text="Copy2:7 segment display"/>
+      <ports identifier="P208" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.21/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P209" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.21/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P210" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.21/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P211" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.21/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P212" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.21/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P213" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.21/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P214" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.21/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P215" height="8.0" width="8.0" outgoingEdges="//@children.18/@containedEdges.36" incomingEdges="//@children.18/@children.21/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N92" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L92" height="15.0" width="125.0" text="Copy1:Translate3D54"/>
+        <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P217" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N93" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L93" height="15.0" width="110.0" text="Copy1:Rotate3D31"/>
+        <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P219" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N94" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L94" height="15.0" width="9.0" text="A"/>
+        <ports identifier="P220" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N95" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L95" height="15.0" width="125.0" text="Copy1:Translate3D49"/>
+        <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P223" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N96" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L96" height="15.0" width="110.0" text="Copy1:Rotate3D36"/>
+        <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P225" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N97" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L97" height="15.0" width="11.0" text="G"/>
+        <ports identifier="P226" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N98" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L98" height="15.0" width="9.0" text="E"/>
+        <ports identifier="P228" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N99" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="125.0" text="Copy1:Translate3D43"/>
+        <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P231" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N100" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L100" height="15.0" width="10.0" text="D"/>
+        <ports identifier="P232" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N101" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L101" height="15.0" width="125.0" text="Copy1:Translate3D30"/>
+        <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P235" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N102" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L102" height="15.0" width="103.0" text="Copy1:Rotate3D2"/>
+        <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P237" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N103" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L103" height="15.0" width="10.0" text="C"/>
+        <ports identifier="P238" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N104" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L104" height="15.0" width="125.0" text="Copy1:Translate3D45"/>
+        <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P241" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N105" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L105" height="15.0" width="96.0" text="Copy1:Rotate3D"/>
+        <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P243" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N106" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L106" height="15.0" width="9.0" text="B"/>
+        <ports identifier="P244" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N107" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="125.0" text="Copy1:Translate3D52"/>
+        <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P247" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="8.0" text="F"/>
+        <ports identifier="P248" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N109" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L109" height="15.0" width="125.0" text="Copy1:Translate3D35"/>
+        <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P251" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N110" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L110" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@children.21/@containedEdges.7 //@children.18/@children.21/@containedEdges.10 //@children.18/@children.21/@containedEdges.14 //@children.18/@children.21/@containedEdges.16 //@children.18/@children.21/@containedEdges.19 //@children.18/@children.21/@containedEdges.22 //@children.18/@children.21/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P253" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@children.21/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E144" sources="//@children.18/@children.21/@ports.0" targets="//@children.18/@children.21/@children.2/@ports.1"/>
+      <containedEdges identifier="E145" sources="//@children.18/@children.21/@ports.5" targets="//@children.18/@children.21/@children.16/@ports.1"/>
+      <containedEdges identifier="E146" sources="//@children.18/@children.21/@ports.4" targets="//@children.18/@children.21/@children.6/@ports.1"/>
+      <containedEdges identifier="E147" sources="//@children.18/@children.21/@ports.2" targets="//@children.18/@children.21/@children.11/@ports.1"/>
+      <containedEdges identifier="E148" sources="//@children.18/@children.21/@ports.1" targets="//@children.18/@children.21/@children.14/@ports.1"/>
+      <containedEdges identifier="E149" sources="//@children.18/@children.21/@ports.3" targets="//@children.18/@children.21/@children.8/@ports.1"/>
+      <containedEdges identifier="E150" sources="//@children.18/@children.21/@ports.6" targets="//@children.18/@children.21/@children.5/@ports.1"/>
+      <containedEdges identifier="E151" sources="//@children.18/@children.21/@children.0/@ports.1" targets="//@children.18/@children.21/@children.18/@ports.0"/>
+      <containedEdges identifier="E152" sources="//@children.18/@children.21/@children.1/@ports.1" targets="//@children.18/@children.21/@children.15/@ports.0"/>
+      <containedEdges identifier="E153" sources="//@children.18/@children.21/@children.2/@ports.0" targets="//@children.18/@children.21/@children.9/@ports.0"/>
+      <containedEdges identifier="E154" sources="//@children.18/@children.21/@children.3/@ports.1" targets="//@children.18/@children.21/@children.18/@ports.0"/>
+      <containedEdges identifier="E155" sources="//@children.18/@children.21/@children.4/@ports.1" targets="//@children.18/@children.21/@children.0/@ports.0"/>
+      <containedEdges identifier="E156" sources="//@children.18/@children.21/@children.5/@ports.0" targets="//@children.18/@children.21/@children.7/@ports.0"/>
+      <containedEdges identifier="E157" sources="//@children.18/@children.21/@children.6/@ports.0" targets="//@children.18/@children.21/@children.10/@ports.0"/>
+      <containedEdges identifier="E158" sources="//@children.18/@children.21/@children.7/@ports.1" targets="//@children.18/@children.21/@children.18/@ports.0"/>
+      <containedEdges identifier="E159" sources="//@children.18/@children.21/@children.8/@ports.0" targets="//@children.18/@children.21/@children.17/@ports.0"/>
+      <containedEdges identifier="E160" sources="//@children.18/@children.21/@children.9/@ports.1" targets="//@children.18/@children.21/@children.18/@ports.0"/>
+      <containedEdges identifier="E161" sources="//@children.18/@children.21/@children.10/@ports.1" targets="//@children.18/@children.21/@children.3/@ports.0"/>
+      <containedEdges identifier="E162" sources="//@children.18/@children.21/@children.11/@ports.0" targets="//@children.18/@children.21/@children.13/@ports.0"/>
+      <containedEdges identifier="E163" sources="//@children.18/@children.21/@children.12/@ports.1" targets="//@children.18/@children.21/@children.18/@ports.0"/>
+      <containedEdges identifier="E164" sources="//@children.18/@children.21/@children.13/@ports.1" targets="//@children.18/@children.21/@children.12/@ports.0"/>
+      <containedEdges identifier="E165" sources="//@children.18/@children.21/@children.14/@ports.0" targets="//@children.18/@children.21/@children.1/@ports.0"/>
+      <containedEdges identifier="E166" sources="//@children.18/@children.21/@children.15/@ports.1" targets="//@children.18/@children.21/@children.18/@ports.0"/>
+      <containedEdges identifier="E167" sources="//@children.18/@children.21/@children.16/@ports.0" targets="//@children.18/@children.21/@children.4/@ports.0"/>
+      <containedEdges identifier="E168" sources="//@children.18/@children.21/@children.17/@ports.1" targets="//@children.18/@children.21/@children.18/@ports.0"/>
+      <containedEdges identifier="E169" sources="//@children.18/@children.21/@children.18/@ports.1" targets="//@children.18/@children.21/@ports.7"/>
+    </children>
+    <children identifier="N111" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L111" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P255" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N112" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L112" height="15.0" width="77.0" text="Translate3D3"/>
+      <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P257" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N113" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L113" height="15.0" width="77.0" text="Translate3D4"/>
+      <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P259" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N114" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L114" height="15.0" width="57.0" text="Scale3D2"/>
+      <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P261" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N115" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L115" height="15.0" width="64.0" text="Scale3D37"/>
+      <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P263" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N116" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L116" height="15.0" width="64.0" text="Scale3D42"/>
+      <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.18/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P265" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.18/@children.0/@ports.0" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.18/@children.0/@ports.1" targets="//@children.18/@children.18/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.18/@children.1/@ports.1" targets="//@children.18/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.18/@children.2/@ports.0" targets="//@children.18/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.18/@children.2/@ports.1" targets="//@children.18/@children.18/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.18/@children.3/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.18/@children.4/@ports.0" targets="//@children.18/@children.5/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.18/@children.4/@ports.1" targets="//@children.18/@children.18/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.18/@children.5/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.18/@children.6/@ports.1" targets="//@children.18/@children.18/@ports.5"/>
+    <containedEdges identifier="E33" sources="//@children.18/@children.6/@ports.0" targets="//@children.18/@children.11/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.18/@children.7/@ports.0" targets="//@children.18/@children.9/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.18/@children.7/@ports.1" targets="//@children.18/@children.18/@ports.3"/>
+    <containedEdges identifier="E36" sources="//@children.18/@children.8/@ports.0" targets="//@children.18/@children.10/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.18/@children.8/@ports.1" targets="//@children.18/@children.18/@ports.4"/>
+    <containedEdges identifier="E38" sources="//@children.18/@children.9/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.18/@children.10/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.18/@children.11/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.18/@children.12/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.18/@children.13/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.18/@children.14/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.18/@children.15/@ports.0" targets="//@children.18/@children.12/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.18/@children.15/@ports.1" targets="//@children.18/@children.18/@ports.6"/>
+    <containedEdges identifier="E46" sources="//@children.18/@children.16/@ports.0" targets="//@children.18/@children.14/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.18/@children.16/@ports.1" targets="//@children.18/@children.18/@ports.8"/>
+    <containedEdges identifier="E48" sources="//@children.18/@children.17/@ports.0" targets="//@children.18/@children.13/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.18/@children.17/@ports.1" targets="//@children.18/@children.18/@ports.7"/>
+    <containedEdges identifier="E50" sources="//@children.18/@children.18/@ports.9" targets="//@children.18/@children.19/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.18/@children.18/@ports.10" targets="//@children.18/@children.19/@ports.1"/>
+    <containedEdges identifier="E52" sources="//@children.18/@children.18/@ports.11" targets="//@children.18/@children.19/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.18/@children.18/@ports.12" targets="//@children.18/@children.19/@ports.3"/>
+    <containedEdges identifier="E54" sources="//@children.18/@children.18/@ports.13" targets="//@children.18/@children.19/@ports.4"/>
+    <containedEdges identifier="E55" sources="//@children.18/@children.18/@ports.14" targets="//@children.18/@children.19/@ports.5"/>
+    <containedEdges identifier="E56" sources="//@children.18/@children.18/@ports.15" targets="//@children.18/@children.19/@ports.6"/>
+    <containedEdges identifier="E57" sources="//@children.18/@children.19/@ports.7" targets="//@children.18/@children.25/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.18/@children.20/@ports.7" targets="//@children.18/@children.26/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.18/@children.21/@ports.7" targets="//@children.18/@children.27/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.18/@children.22/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.18/@children.23/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.18/@children.24/@ports.1" targets="//@children.18/@children.1/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.18/@children.25/@ports.1" targets="//@children.18/@children.24/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.18/@children.26/@ports.1" targets="//@children.18/@children.22/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.18/@children.27/@ports.1" targets="//@children.18/@children.23/@ports.0"/>
+  </children>
+  <children identifier="N117" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L117" height="15.0" width="84.0" text="Translate3D20"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.13/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.15/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.16/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.17/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.18/@ports.0" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.19/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gr_pendulum_Pendulum.elkg
+++ b/realworld/ptolemy/hierarchical/gr_pendulum_Pendulum.elkg
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="Sphere"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="54.0" text="Translate"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="70.0" text="ViewScreen"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3 //@containedEdges.6 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="48.0" text="Cylinder"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="39.0" text="Rotate"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="24.0" text="Text"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="50.0" text="Scale3D"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="61.0" text="Translate2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="138.0" text="damped pendulum ODE"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.8/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="114.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="114.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="100.0" text="Periodic Sampler"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.2 //@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.4 //@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.2/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.8/@children.2/@ports.2" targets="//@children.8/@children.0/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.8/@children.2/@ports.2" targets="//@children.8/@children.3/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.8/@children.3/@ports.2" targets="//@children.8/@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.8/@children.3/@ports.2" targets="//@children.8/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="35.0" text="Stage"/>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.9/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="72.0" text="0:Translate0"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="78.0" text="0:Translate11"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="49.0" text="0:Box14"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="72.0" text="0:Translate6"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="49.0" text="0:Box15"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="49.0" text="0:Box12"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="49.0" text="0:Box13"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="72.0" text="0:Translate1"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="57.0" text="Scale3D0"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.1 //@children.9/@containedEdges.3 //@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.8/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.8/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.9/@children.2/@ports.0" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.9/@children.3/@ports.1" targets="//@children.9/@children.8/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.9/@children.4/@ports.0" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.9/@children.5/@ports.0" targets="//@children.9/@children.7/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.9/@children.6/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.9/@children.7/@ports.1" targets="//@children.9/@children.8/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.9/@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gr_pong_Pong.elkg
+++ b/realworld/ptolemy/hierarchical/gr_pong_Pong.elkg
@@ -1,0 +1,634 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Animation"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.6" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="22.0" text="Ball"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="41.0" text="Paddle"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="84.0" text="Translate3D10"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="253.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="75.0" text="Copy1:Const"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="253.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="254.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="254.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="245.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="245.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="245.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="245.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="51.0" text="Left Wall"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="70.0" text="ViewScreen"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.10 //@children.0/@containedEdges.19 //@children.0/@containedEdges.21 //@children.0/@containedEdges.23 //@children.0/@containedEdges.24 //@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="60.0" text="Right Wall"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="77.0" text="Translate3D3"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="50.0" text="Top Wall"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="77.0" text="Translate3D4"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="68.0" text="Intersection"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="66.0" text="Game Over"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="77.0" text="Translate3D5"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="28.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.0/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.1" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@ports.2" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@ports.2" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@ports.3" targets="//@children.0/@children.22/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.3"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.1/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.16/@ports.0" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.17/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.18/@ports.0" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.19/@ports.0" targets="//@children.0/@children.20/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.20/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.21/@ports.0" targets="//@children.0/@children.22/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.22/@ports.3" targets="//@children.0/@children.20/@ports.2"/>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="69.0" text="Key Sensor"/>
+    <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="98.0" text="ArrowKeySensor"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="1.7999999523162842">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E39" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@ports.1"/>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="69.0" text="Pong Model"/>
+    <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.2/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="74.0" text="Game Model"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="10.375">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="22.625">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="28.75">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="34.875">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="92.0" text="Paddle Position"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="41.0" text="Scale3"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="103.0" text="PeriodicSampler2"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E41" sources="//@children.2/@ports.1" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.2/@children.0/@ports.3" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@ports.4"/>
+    <containedEdges identifier="E49" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.0/@ports.6"/>
+  </children>
+  <children identifier="N36" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="183.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="183.0" y="8.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.4" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gr_robotarm_RobotArm.elkg
+++ b/realworld/ptolemy/hierarchical/gr_robotarm_RobotArm.elkg
@@ -1,0 +1,2036 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="ViewScreen2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="87.0" text="Keyboard Input"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="117.0" text="InstanceOfrobot arm"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.2/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.3" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="57.0" text="Scale3D5"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.9 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="77.0" text="Translate3D0"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="46.0" text="Rotate3"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="77.0" text="Translate3D1"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="46.0" text="Rotate2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="46.0" text="Rotate0"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.6 //@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.12 //@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="46.0" text="Rotate4"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="77.0" text="Translate3D3"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="95.0" text="InstanceOfstand"/>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.13" incomingEdges="//@children.2/@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="97.0" text="PolyCylinder3D4"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="31.0" text="Box5"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="77.0" text="Translate3D8"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.9/@containedEdges.0 //@children.2/@children.9/@containedEdges.2 //@children.2/@children.9/@containedEdges.4 //@children.2/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E26" sources="//@children.2/@children.9/@children.0/@ports.0" targets="//@children.2/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E27" sources="//@children.2/@children.9/@children.1/@ports.0" targets="//@children.2/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.2/@children.9/@children.2/@ports.1" targets="//@children.2/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.2/@children.9/@children.3/@ports.0" targets="//@children.2/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.2/@children.9/@children.4/@ports.1" targets="//@children.2/@children.9/@children.5/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.2/@children.9/@children.5/@ports.1" targets="//@children.2/@children.9/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.2/@children.9/@children.6/@ports.0" targets="//@children.2/@children.9/@children.7/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.2/@children.9/@children.7/@ports.1" targets="//@children.2/@children.9/@children.5/@ports.0"/>
+    </children>
+    <children identifier="N22">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L22" height="15.0" width="144.0" text="InstanceOfshoulder base"/>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.14" incomingEdges="//@children.2/@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N23" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="104.0" text="PolyCylinder3D13"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="46.0" text="Rotate0"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="64.0" text="Scale3D10"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="84.0" text="Translate3D12"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="53.0" text="Rotate17"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="57.0" text="Scale3D0"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.5 //@children.2/@children.10/@containedEdges.10 //@children.2/@children.10/@containedEdges.12 //@children.2/@children.10/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="31.0" text="Box6"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="31.0" text="Box1"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.7 //@children.2/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="77.0" text="Translate3D7"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="83.0" text="Translate3D11"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="47.0" text="Box3D0"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.10/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.10/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.2/@children.10/@children.0/@ports.0" targets="//@children.2/@children.10/@children.1/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.2/@children.10/@children.1/@ports.1" targets="//@children.2/@children.10/@children.3/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.2/@children.10/@children.2/@ports.1" targets="//@children.2/@children.10/@children.4/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.2/@children.10/@children.3/@ports.1" targets="//@children.2/@children.10/@children.2/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.2/@children.10/@children.4/@ports.1" targets="//@children.2/@children.10/@children.5/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.2/@children.10/@children.5/@ports.1" targets="//@children.2/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.2/@children.10/@children.6/@ports.1" targets="//@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.2/@children.10/@children.7/@ports.0" targets="//@children.2/@children.10/@children.10/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.2/@children.10/@children.8/@ports.0" targets="//@children.2/@children.10/@children.11/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.2/@children.10/@children.9/@ports.0" targets="//@children.2/@children.10/@children.12/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.2/@children.10/@children.10/@ports.1" targets="//@children.2/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.2/@children.10/@children.11/@ports.1" targets="//@children.2/@children.10/@children.10/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.2/@children.10/@children.12/@ports.1" targets="//@children.2/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.2/@children.10/@children.13/@ports.0" targets="//@children.2/@children.10/@children.14/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.2/@children.10/@children.14/@ports.1" targets="//@children.2/@children.10/@children.6/@ports.0"/>
+    </children>
+    <children identifier="N38">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L38" height="15.0" width="121.0" text="InstanceOflower limb"/>
+      <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.15" incomingEdges="//@children.2/@children.11/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N39" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="107.0" text="CircularSweep3D0"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.2/@children.11/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="107.0" text="CircularSweep3D1"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.2/@children.11/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="46.0" text="Rotate2"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@children.11/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.2/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="31.0" text="Box6"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="60.0" y="8.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.2/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="77.0" text="Translate3D9"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.2/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="84.0" text="Translate3D14"/>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="107.0" text="CircularSweep3D6"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="107.0" text="CircularSweep3D2"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="31.0" text="Box3"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="46.0" text="Rotate4"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="77.0" text="Translate3D5"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="77.0" text="Translate3D7"/>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.6 //@children.2/@children.11/@containedEdges.10 //@children.2/@children.11/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="31.0" text="Box1"/>
+        <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N54" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L54" height="15.0" width="31.0" text="Box2"/>
+        <ports identifier="P100" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N55" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L55" height="15.0" width="31.0" text="Box4"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N56" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L56" height="15.0" width="77.0" text="Translate3D8"/>
+        <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N57" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="83.0" text="Translate3D11"/>
+        <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P107" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="84.0" text="Translate3D12"/>
+        <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="46.0" text="Rotate0"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.0 //@children.2/@children.11/@containedEdges.4 //@children.2/@children.11/@containedEdges.5 //@children.2/@children.11/@containedEdges.12 //@children.2/@children.11/@containedEdges.17 //@children.2/@children.11/@containedEdges.18 //@children.2/@children.11/@containedEdges.19 //@children.2/@children.11/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.11/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.11/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E49" sources="//@children.2/@children.11/@children.0/@ports.1" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.2/@children.11/@children.1/@ports.1" targets="//@children.2/@children.11/@children.2/@ports.2"/>
+      <containedEdges identifier="E51" sources="//@children.2/@children.11/@children.2/@ports.3" targets="//@children.2/@children.11/@children.4/@ports.3"/>
+      <containedEdges identifier="E52" sources="//@children.2/@children.11/@children.3/@ports.1" targets="//@children.2/@children.11/@children.5/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.2/@children.11/@children.4/@ports.4" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.2/@children.11/@children.5/@ports.1" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.2/@children.11/@children.6/@ports.0" targets="//@children.2/@children.11/@children.12/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.2/@children.11/@children.7/@ports.0" targets="//@children.2/@children.11/@children.9/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.2/@children.11/@children.8/@ports.0" targets="//@children.2/@children.11/@children.11/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.2/@children.11/@children.9/@ports.1" targets="//@children.2/@children.11/@children.10/@ports.0"/>
+      <containedEdges identifier="E59" sources="//@children.2/@children.11/@children.10/@ports.1" targets="//@children.2/@children.11/@children.12/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.2/@children.11/@children.11/@ports.1" targets="//@children.2/@children.11/@children.12/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.2/@children.11/@children.12/@ports.1" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.2/@children.11/@children.13/@ports.0" targets="//@children.2/@children.11/@children.17/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.2/@children.11/@children.14/@ports.0" targets="//@children.2/@children.11/@children.18/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.2/@children.11/@children.15/@ports.0" targets="//@children.2/@children.11/@children.19/@ports.0"/>
+      <containedEdges identifier="E65" sources="//@children.2/@children.11/@children.16/@ports.0" targets="//@children.2/@children.11/@children.20/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.2/@children.11/@children.17/@ports.1" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.2/@children.11/@children.18/@ports.1" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.2/@children.11/@children.19/@ports.1" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E69" sources="//@children.2/@children.11/@children.20/@ports.1" targets="//@children.2/@children.11/@children.21/@ports.0"/>
+      <containedEdges identifier="E70" sources="//@children.2/@children.11/@children.21/@ports.1" targets="//@children.2/@children.11/@children.22/@ports.0"/>
+      <containedEdges identifier="E71" sources="//@children.2/@children.11/@children.22/@ports.1" targets="//@children.2/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N62">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L62" height="15.0" width="123.0" text="InstanceOfupper limb"/>
+      <ports identifier="P114" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.16" incomingEdges="//@children.2/@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N63" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L63" height="15.0" width="31.0" text="Box1"/>
+        <ports identifier="P115" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N64" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L64" height="15.0" width="57.0" text="Scale3D0"/>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.0 //@children.2/@children.12/@containedEdges.3 //@children.2/@children.12/@containedEdges.6 //@children.2/@children.12/@containedEdges.7 //@children.2/@children.12/@containedEdges.8 //@children.2/@children.12/@containedEdges.12 //@children.2/@children.12/@containedEdges.13 //@children.2/@children.12/@containedEdges.14 //@children.2/@children.12/@containedEdges.17 //@children.2/@children.12/@containedEdges.18 //@children.2/@children.12/@containedEdges.22 //@children.2/@children.12/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N65" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L65" height="15.0" width="31.0" text="Box4"/>
+        <ports identifier="P118" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N66" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L66" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P120" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N67" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L67" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N68" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="31.0" text="Box2"/>
+        <ports identifier="P122" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N70" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L70" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P126" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N71" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L71" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N72" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="31.0" text="Box3"/>
+        <ports identifier="P129" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N73" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="31.0" text="Box5"/>
+        <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N74" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L74" height="15.0" width="31.0" text="Box6"/>
+        <ports identifier="P131" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N75" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L75" height="15.0" width="84.0" text="Translate3D12"/>
+        <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P133" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N76" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L76" height="15.0" width="84.0" text="Translate3D15"/>
+        <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P135" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N77" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L77" height="15.0" width="84.0" text="Translate3D22"/>
+        <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N78" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L78" height="15.0" width="38.0" text="Box23"/>
+        <ports identifier="P138" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N79" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="31.0" text="Box7"/>
+        <ports identifier="P139" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="31.0" text="Box8"/>
+        <ports identifier="P144" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="31.0" text="Box9"/>
+        <ports identifier="P145" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="38.0" text="Box10"/>
+        <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N85" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L85" height="15.0" width="83.0" text="Translate3D11"/>
+        <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.20 //@children.2/@children.12/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N86" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L86" height="15.0" width="84.0" text="Translate3D13"/>
+        <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P150" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N87" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L87" height="15.0" width="55.0" text="Cylinder0"/>
+        <ports identifier="P151" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N88" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L88" height="15.0" width="77.0" text="Translate3D5"/>
+        <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P153" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N89" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L89" height="15.0" width="53.0" text="Rotate24"/>
+        <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.12/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P155" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.12/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E72" sources="//@children.2/@children.12/@children.0/@ports.0" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E73" sources="//@children.2/@children.12/@children.1/@ports.1" targets="//@children.2/@children.12/@ports.0"/>
+      <containedEdges identifier="E74" sources="//@children.2/@children.12/@children.2/@ports.0" targets="//@children.2/@children.12/@children.3/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.2/@children.12/@children.3/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.2/@children.12/@children.4/@ports.0" targets="//@children.2/@children.12/@children.6/@ports.0"/>
+      <containedEdges identifier="E77" sources="//@children.2/@children.12/@children.5/@ports.0" targets="//@children.2/@children.12/@children.7/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.2/@children.12/@children.6/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.2/@children.12/@children.7/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.2/@children.12/@children.8/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.2/@children.12/@children.9/@ports.0" targets="//@children.2/@children.12/@children.8/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.2/@children.12/@children.10/@ports.0" targets="//@children.2/@children.12/@children.12/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.2/@children.12/@children.11/@ports.0" targets="//@children.2/@children.12/@children.13/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.2/@children.12/@children.12/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.2/@children.12/@children.13/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.2/@children.12/@children.14/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.2/@children.12/@children.15/@ports.0" targets="//@children.2/@children.12/@children.14/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.2/@children.12/@children.16/@ports.0" targets="//@children.2/@children.12/@children.17/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.2/@children.12/@children.17/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E90" sources="//@children.2/@children.12/@children.18/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E91" sources="//@children.2/@children.12/@children.19/@ports.0" targets="//@children.2/@children.12/@children.18/@ports.0"/>
+      <containedEdges identifier="E92" sources="//@children.2/@children.12/@children.20/@ports.0" targets="//@children.2/@children.12/@children.22/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.2/@children.12/@children.21/@ports.0" targets="//@children.2/@children.12/@children.23/@ports.0"/>
+      <containedEdges identifier="E94" sources="//@children.2/@children.12/@children.22/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E95" sources="//@children.2/@children.12/@children.23/@ports.1" targets="//@children.2/@children.12/@children.1/@ports.0"/>
+      <containedEdges identifier="E96" sources="//@children.2/@children.12/@children.24/@ports.0" targets="//@children.2/@children.12/@children.26/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.2/@children.12/@children.25/@ports.1" targets="//@children.2/@children.12/@children.22/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.2/@children.12/@children.26/@ports.1" targets="//@children.2/@children.12/@children.25/@ports.0"/>
+    </children>
+    <children identifier="N90">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L90" height="15.0" width="89.0" text="InstanceOfwrist"/>
+      <ports identifier="P156" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.17" incomingEdges="//@children.2/@children.13/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N91" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L91" height="15.0" width="107.0" text="CircularSweep3D0"/>
+        <ports identifier="P157" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N92" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L92" height="15.0" width="45.0" text="PolyCyl"/>
+        <ports identifier="P158" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N93" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L93" height="15.0" width="46.0" text="Rotate2"/>
+        <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P160" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N94" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L94" height="15.0" width="46.0" text="Rotate4"/>
+        <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P162" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N95" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L95" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P164" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N96" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L96" height="15.0" width="46.0" text="Rotate8"/>
+        <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P166" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N97" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L97" height="15.0" width="107.0" text="CircularSweep3D1"/>
+        <ports identifier="P167" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N98" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L98" height="15.0" width="46.0" text="Rotate3"/>
+        <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P169" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N99" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="57.0" text="Scale3D4"/>
+        <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P171" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N100" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L100" height="15.0" width="103.0" text="PolyCylinder3D11"/>
+        <ports identifier="P172" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N101" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L101" height="15.0" width="53.0" text="Rotate12"/>
+        <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P174" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N102" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L102" height="15.0" width="53.0" text="Rotate13"/>
+        <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P176" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N103" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L103" height="15.0" width="84.0" text="Translate3D14"/>
+        <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P178" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N104" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L104" height="15.0" width="84.0" text="Translate3D15"/>
+        <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.8 //@children.2/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P180" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N105" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L105" height="15.0" width="38.0" text="Box28"/>
+        <ports identifier="P181" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N106" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L106" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P182" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N107" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P184" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P186" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N109" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L109" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P188" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N110" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L110" height="15.0" width="46.0" text="Rotate9"/>
+        <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.4 //@children.2/@children.13/@containedEdges.5 //@children.2/@children.13/@containedEdges.13 //@children.2/@children.13/@containedEdges.16 //@children.2/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P190" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N111" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L111" height="15.0" width="53.0" text="Rotate10"/>
+        <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P192" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N112" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L112" height="15.0" width="64.0" text="Scale3D15"/>
+        <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.18 //@children.2/@children.13/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P194" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N113" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L113" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+        <ports identifier="P195" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N114" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L114" height="15.0" width="53.0" text="Rotate27"/>
+        <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P197" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N115" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L115" height="15.0" width="46.0" text="Rotate0"/>
+        <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P199" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N116" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L116" height="15.0" width="84.0" text="Translate3D22"/>
+        <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.13/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P201" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.13/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E99" sources="//@children.2/@children.13/@children.0/@ports.0" targets="//@children.2/@children.13/@children.5/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.2/@children.13/@children.1/@ports.0" targets="//@children.2/@children.13/@children.2/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.2/@children.13/@children.2/@ports.1" targets="//@children.2/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.2/@children.13/@children.3/@ports.1" targets="//@children.2/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.2/@children.13/@children.4/@ports.1" targets="//@children.2/@children.13/@children.19/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.2/@children.13/@children.5/@ports.1" targets="//@children.2/@children.13/@children.19/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.2/@children.13/@children.6/@ports.0" targets="//@children.2/@children.13/@children.7/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.2/@children.13/@children.7/@ports.1" targets="//@children.2/@children.13/@children.8/@ports.0"/>
+      <containedEdges identifier="E107" sources="//@children.2/@children.13/@children.8/@ports.1" targets="//@children.2/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E108" sources="//@children.2/@children.13/@children.9/@ports.0" targets="//@children.2/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E109" sources="//@children.2/@children.13/@children.10/@ports.1" targets="//@children.2/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.2/@children.13/@children.11/@ports.1" targets="//@children.2/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E111" sources="//@children.2/@children.13/@children.12/@ports.1" targets="//@children.2/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E112" sources="//@children.2/@children.13/@children.13/@ports.1" targets="//@children.2/@children.13/@children.19/@ports.0"/>
+      <containedEdges identifier="E113" sources="//@children.2/@children.13/@children.14/@ports.0" targets="//@children.2/@children.13/@children.16/@ports.0"/>
+      <containedEdges identifier="E114" sources="//@children.2/@children.13/@children.15/@ports.0" targets="//@children.2/@children.13/@children.17/@ports.0"/>
+      <containedEdges identifier="E115" sources="//@children.2/@children.13/@children.16/@ports.1" targets="//@children.2/@children.13/@children.19/@ports.0"/>
+      <containedEdges identifier="E116" sources="//@children.2/@children.13/@children.17/@ports.1" targets="//@children.2/@children.13/@children.19/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.2/@children.13/@children.18/@ports.1" targets="//@children.2/@children.13/@children.21/@ports.0"/>
+      <containedEdges identifier="E118" sources="//@children.2/@children.13/@children.19/@ports.1" targets="//@children.2/@children.13/@children.20/@ports.0"/>
+      <containedEdges identifier="E119" sources="//@children.2/@children.13/@children.20/@ports.1" targets="//@children.2/@children.13/@children.18/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.2/@children.13/@children.21/@ports.1" targets="//@children.2/@children.13/@ports.0"/>
+      <containedEdges identifier="E121" sources="//@children.2/@children.13/@children.22/@ports.0" targets="//@children.2/@children.13/@children.23/@ports.0"/>
+      <containedEdges identifier="E122" sources="//@children.2/@children.13/@children.23/@ports.1" targets="//@children.2/@children.13/@children.24/@ports.0"/>
+      <containedEdges identifier="E123" sources="//@children.2/@children.13/@children.24/@ports.1" targets="//@children.2/@children.13/@children.25/@ports.0"/>
+      <containedEdges identifier="E124" sources="//@children.2/@children.13/@children.25/@ports.1" targets="//@children.2/@children.13/@children.21/@ports.0"/>
+    </children>
+    <children identifier="N117">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L117" height="15.0" width="102.0" text="InstanceOfgripper"/>
+      <ports identifier="P202" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.18" incomingEdges="//@children.2/@children.14/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N118" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L118" height="15.0" width="97.0" text="PolyCylinder3D0"/>
+        <ports identifier="P203" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N119" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L119" height="15.0" width="45.0" text="PolyCyl"/>
+        <ports identifier="P204" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N120" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L120" height="15.0" width="77.0" text="Translate3D0"/>
+        <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P206" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N121" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L121" height="15.0" width="46.0" text="Rotate1"/>
+        <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.0 //@children.2/@children.14/@containedEdges.8 //@children.2/@children.14/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P208" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N122" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L122" height="15.0" width="46.0" text="Rotate6"/>
+        <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.1 //@children.2/@children.14/@containedEdges.15 //@children.2/@children.14/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N123" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L123" height="15.0" width="53.0" text="Rotate13"/>
+        <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P212" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N124" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L124" height="15.0" width="31.0" text="Box7"/>
+        <ports identifier="P213" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N125" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L125" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.6 //@children.2/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N126" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L126" height="15.0" width="46.0" text="Rotate3"/>
+        <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P217" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N127" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L127" height="15.0" width="38.0" text="Box10"/>
+        <ports identifier="P218" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N128" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L128" height="15.0" width="77.0" text="Translate3D1"/>
+        <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P220" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N129" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L129" height="15.0" width="38.0" text="Box14"/>
+        <ports identifier="P221" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N130" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L130" height="15.0" width="31.0" text="Box0"/>
+        <ports identifier="P222" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N131" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L131" height="15.0" width="77.0" text="Translate3D2"/>
+        <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.11 //@children.2/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P224" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N132" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L132" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P226" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N133" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L133" height="15.0" width="46.0" text="Rotate4"/>
+        <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P228" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N134" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L134" height="15.0" width="97.0" text="PolyCylinder3D1"/>
+        <ports identifier="P229" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N135" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L135" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.16 //@children.2/@children.14/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P231" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N136" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L136" height="15.0" width="46.0" text="Rotate5"/>
+        <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P233" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N137" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L137" height="15.0" width="97.0" text="PolyCylinder3D2"/>
+        <ports identifier="P234" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N138" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L138" height="15.0" width="77.0" text="Translate3D5"/>
+        <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P236" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N139" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L139" height="15.0" width="104.0" text="PolyCylinder3D24"/>
+        <ports identifier="P237" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N140" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L140" height="15.0" width="77.0" text="Translate3D6"/>
+        <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.21 //@children.2/@children.14/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P239" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N141" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L141" height="15.0" width="46.0" text="Rotate7"/>
+        <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P241" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N142" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L142" height="15.0" width="104.0" text="PolyCylinder3D27"/>
+        <ports identifier="P242" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N143" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="77.0" text="Translate3D7"/>
+        <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P244" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N144" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L144" height="15.0" width="84.0" text="Translate3D28"/>
+        <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.2 //@children.2/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P246" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N145" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L145" height="15.0" width="53.0" text="Rotate14"/>
+        <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P248" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N146" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L146" height="15.0" width="53.0" text="Rotate30"/>
+        <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.14/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P250" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.14/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E125" sources="//@children.2/@children.14/@children.0/@ports.0" targets="//@children.2/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E126" sources="//@children.2/@children.14/@children.1/@ports.0" targets="//@children.2/@children.14/@children.4/@ports.0"/>
+      <containedEdges identifier="E127" sources="//@children.2/@children.14/@children.2/@ports.1" targets="//@children.2/@children.14/@children.26/@ports.0"/>
+      <containedEdges identifier="E128" sources="//@children.2/@children.14/@children.3/@ports.1" targets="//@children.2/@children.14/@children.26/@ports.0"/>
+      <containedEdges identifier="E129" sources="//@children.2/@children.14/@children.4/@ports.1" targets="//@children.2/@children.14/@children.5/@ports.0"/>
+      <containedEdges identifier="E130" sources="//@children.2/@children.14/@children.5/@ports.1" targets="//@children.2/@children.14/@children.2/@ports.0"/>
+      <containedEdges identifier="E131" sources="//@children.2/@children.14/@children.6/@ports.0" targets="//@children.2/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E132" sources="//@children.2/@children.14/@children.7/@ports.1" targets="//@children.2/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E133" sources="//@children.2/@children.14/@children.8/@ports.1" targets="//@children.2/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E134" sources="//@children.2/@children.14/@children.9/@ports.0" targets="//@children.2/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E135" sources="//@children.2/@children.14/@children.10/@ports.1" targets="//@children.2/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.2/@children.14/@children.11/@ports.0" targets="//@children.2/@children.14/@children.13/@ports.0"/>
+      <containedEdges identifier="E137" sources="//@children.2/@children.14/@children.12/@ports.0" targets="//@children.2/@children.14/@children.14/@ports.0"/>
+      <containedEdges identifier="E138" sources="//@children.2/@children.14/@children.13/@ports.1" targets="//@children.2/@children.14/@children.15/@ports.0"/>
+      <containedEdges identifier="E139" sources="//@children.2/@children.14/@children.14/@ports.1" targets="//@children.2/@children.14/@children.13/@ports.0"/>
+      <containedEdges identifier="E140" sources="//@children.2/@children.14/@children.15/@ports.1" targets="//@children.2/@children.14/@children.4/@ports.0"/>
+      <containedEdges identifier="E141" sources="//@children.2/@children.14/@children.16/@ports.0" targets="//@children.2/@children.14/@children.17/@ports.0"/>
+      <containedEdges identifier="E142" sources="//@children.2/@children.14/@children.17/@ports.1" targets="//@children.2/@children.14/@children.18/@ports.0"/>
+      <containedEdges identifier="E143" sources="//@children.2/@children.14/@children.18/@ports.1" targets="//@children.2/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E144" sources="//@children.2/@children.14/@children.19/@ports.0" targets="//@children.2/@children.14/@children.20/@ports.0"/>
+      <containedEdges identifier="E145" sources="//@children.2/@children.14/@children.20/@ports.1" targets="//@children.2/@children.14/@children.17/@ports.0"/>
+      <containedEdges identifier="E146" sources="//@children.2/@children.14/@children.21/@ports.0" targets="//@children.2/@children.14/@children.22/@ports.0"/>
+      <containedEdges identifier="E147" sources="//@children.2/@children.14/@children.22/@ports.1" targets="//@children.2/@children.14/@children.23/@ports.0"/>
+      <containedEdges identifier="E148" sources="//@children.2/@children.14/@children.23/@ports.1" targets="//@children.2/@children.14/@children.4/@ports.0"/>
+      <containedEdges identifier="E149" sources="//@children.2/@children.14/@children.24/@ports.0" targets="//@children.2/@children.14/@children.25/@ports.0"/>
+      <containedEdges identifier="E150" sources="//@children.2/@children.14/@children.25/@ports.1" targets="//@children.2/@children.14/@children.22/@ports.0"/>
+      <containedEdges identifier="E151" sources="//@children.2/@children.14/@children.26/@ports.1" targets="//@children.2/@children.14/@children.27/@ports.0"/>
+      <containedEdges identifier="E152" sources="//@children.2/@children.14/@children.27/@ports.1" targets="//@children.2/@children.14/@children.28/@ports.0"/>
+      <containedEdges identifier="E153" sources="//@children.2/@children.14/@children.28/@ports.1" targets="//@children.2/@children.14/@ports.0"/>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.2/@children.5/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.2/@ports.2" targets="//@children.2/@children.2/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.2/@ports.3" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.2/@ports.4" targets="//@children.2/@children.7/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.9/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.2/@children.12/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.13/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.14/@ports.0" targets="//@children.2/@children.8/@ports.0"/>
+  </children>
+  <children identifier="N147">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L147" height="15.0" width="179.0" text="InstanceOfkey_input_controller"/>
+    <ports identifier="P251" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.3/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N148">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L148" height="15.0" width="109.0" text="get_motor_number"/>
+      <ports identifier="P257" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P258" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N149" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L149" height="15.0" width="119.0" text="FSM_motor_number"/>
+        <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P260" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E164" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E165" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N150">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L150" height="15.0" width="75.0" text="get_direction"/>
+      <ports identifier="P261" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.3" incomingEdges="//@children.3/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P262" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.1/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N151" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L151" height="15.0" width="119.0" text="FSM_motor_number"/>
+        <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P264" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E166" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E167" sources="//@children.3/@children.1/@children.0/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N152" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L152" height="15.0" width="41.0" text="Scale0"/>
+      <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P266" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N153" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L153" height="15.0" width="47.0" text="Switch1"/>
+      <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P268" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.5 //@children.3/@containedEdges.6 //@children.3/@containedEdges.7 //@children.3/@containedEdges.8 //@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P269" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E154" sources="//@children.3/@ports.5" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E155" sources="//@children.3/@ports.5" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E156" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.3/@ports.2"/>
+    <containedEdges identifier="E157" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E158" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E159" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E160" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E161" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E162" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@ports.3"/>
+    <containedEdges identifier="E163" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@ports.4"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.3/@ports.5"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.3" targets="//@children.2/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gr_stickymasses_StickyMasses.elkg
+++ b/realworld/ptolemy/hierarchical/gr_stickymasses_StickyMasses.elkg
@@ -1,0 +1,1218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="40.0" text="Viewer"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="99.0" text="blue spring-mass"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@children.0/@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="55.0" text="Torus3D1"/>
+        <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="55.0" text="Torus3D2"/>
+        <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="77.0" text="Translate3D9"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.5 //@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="69.0" text="Rotate3D10"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="69.0" text="Rotate3D13"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="69.0" text="Rotate3D14"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="55.0" text="Torus3D3"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="62.0" text="Rotate3D4"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.8 //@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="62.0" text="Torus3D16"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="69.0" text="Rotate3D17"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="69.0" text="Rotate3D20"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="84.0" text="Translate3D24"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.12 //@children.0/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="62.0" text="Torus3D27"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="69.0" text="Rotate3D28"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="84.0" text="Translate3D33"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.15 //@children.0/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="62.0" text="Torus3D38"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="62.0" text="Torus3D39"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="69.0" text="Rotate3D40"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="69.0" text="Rotate3D41"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="84.0" text="Translate3D42"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.20 //@children.0/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="69.0" text="Rotate3D43"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="84.0" text="Translate3D52"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.22 //@children.0/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.0/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.24 //@children.0/@children.0/@containedEdges.25 //@children.0/@children.0/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="65.0" text="Sphere3D1"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="85.0" text="Compute Twist"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.30 //@children.0/@children.0/@containedEdges.31 //@children.0/@children.0/@containedEdges.32 //@children.0/@children.0/@containedEdges.33 //@children.0/@children.0/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="25.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.35 //@children.0/@children.0/@containedEdges.36 //@children.0/@children.0/@containedEdges.37 //@children.0/@children.0/@containedEdges.38 //@children.0/@children.0/@containedEdges.39 //@children.0/@children.0/@containedEdges.40 //@children.0/@children.0/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E23" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.28/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.26/@ports.0"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@children.26/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.0/@children.6/@ports.0" targets="//@children.0/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.0/@children.0/@children.7/@ports.1" targets="//@children.0/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.0/@children.8/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.0/@children.9/@ports.0" targets="//@children.0/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.0/@children.10/@ports.1" targets="//@children.0/@children.0/@children.11/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.0/@children.11/@ports.1" targets="//@children.0/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.0/@children.12/@ports.1" targets="//@children.0/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.0/@children.13/@ports.0" targets="//@children.0/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.0/@children.14/@ports.1" targets="//@children.0/@children.0/@children.15/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.0/@children.15/@ports.1" targets="//@children.0/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.0/@children.16/@ports.0" targets="//@children.0/@children.0/@children.18/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.0/@children.17/@ports.0" targets="//@children.0/@children.0/@children.21/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.0/@children.0/@children.18/@ports.1" targets="//@children.0/@children.0/@children.19/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.0/@children.0/@children.19/@ports.1" targets="//@children.0/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.0/@children.20/@ports.1" targets="//@children.0/@children.0/@children.15/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.0/@children.21/@ports.1" targets="//@children.0/@children.0/@children.22/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.0/@children.0/@children.22/@ports.1" targets="//@children.0/@children.0/@children.20/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.0/@children.0/@children.23/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.2"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.0/@children.23/@ports.1" targets="//@children.0/@children.0/@children.11/@ports.2"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.0/@children.23/@ports.1" targets="//@children.0/@children.0/@children.19/@ports.2"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.0/@children.24/@ports.0" targets="//@children.0/@children.0/@children.25/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.0/@children.25/@ports.1" targets="//@children.0/@children.0/@children.22/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.0/@children.26/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.0/@children.27/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.0/@children.27/@ports.0" targets="//@children.0/@children.0/@children.7/@ports.2"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.0/@children.27/@ports.0" targets="//@children.0/@children.0/@children.14/@ports.2"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.0/@children.27/@ports.0" targets="//@children.0/@children.0/@children.21/@ports.2"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.0/@children.27/@ports.0" targets="//@children.0/@children.0/@children.23/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.0/@children.28/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.0/@children.28/@ports.0" targets="//@children.0/@children.0/@children.8/@ports.2"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.0/@children.28/@ports.0" targets="//@children.0/@children.0/@children.12/@ports.2"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.0/@children.28/@ports.0" targets="//@children.0/@children.0/@children.15/@ports.2"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.0/@children.28/@ports.0" targets="//@children.0/@children.0/@children.20/@ports.2"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.0/@children.28/@ports.0" targets="//@children.0/@children.0/@children.22/@ports.2"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.0/@children.28/@ports.0" targets="//@children.0/@children.0/@children.27/@ports.1"/>
+    </children>
+    <children identifier="N32" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="57.0" text="Scale3D3"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="43.0" text="left wall"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="84.0" text="Translate3D26"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.10 //@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="62.0" text="Rotate3D1"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="25.0" text="floor"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="77.0" text="Translate3D3"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="70.0" text="ViewScreen"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="51.0" text="right wall"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.11 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="55.0" text="Rotate3D"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="77.0" text="Translate3D4"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L44" height="15.0" width="93.0" text="red spring-mass"/>
+      <ports identifier="P88" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.13/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.14" incomingEdges="//@children.0/@children.13/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N45" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="55.0" text="Torus3D1"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="55.0" text="Torus3D2"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="77.0" text="Translate3D9"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.5 //@children.0/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.35">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="69.0" text="Rotate3D10"/>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.30">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="69.0" text="Rotate3D13"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="69.0" text="Rotate3D14"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="55.0" text="Torus3D3"/>
+        <ports identifier="P103" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="62.0" text="Rotate3D4"/>
+        <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.31">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="84.0" text="Translate3D10"/>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.8 //@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.36">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N54" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L54" height="15.0" width="62.0" text="Torus3D16"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N55" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L55" height="15.0" width="69.0" text="Rotate3D17"/>
+        <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N56" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L56" height="15.0" width="69.0" text="Rotate3D20"/>
+        <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P114" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N57" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="84.0" text="Translate3D24"/>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.12 //@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.37">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="62.0" text="Torus3D27"/>
+        <ports identifier="P119" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="69.0" text="Rotate3D28"/>
+        <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P121" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.32">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="84.0" text="Translate3D33"/>
+        <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.15 //@children.0/@children.13/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.38">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="62.0" text="Torus3D38"/>
+        <ports identifier="P126" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N62" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L62" height="15.0" width="62.0" text="Torus3D39"/>
+        <ports identifier="P127" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N63" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L63" height="15.0" width="69.0" text="Rotate3D40"/>
+        <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P129" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N64" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L64" height="15.0" width="69.0" text="Rotate3D41"/>
+        <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N65" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L65" height="15.0" width="84.0" text="Translate3D42"/>
+        <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.20 //@children.0/@children.13/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P134" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.39">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N66" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L66" height="15.0" width="69.0" text="Rotate3D43"/>
+        <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.33">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N67" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L67" height="15.0" width="84.0" text="Translate3D52"/>
+        <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@children.13/@containedEdges.22 //@children.0/@children.13/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@children.13/@containedEdges.40">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N68" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.13/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.13/@containedEdges.24 //@children.0/@children.13/@containedEdges.25 //@children.0/@children.13/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="65.0" text="Sphere3D1"/>
+        <ports identifier="P144" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N70" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L70" height="15.0" width="77.0" text="Translate3D4"/>
+        <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.13/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P146" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N71" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L71" height="15.0" width="50.0" text="Scale3D"/>
+        <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.13/@containedEdges.3 //@children.0/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.13/@containedEdges.29">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N72" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="85.0" text="Compute Twist"/>
+        <ports identifier="P149" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.30 //@children.0/@children.13/@containedEdges.31 //@children.0/@children.13/@containedEdges.32 //@children.0/@children.13/@containedEdges.33 //@children.0/@children.13/@containedEdges.34">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N73" height="25.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P151" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.35 //@children.0/@children.13/@containedEdges.36 //@children.0/@children.13/@containedEdges.37 //@children.0/@children.13/@containedEdges.38 //@children.0/@children.13/@containedEdges.39 //@children.0/@children.13/@containedEdges.40 //@children.0/@children.13/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E65" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.13/@children.28/@ports.1"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.13/@children.0/@ports.0" targets="//@children.0/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.13/@children.1/@ports.0" targets="//@children.0/@children.13/@children.5/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.13/@children.2/@ports.1" targets="//@children.0/@children.13/@children.26/@ports.0"/>
+      <containedEdges identifier="E69" sources="//@children.0/@children.13/@children.3/@ports.1" targets="//@children.0/@children.13/@children.26/@ports.0"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.2/@ports.0"/>
+      <containedEdges identifier="E71" sources="//@children.0/@children.13/@children.5/@ports.1" targets="//@children.0/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.13/@children.6/@ports.0" targets="//@children.0/@children.13/@children.7/@ports.0"/>
+      <containedEdges identifier="E73" sources="//@children.0/@children.13/@children.7/@ports.1" targets="//@children.0/@children.13/@children.8/@ports.0"/>
+      <containedEdges identifier="E74" sources="//@children.0/@children.13/@children.8/@ports.1" targets="//@children.0/@children.13/@children.2/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.0/@children.13/@children.9/@ports.0" targets="//@children.0/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.0/@children.13/@children.10/@ports.1" targets="//@children.0/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E77" sources="//@children.0/@children.13/@children.11/@ports.1" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.0/@children.13/@children.12/@ports.1" targets="//@children.0/@children.13/@children.8/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.0/@children.13/@children.13/@ports.0" targets="//@children.0/@children.13/@children.14/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.0/@children.13/@children.14/@ports.1" targets="//@children.0/@children.13/@children.15/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.13/@children.15/@ports.1" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.13/@children.16/@ports.0" targets="//@children.0/@children.13/@children.18/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.0/@children.13/@children.17/@ports.0" targets="//@children.0/@children.13/@children.21/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.13/@children.18/@ports.1" targets="//@children.0/@children.13/@children.19/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.13/@children.19/@ports.1" targets="//@children.0/@children.13/@children.20/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.13/@children.20/@ports.1" targets="//@children.0/@children.13/@children.15/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.0/@children.13/@children.21/@ports.1" targets="//@children.0/@children.13/@children.22/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.13/@children.22/@ports.1" targets="//@children.0/@children.13/@children.20/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.0/@children.13/@children.23/@ports.1" targets="//@children.0/@children.13/@children.4/@ports.2"/>
+      <containedEdges identifier="E90" sources="//@children.0/@children.13/@children.23/@ports.1" targets="//@children.0/@children.13/@children.11/@ports.2"/>
+      <containedEdges identifier="E91" sources="//@children.0/@children.13/@children.23/@ports.1" targets="//@children.0/@children.13/@children.19/@ports.2"/>
+      <containedEdges identifier="E92" sources="//@children.0/@children.13/@children.24/@ports.0" targets="//@children.0/@children.13/@children.25/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.0/@children.13/@children.25/@ports.1" targets="//@children.0/@children.13/@children.22/@ports.0"/>
+      <containedEdges identifier="E94" sources="//@children.0/@children.13/@children.26/@ports.1" targets="//@children.0/@children.13/@ports.1"/>
+      <containedEdges identifier="E95" sources="//@children.0/@children.13/@children.27/@ports.0" targets="//@children.0/@children.13/@children.3/@ports.2"/>
+      <containedEdges identifier="E96" sources="//@children.0/@children.13/@children.27/@ports.0" targets="//@children.0/@children.13/@children.7/@ports.2"/>
+      <containedEdges identifier="E97" sources="//@children.0/@children.13/@children.27/@ports.0" targets="//@children.0/@children.13/@children.14/@ports.2"/>
+      <containedEdges identifier="E98" sources="//@children.0/@children.13/@children.27/@ports.0" targets="//@children.0/@children.13/@children.21/@ports.2"/>
+      <containedEdges identifier="E99" sources="//@children.0/@children.13/@children.27/@ports.0" targets="//@children.0/@children.13/@children.23/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.0/@children.13/@children.28/@ports.0" targets="//@children.0/@children.13/@children.2/@ports.2"/>
+      <containedEdges identifier="E101" sources="//@children.0/@children.13/@children.28/@ports.0" targets="//@children.0/@children.13/@children.8/@ports.2"/>
+      <containedEdges identifier="E102" sources="//@children.0/@children.13/@children.28/@ports.0" targets="//@children.0/@children.13/@children.12/@ports.2"/>
+      <containedEdges identifier="E103" sources="//@children.0/@children.13/@children.28/@ports.0" targets="//@children.0/@children.13/@children.15/@ports.2"/>
+      <containedEdges identifier="E104" sources="//@children.0/@children.13/@children.28/@ports.0" targets="//@children.0/@children.13/@children.20/@ports.2"/>
+      <containedEdges identifier="E105" sources="//@children.0/@children.13/@children.28/@ports.0" targets="//@children.0/@children.13/@children.22/@ports.2"/>
+      <containedEdges identifier="E106" sources="//@children.0/@children.13/@children.28/@ports.0" targets="//@children.0/@children.13/@children.27/@ports.1"/>
+    </children>
+    <children identifier="N74" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="77.0" text="Translate3D5"/>
+      <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="77.0" text="Translate3D6"/>
+      <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P156" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="25.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P157" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.0/@children.16/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@ports.0" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.11/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.16/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N78">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L78" height="15.0" width="118.0" text="StickyMassesModel"/>
+    <ports identifier="P160" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3" incomingEdges="//@children.2/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N79" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L79" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P163" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N80" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L80" height="15.0" width="112.0" text="Sticky Mass model"/>
+      <ports identifier="P164" height="8.0" width="8.0" x="61.0" y="-1.875">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P165" height="8.0" width="8.0" x="61.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P167" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P168" height="8.0" width="8.0" x="61.0" y="22.625">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P169" height="8.0" width="8.0" x="61.0" y="28.75">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P170" height="8.0" width="8.0" x="61.0" y="34.875">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E107" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E108" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E109" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E110" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.0/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gt_bouncingballx2_BouncingBallX2.elkg
+++ b/realworld/ptolemy/hierarchical/gt_bouncingballx2_BouncingBallX2.elkg
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="38.0" width="58.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="88.0" text="ModelExecutor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="25.0" y="38.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="58.0" y="15.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="59.0" text="Animation"/>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="70.0" text="ViewScreen"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="58.0" text="Sphere3D"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="40.0" text="Box3D"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="65.0" text="Sphere3D2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="100.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="100.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.2/@children.7/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.2/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.5/@ports.2"/>
+  </children>
+  <children identifier="N12" height="38.0" width="58.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="95.0" text="ModelExecutor2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="25.0" y="38.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="58.0" y="15.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="ReverseDirection"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="10.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L14" height="15.0" width="157.0" text="ReverseMovementDirection"/>
+      <ports identifier="P26" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="96.0" width="100.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="149.0" text="ReverseCrossingDirection"/>
+      <ports identifier="P29" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N16" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="425.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.1/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gt_diningphilosophers_DiningPhilosophers.elkg
+++ b/realworld/ptolemy/hierarchical/gt_diningphilosophers_DiningPhilosophers.elkg
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="64.0" text="ModelView"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="64.0" text="CreateFirst"/>
+    <ports identifier="P28" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="76.0" text="Replacement"/>
+      <children identifier="N13" height="37.0" width="103.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="89.0" text="ResourcePool2"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.10/@children.0/@containedEdges.0 //@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.10/@children.0/@containedEdges.2 //@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L14" height="15.0" width="69.0" text="Philosopher"/>
+        <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@children.1/@containedEdges.0 //@children.10/@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@children.1/@containedEdges.2 //@children.10/@children.0/@children.1/@containedEdges.3" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.3" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.2" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N15" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="69.0" text="Philosopher"/>
+          <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@children.0/@children.1/@containedEdges.4 //@children.10/@children.0/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P39" height="8.0" width="8.0" x="26.5" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="43.0" text="Display"/>
+          <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="66.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="46.0" text="Barrier1"/>
+          <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.0 //@children.10/@children.0/@children.1/@containedEdges.2 //@children.10/@children.0/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="25.0" width="185.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P42" height="8.0" width="8.0" x="185.0" y="8.5" outgoingEdges="//@children.10/@children.0/@children.1/@containedEdges.6 //@children.10/@children.0/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N19" height="37.0" width="103.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L19" height="15.0" width="89.0" text="ResourcePool1"/>
+          <ports identifier="P44" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.10/@children.0/@children.1/@containedEdges.8 //@children.10/@children.0/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N20" height="37.0" width="103.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L20" height="15.0" width="89.0" text="ResourcePool2"/>
+          <ports identifier="P46" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.10/@children.0/@children.1/@containedEdges.10 //@children.10/@children.0/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N21" height="66.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L21" height="15.0" width="46.0" text="Barrier2"/>
+          <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@children.10/@children.0/@children.1/@containedEdges.5 //@children.10/@children.0/@children.1/@containedEdges.9 //@children.10/@children.0/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E19" sources="//@children.10/@children.0/@children.1/@ports.0" targets="//@children.10/@children.0/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E20" sources="//@children.10/@children.0/@children.1/@ports.0" targets="//@children.10/@children.0/@children.1/@children.4/@ports.1"/>
+        <containedEdges identifier="E21" sources="//@children.10/@children.0/@children.1/@ports.1" targets="//@children.10/@children.0/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E22" sources="//@children.10/@children.0/@children.1/@ports.1" targets="//@children.10/@children.0/@children.1/@children.5/@ports.1"/>
+        <containedEdges identifier="E23" sources="//@children.10/@children.0/@children.1/@children.0/@ports.1" targets="//@children.10/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E24" sources="//@children.10/@children.0/@children.1/@children.0/@ports.1" targets="//@children.10/@children.0/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E25" sources="//@children.10/@children.0/@children.1/@children.3/@ports.0" targets="//@children.10/@children.0/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E26" sources="//@children.10/@children.0/@children.1/@children.3/@ports.0" targets="//@children.10/@children.0/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E27" sources="//@children.10/@children.0/@children.1/@children.4/@ports.0" targets="//@children.10/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E28" sources="//@children.10/@children.0/@children.1/@children.4/@ports.0" targets="//@children.10/@children.0/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E29" sources="//@children.10/@children.0/@children.1/@children.5/@ports.0" targets="//@children.10/@children.0/@children.1/@ports.3"/>
+        <containedEdges identifier="E30" sources="//@children.10/@children.0/@children.1/@children.5/@ports.0" targets="//@children.10/@children.0/@children.1/@children.6/@ports.0"/>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.10/@children.0/@children.0/@ports.0" targets="//@children.10/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E16" sources="//@children.10/@children.0/@children.0/@ports.0" targets="//@children.10/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.10/@children.0/@children.1/@ports.3" targets="//@children.10/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E18" sources="//@children.10/@children.0/@children.1/@ports.2" targets="//@children.10/@children.0/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N22">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L22" height="15.0" width="63.0" text="CreateOne"/>
+    <ports identifier="P49" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N23">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L23" height="15.0" width="43.0" text="Pattern"/>
+      <children identifier="N24" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="118.0" text="PreviousPhilosopher"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="37.0" width="103.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="53.0" text="NextPool"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.11/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.11/@children.0/@children.0/@ports.1" targets="//@children.11/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.11/@children.0/@children.1/@ports.0" targets="//@children.11/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N26">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L26" height="15.0" width="76.0" text="Replacement"/>
+      <children identifier="N27" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="118.0" text="PreviousPhilosopher"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L28" height="15.0" width="69.0" text="Philosopher"/>
+        <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.0 //@children.11/@children.1/@children.1/@containedEdges.1" incomingEdges="//@children.11/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.2 //@children.11/@children.1/@children.1/@containedEdges.3" incomingEdges="//@children.11/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.2" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.1" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N29" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="69.0" text="Philosopher"/>
+          <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.4 //@children.11/@children.1/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P65" height="8.0" width="8.0" x="26.5" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N30" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L30" height="15.0" width="43.0" text="Display"/>
+          <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N31" height="66.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L31" height="15.0" width="46.0" text="Barrier1"/>
+          <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.0 //@children.11/@children.1/@children.1/@containedEdges.2 //@children.11/@children.1/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N32" height="25.0" width="185.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L32" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P68" height="8.0" width="8.0" x="185.0" y="8.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.6 //@children.11/@children.1/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N33" height="37.0" width="103.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L33" height="15.0" width="89.0" text="ResourcePool1"/>
+          <ports identifier="P70" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.8 //@children.11/@children.1/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N34" height="37.0" width="103.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L34" height="15.0" width="89.0" text="ResourcePool2"/>
+          <ports identifier="P72" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.11/@children.1/@children.1/@containedEdges.10 //@children.11/@children.1/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N35" height="66.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L35" height="15.0" width="46.0" text="Barrier2"/>
+          <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@children.11/@children.1/@children.1/@containedEdges.5 //@children.11/@children.1/@children.1/@containedEdges.9 //@children.11/@children.1/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E39" sources="//@children.11/@children.1/@children.1/@ports.0" targets="//@children.11/@children.1/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E40" sources="//@children.11/@children.1/@children.1/@ports.0" targets="//@children.11/@children.1/@children.1/@children.4/@ports.1"/>
+        <containedEdges identifier="E41" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E42" sources="//@children.11/@children.1/@children.1/@ports.1" targets="//@children.11/@children.1/@children.1/@children.5/@ports.1"/>
+        <containedEdges identifier="E43" sources="//@children.11/@children.1/@children.1/@children.0/@ports.1" targets="//@children.11/@children.1/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E44" sources="//@children.11/@children.1/@children.1/@children.0/@ports.1" targets="//@children.11/@children.1/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E45" sources="//@children.11/@children.1/@children.1/@children.3/@ports.0" targets="//@children.11/@children.1/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E46" sources="//@children.11/@children.1/@children.1/@children.3/@ports.0" targets="//@children.11/@children.1/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E47" sources="//@children.11/@children.1/@children.1/@children.4/@ports.0" targets="//@children.11/@children.1/@children.1/@ports.2"/>
+        <containedEdges identifier="E48" sources="//@children.11/@children.1/@children.1/@children.4/@ports.0" targets="//@children.11/@children.1/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E49" sources="//@children.11/@children.1/@children.1/@children.5/@ports.0" targets="//@children.11/@children.1/@children.1/@ports.3"/>
+        <containedEdges identifier="E50" sources="//@children.11/@children.1/@children.1/@children.5/@ports.0" targets="//@children.11/@children.1/@children.1/@children.6/@ports.0"/>
+      </children>
+      <children identifier="N36" height="37.0" width="103.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="81.0" text="ResourcePool"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.11/@children.1/@containedEdges.3 //@children.11/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.11/@children.1/@containedEdges.0 //@children.11/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="37.0" width="103.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="53.0" text="NextPool"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@children.11/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@children.11/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E33" sources="//@children.11/@children.1/@children.0/@ports.1" targets="//@children.11/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.11/@children.1/@children.1/@ports.3" targets="//@children.11/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.11/@children.1/@children.1/@ports.2" targets="//@children.11/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.11/@children.1/@children.2/@ports.0" targets="//@children.11/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.11/@children.1/@children.2/@ports.0" targets="//@children.11/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E38" sources="//@children.11/@children.1/@children.3/@ports.0" targets="//@children.11/@children.1/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N38" height="25.0" width="121.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="121.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.2" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.0/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gt_mapreduce_MapReduce.elkg
+++ b/realworld/ptolemy/hierarchical/gt_mapreduce_MapReduce.elkg
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="26.0" text="Split"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="60.0" text="Distributor"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N3" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="37.0" text="merge"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="26.0" text="Map"/>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.2/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="39.0" text="worker"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="44.0" text="storage"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@ports.2" targets="//@children.2/@children.1/@ports.4"/>
+    <containedEdges identifier="E17" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.0/@ports.3" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.1/@ports.5" targets="//@children.2/@ports.5"/>
+    <containedEdges identifier="E21" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E22" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@ports.4"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="45.0" text="Reduce"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="39.0" text="worker"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="53.0" text="converter"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.3/@ports.2" targets="//@children.3/@children.0/@ports.4"/>
+    <containedEdges identifier="E24" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.0/@ports.2" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@ports.3"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="72.0" text="WaitingStop"/>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="37.0" text="merge"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="47.0" text="sampler"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="29.0" text="and2"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="25.0" text="filter"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="31.0" text="delay"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="39.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="28.0" text="Stop"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E29" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.2"/>
+    <containedEdges identifier="E32" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N17" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="51.0" y="8.333333015441895" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="51.0" y="24.66666603088379" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.4" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gt_modelgeneration_ModelGeneration.elkg
+++ b/realworld/ptolemy/hierarchical/gt_modelgeneration_ModelGeneration.elkg
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="CreateDisplay"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="76.0" text="Replacement"/>
+      <children identifier="N3" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="64.0" text="ModelView"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="69.0" text="CreateNode"/>
+    <ports identifier="P17" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="43.0" text="Pattern"/>
+      <children identifier="N11" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E13" sources="//@children.5/@children.0/@children.1/@ports.1" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="76.0" text="Replacement"/>
+      <children identifier="N14" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="68.0" text="SingleEvent"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.5/@children.1/@children.0/@ports.0" targets="//@children.5/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.5/@children.1/@children.2/@ports.1" targets="//@children.5/@children.1/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N17" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="70.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.3/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.7/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gt_modelgeneration_ModelGenerationDDF.elkg
+++ b/realworld/ptolemy/hierarchical/gt_modelgeneration_ModelGenerationDDF.elkg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="93.0" text="ModelGenerator"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="64.0" text="ModelView"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="85.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="39.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="28.0" text="Stop"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="15.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="81.0" text="CreateDisplay"/>
+    <ports identifier="P30" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="76.0" text="Replacement"/>
+      <children identifier="N14" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.11/@children.0/@children.1/@ports.1" targets="//@children.11/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N16">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L16" height="15.0" width="69.0" text="CreateNode"/>
+    <ports identifier="P36" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N17">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L17" height="15.0" width="43.0" text="Pattern"/>
+      <children identifier="N18" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.12/@children.0/@children.1/@ports.1" targets="//@children.12/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N20">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L20" height="15.0" width="76.0" text="Replacement"/>
+      <children identifier="N21" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="68.0" text="SingleEvent"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E16" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.12/@children.1/@children.2/@ports.1" targets="//@children.12/@children.1/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.3" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.12/@ports.1" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/gt_sinewaveoptimization_SinewaveOptimization.elkg
+++ b/realworld/ptolemy/hierarchical/gt_sinewaveoptimization_SinewaveOptimization.elkg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="63.0" text="_Controller"/>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="52.0" text="InitModel"/>
+      <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="65.0" text="ReadModel"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="122.0" text="ViewOptimizedModel"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="107.0" text="ViewOriginalModel"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="57.0" text="Transform"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="57.0" text="Transform"/>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="91.0" text="SimplifyMultiply"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="28.0" text="Start"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="71.0" text="NeedRepeat"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="81.0" text="SimplifyDivide"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="91.0" text="RemoveMultiply"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E6" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/hdf_adaptivecoding_AdaptiveCoding.elkg
+++ b/realworld/ptolemy/hierarchical/hdf_adaptivecoding_AdaptiveCoding.elkg
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="106.0" text="Uncoded Symbols"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Coder"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="ModalModel2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1 //@children.6/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.6/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.6/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3 //@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.6/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.4/@ports.2" targets="//@children.6/@ports.3"/>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="98.0" text="Number of Errors"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="60.0" text="Error Rate"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.3" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/hoc_case_Case.elkg
+++ b/realworld/ptolemy/hierarchical/hoc_case_Case.elkg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="31.0" text="Case"/>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="8.0" text="1"/>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.3" incomingEdges="//@children.3/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="72.0" text="TrigFunction"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+      <containedEdges identifier="E13" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="8.0" text="0"/>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.1/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.4" incomingEdges="//@children.3/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.3/@children.1/@children.0/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="38.0" text="default"/>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.2/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.5" incomingEdges="//@children.3/@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E16" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.3/@children.2/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/hoc_dftsubset_DFTSubSet.elkg
+++ b/realworld/ptolemy/hierarchical/hoc_dftsubset_DFTSubSet.elkg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="112.0" text="ComputeCoefficient"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="25.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="180.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="94.0" text="InputBlockDelay"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="Commutator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="96.0" text="SequenceScope"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="107.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="107.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/hoc_iterateoverarray_IterateOverArray.elkg
+++ b/realworld/ptolemy/hierarchical/hoc_iterateoverarray_IterateOverArray.elkg
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="103.0" text="AntennaElements"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="94.0" text="composite actor"/>
+      <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.1 //@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="25.0" width="323.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="31.0" text="expjx"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="323.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N5" height="25.0" width="281.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="102.0" text="HammingWindow"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="113.0" text="SumArrayElements"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="59.0" text="Normalize"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="69.0" text="CreateArray"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="49.0" text="Steering"/>
+    <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="94.0" text="composite actor"/>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.1 //@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="25.0" width="430.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="430.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E20" sources="//@children.6/@children.0/@children.0/@ports.2" targets="//@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E21" sources="//@children.6/@children.0/@children.1/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N14" height="25.0" width="274.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="107.0" text="PlaneWavePhasor"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="274.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.9/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/hoc_threadedcomposite_MulticoreExecution.elkg
+++ b/realworld/ptolemy/hierarchical/hoc_threadedcomposite_MulticoreExecution.elkg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="116.0" text="ThreadedComposite"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="150.0" text="ThreadedCompositeInside"/>
+      <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="87.0" text="ExecutionTime"/>
+        <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E4" sources="//@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E5" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="123.0" text="ThreadedComposite2"/>
+    <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="150.0" text="ThreadedCompositeInside"/>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="87.0" text="ExecutionTime"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E6" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E7" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E8" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/lib_life_Life.elkg
+++ b/realworld/ptolemy/hierarchical/lib_life_Life.elkg
@@ -1,0 +1,972 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="134.0" text="Conways Game Of Life"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="49.0" text="Repeat2"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11 //@children.0/@containedEdges.12 //@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="69.0" text="GetElement"/>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.3/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.3/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.3/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.15" incomingEdges="//@children.0/@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.1 //@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E47" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.0/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.3/@children.1/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.3/@children.2/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.3/@children.0/@ports.1" targets="//@children.0/@children.3/@ports.3"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.3/@children.1/@ports.2" targets="//@children.0/@children.3/@children.0/@ports.2"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.3/@children.2/@ports.1" targets="//@children.0/@children.3/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="77.0" text="GetElement2"/>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.4/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.4/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.4/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.16" incomingEdges="//@children.0/@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.1 //@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E53" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.4/@children.2/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.4/@ports.3"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.4/@children.1/@ports.2" targets="//@children.0/@children.4/@children.0/@ports.2"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.4/@children.2/@ports.1" targets="//@children.0/@children.4/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="77.0" text="GetElement3"/>
+      <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.17" incomingEdges="//@children.0/@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N14" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.5/@containedEdges.1 //@children.0/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E59" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.5/@children.2/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.5/@children.0/@ports.1" targets="//@children.0/@children.5/@ports.3"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.5/@children.1/@ports.2" targets="//@children.0/@children.5/@children.0/@ports.2"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.5/@children.2/@ports.1" targets="//@children.0/@children.5/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N17">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L17" height="15.0" width="77.0" text="GetElement4"/>
+      <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.6/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.6/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.6/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.18" incomingEdges="//@children.0/@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N18" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.6/@containedEdges.1 //@children.0/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E65" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.6/@children.0/@ports.1" targets="//@children.0/@children.6/@ports.3"/>
+      <containedEdges identifier="E69" sources="//@children.0/@children.6/@children.1/@ports.2" targets="//@children.0/@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.6/@children.2/@ports.1" targets="//@children.0/@children.6/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N21">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L21" height="15.0" width="77.0" text="GetElement5"/>
+      <ports identifier="P58" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.7/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.7/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.7/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.19" incomingEdges="//@children.0/@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N22" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.7/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.7/@containedEdges.1 //@children.0/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E71" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.7/@children.0/@ports.0"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.7/@children.1/@ports.0"/>
+      <containedEdges identifier="E73" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E74" sources="//@children.0/@children.7/@children.0/@ports.1" targets="//@children.0/@children.7/@ports.3"/>
+      <containedEdges identifier="E75" sources="//@children.0/@children.7/@children.1/@ports.2" targets="//@children.0/@children.7/@children.0/@ports.2"/>
+      <containedEdges identifier="E76" sources="//@children.0/@children.7/@children.2/@ports.1" targets="//@children.0/@children.7/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N25">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L25" height="15.0" width="77.0" text="GetElement6"/>
+      <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.8/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.8/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.8/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.20" incomingEdges="//@children.0/@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N26" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.8/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.8/@containedEdges.1 //@children.0/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E77" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.8/@children.1/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.0/@children.8/@children.0/@ports.1" targets="//@children.0/@children.8/@ports.3"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.8/@children.1/@ports.2" targets="//@children.0/@children.8/@children.0/@ports.2"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.8/@children.2/@ports.1" targets="//@children.0/@children.8/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N29">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L29" height="15.0" width="77.0" text="GetElement7"/>
+      <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.9/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.9/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.9/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.21" incomingEdges="//@children.0/@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N30" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.9/@containedEdges.2 //@children.0/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E83" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.9/@children.0/@ports.1" targets="//@children.0/@children.9/@ports.3"/>
+      <containedEdges identifier="E87" sources="//@children.0/@children.9/@children.1/@ports.2" targets="//@children.0/@children.9/@children.0/@ports.2"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.9/@children.2/@ports.1" targets="//@children.0/@children.9/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N33">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L33" height="15.0" width="77.0" text="GetElement8"/>
+      <ports identifier="P94" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.10/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.10/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.10/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.22" incomingEdges="//@children.0/@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N34" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.10/@containedEdges.1 //@children.0/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E89" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E90" sources="//@children.0/@children.10/@ports.2" targets="//@children.0/@children.10/@children.1/@ports.0"/>
+      <containedEdges identifier="E91" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.10/@children.2/@ports.0"/>
+      <containedEdges identifier="E92" sources="//@children.0/@children.10/@children.0/@ports.1" targets="//@children.0/@children.10/@ports.3"/>
+      <containedEdges identifier="E93" sources="//@children.0/@children.10/@children.1/@ports.2" targets="//@children.0/@children.10/@children.0/@ports.2"/>
+      <containedEdges identifier="E94" sources="//@children.0/@children.10/@children.2/@ports.1" targets="//@children.0/@children.10/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N37" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16 //@children.0/@containedEdges.17 //@children.0/@containedEdges.18 //@children.0/@containedEdges.19 //@children.0/@containedEdges.20 //@children.0/@containedEdges.21 //@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="44.0" text="Pulse x"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="44.0" text="Pulse y"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.25 //@children.0/@containedEdges.26 //@children.0/@containedEdges.27 //@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L40" height="15.0" width="56.0" text="Borders x"/>
+      <ports identifier="P113" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.0 //@children.0/@children.14/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.32 //@children.0/@containedEdges.33 //@children.0/@containedEdges.34" incomingEdges="//@children.0/@children.14/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.29 //@children.0/@containedEdges.30 //@children.0/@containedEdges.31" incomingEdges="//@children.0/@children.14/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N41" height="25.0" width="231.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P116" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="25.0" width="231.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P118" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E95" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.0/@ports.1"/>
+      <containedEdges identifier="E96" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E97" sources="//@children.0/@children.14/@children.0/@ports.0" targets="//@children.0/@children.14/@ports.1"/>
+      <containedEdges identifier="E98" sources="//@children.0/@children.14/@children.1/@ports.0" targets="//@children.0/@children.14/@ports.2"/>
+    </children>
+    <children identifier="N43">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L43" height="15.0" width="56.0" text="Borders y"/>
+      <ports identifier="P120" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.15/@containedEdges.0 //@children.0/@children.15/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.35 //@children.0/@containedEdges.36 //@children.0/@containedEdges.37" incomingEdges="//@children.0/@children.15/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.38 //@children.0/@containedEdges.39 //@children.0/@containedEdges.40" incomingEdges="//@children.0/@children.15/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N44" height="25.0" width="231.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P123" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="25.0" width="231.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P125" height="8.0" width="8.0" x="231.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E99" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.0/@ports.1"/>
+      <containedEdges identifier="E100" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.1/@ports.1"/>
+      <containedEdges identifier="E101" sources="//@children.0/@children.15/@children.0/@ports.0" targets="//@children.0/@children.15/@ports.1"/>
+      <containedEdges identifier="E102" sources="//@children.0/@children.15/@children.1/@ports.0" targets="//@children.0/@children.15/@ports.2"/>
+    </children>
+    <children identifier="N46" height="70.0" width="185.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P127" height="8.0" width="8.0" x="185.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="44.0" incomingEdges="//@children.0/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N47">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L47" height="15.0" width="77.0" text="GetElement9"/>
+      <ports identifier="P130" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.17/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.17/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P132" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.17/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.42" incomingEdges="//@children.0/@children.17/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N48" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.17/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P135" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.17/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.17/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.17/@containedEdges.1 //@children.0/@children.17/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.17/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.17/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.17/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E103" sources="//@children.0/@children.17/@ports.0" targets="//@children.0/@children.17/@children.0/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.0/@children.17/@ports.2" targets="//@children.0/@children.17/@children.1/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.0/@children.17/@ports.1" targets="//@children.0/@children.17/@children.2/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.0/@children.17/@children.0/@ports.1" targets="//@children.0/@children.17/@ports.3"/>
+      <containedEdges identifier="E107" sources="//@children.0/@children.17/@children.1/@ports.2" targets="//@children.0/@children.17/@children.0/@ports.2"/>
+      <containedEdges identifier="E108" sources="//@children.0/@children.17/@children.2/@ports.1" targets="//@children.0/@children.17/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.17/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.3/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.5/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.7/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.8/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.9/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.10/@ports.3" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.16/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.12/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.6/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.7/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.17/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.5/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.15/@ports.2" targets="//@children.0/@children.8/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.15/@ports.2" targets="//@children.0/@children.9/@ports.2"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.15/@ports.2" targets="//@children.0/@children.10/@ports.2"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.16/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.17/@ports.3" targets="//@children.0/@children.16/@ports.2"/>
+  </children>
+  <children identifier="N51" height="160.0" width="133.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="76.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="133.0" y="76.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/lib_life_LifeCGAVR.elkg
+++ b/realworld/ptolemy/hierarchical/lib_life_LifeCGAVR.elkg
@@ -1,0 +1,605 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="134.0" text="Conways Game Of Life"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="49.0" text="Repeat2"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11 //@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.39 //@children.0/@containedEdges.40 //@children.0/@containedEdges.41 //@children.0/@containedEdges.42 //@children.0/@containedEdges.43 //@children.0/@containedEdges.44 //@children.0/@containedEdges.45 //@children.0/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="44.0" text="Pulse x"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.17 //@children.0/@containedEdges.18 //@children.0/@containedEdges.19 //@children.0/@containedEdges.20 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="44.0" text="Pulse y"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="56.0" text="Borders x"/>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.6/@containedEdges.0 //@children.0/@children.6/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.26 //@children.0/@containedEdges.27 //@children.0/@containedEdges.28" incomingEdges="//@children.0/@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.23 //@children.0/@containedEdges.24 //@children.0/@containedEdges.25" incomingEdges="//@children.0/@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N9" height="25.0" width="218.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="218.0" y="8.5" outgoingEdges="//@children.0/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="25.0" width="218.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="218.0" y="8.5" outgoingEdges="//@children.0/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E51" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.6/@children.1/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.6/@children.0/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.6/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.2"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="56.0" text="Borders y"/>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.7/@containedEdges.0 //@children.0/@children.7/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.29 //@children.0/@containedEdges.30 //@children.0/@containedEdges.31" incomingEdges="//@children.0/@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.32 //@children.0/@containedEdges.33 //@children.0/@containedEdges.34" incomingEdges="//@children.0/@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="25.0" width="196.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="196.0" y="8.5" outgoingEdges="//@children.0/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="25.0" width="196.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="196.0" y="8.5" outgoingEdges="//@children.0/@children.7/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E55" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.7/@children.1/@ports.1"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.7/@children.0/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.7/@children.1/@ports.0" targets="//@children.0/@children.7/@ports.2"/>
+    </children>
+    <children identifier="N14" height="70.0" width="185.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="185.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.35 //@children.0/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="44.0" incomingEdges="//@children.0/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="146.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="225.0" width="206.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="61.0" text="LEDMatrix"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="50.25" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="108.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="166.75" incomingEdges="//@children.0/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="131.0" text="ArrayElementAsMatrix"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="139.0" text="ArrayElementAsMatrix2"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="139.0" text="ArrayElementAsMatrix3"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="139.0" text="ArrayElementAsMatrix4"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="139.0" text="ArrayElementAsMatrix5"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="139.0" text="ArrayElementAsMatrix6"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="139.0" text="ArrayElementAsMatrix7"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="139.0" text="ArrayElementAsMatrix8"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="139.0" text="ArrayElementAsMatrix9"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.16/@ports.5"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.18/@ports.5"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.20/@ports.5"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.18/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.19/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.20/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.13/@ports.4"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.17/@ports.4"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.20/@ports.4"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.14/@ports.4"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.18/@ports.4"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.19/@ports.4"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.12/@ports.4"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.15/@ports.4"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.16/@ports.4"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.12/@ports.5"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.13/@ports.5"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.14/@ports.5"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.15/@ports.5"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.17/@ports.5"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.19/@ports.5"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.11/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.16/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.17/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.18/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.19/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.20/@ports.1" targets="//@children.0/@children.8/@ports.2"/>
+  </children>
+  <children identifier="N27" height="160.0" width="111.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="76.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="111.0" y="76.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/lib_life_LifeNoCG.elkg
+++ b/realworld/ptolemy/hierarchical/lib_life_LifeNoCG.elkg
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="134.0" text="Conways Game Of Life"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.0/@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="44.0" text="Pulse y"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="44.0" text="Pulse x"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="56.0" text="Borders y"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="56.0" text="Borders x"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="55.0" width="312.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="165.0" text="Expression Count Neighbors"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="312.0" y="23.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="-0.125" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="7.75" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="15.625" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="31.375" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="39.25" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="47.125" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-8"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="146.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="107.0" text="SequenceToMatrix"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="49.0" text="Repeat2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.17 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="65.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="65.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="70.0" width="185.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="185.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.20 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="44.0" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E6" sources="//@children.0/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.5/@ports.3"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.9/@ports.3"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.5/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.9/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.5/@ports.6"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.5/@ports.7"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.5/@ports.5"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.4"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.10/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N13" height="160.0" width="133.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="76.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="133.0" y="76.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="225.0" width="206.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="56.0" text="LEDArray"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="50.25" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="108.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="166.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.3" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/modal_abp_ABP.elkg
+++ b/realworld/ptolemy/hierarchical/modal_abp_ABP.elkg
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="23.0" text="Plot"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="-1.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="6.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="13.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="20.0">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="27.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="34.0">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="93.0" text="ForwardChannel"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="42.0" text="uniform"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="50.0" text="Bernoulli"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.3/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.3/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.2/@ports.2" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="104.0" text="BackwardChannel"/>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.4/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="uniform"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.4/@containedEdges.3 //@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="50.0" text="Bernoulli"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.4/@children.2/@ports.2" targets="//@children.4/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="115.0" text="Message Generator"/>
+    <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.5/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="79.0" text="VariableDelay"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="91.0" text="ColtExponential"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.1/@ports.2"/>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="95.0" text="ResettableTimer"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="25.0" width="113.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="113.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.7" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.4" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.5" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/modal_blending_Blending.elkg
+++ b/realworld/ptolemy/hierarchical/modal_blending_Blending.elkg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="106.0" text="BlendingController"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="93.0" text="mode_controller"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="-1.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L3" height="15.0" width="71.0" text="Controller_A"/>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N4" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E17" sources="//@children.0/@children.1/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="71.0" text="Controller_B"/>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7" incomingEdges="//@children.0/@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.0/@children.2/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="100.0" text="Blending_A_to_B"/>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.3/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.3/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.8" incomingEdges="//@children.0/@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.9" incomingEdges="//@children.0/@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N8" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="35.0" text="Ramp"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="25.0" width="74.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="68.0" text="Blend_Step"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="74.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.3 //@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="25.0" width="284.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="106.0" text="Blend_Expression"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="284.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E19" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.2/@ports.2"/>
+      <containedEdges identifier="E20" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.3/@children.2/@ports.3"/>
+      <containedEdges identifier="E21" sources="//@children.0/@children.3/@children.0/@ports.0" targets="//@children.0/@children.3/@children.1/@ports.1"/>
+      <containedEdges identifier="E22" sources="//@children.0/@children.3/@children.1/@ports.0" targets="//@children.0/@children.3/@ports.3"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.3/@children.1/@ports.0" targets="//@children.0/@children.3/@children.2/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.3/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.2"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="100.0" text="Blending_B_to_A"/>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.4/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.4/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.10" incomingEdges="//@children.0/@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.11" incomingEdges="//@children.0/@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="25.0" width="74.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="68.0" text="Blend_Step"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="74.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.3 //@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="25.0" width="283.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="106.0" text="Blend_Expression"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="283.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.0/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E25" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.4/@children.2/@ports.2"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.4/@children.2/@ports.3"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.4/@children.0/@ports.0" targets="//@children.0/@children.4/@children.1/@ports.1"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.4/@children.1/@ports.0" targets="//@children.0/@children.4/@ports.3"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.4/@children.1/@ports.0" targets="//@children.0/@children.4/@children.2/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.4/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.2"/>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.6" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.3/@ports.3" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@children.0/@ports.5"/>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="145.0" text="Control_SequencePlotter"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="132.0" text="Input_SequencePlotter"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/modal_case_Case.elkg
+++ b/realworld/ptolemy/hierarchical/modal_case_Case.elkg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="38.0" text="Case2"/>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="8.0" text="0"/>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.3" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="8.0" text="1"/>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.1/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.4" incomingEdges="//@children.3/@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N8" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="72.0" text="TrigFunction"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.3/@children.1/@children.0/@ports.1" targets="//@children.3/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.3/@children.1/@children.1/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+      <containedEdges identifier="E15" sources="//@children.3/@children.1/@children.2/@ports.1" targets="//@children.3/@children.1/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="38.0" text="default"/>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.2/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.5" incomingEdges="//@children.3/@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E16" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.3/@children.2/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pn_blindcommunication_BlindCommunication.elkg
+++ b/realworld/ptolemy/hierarchical/pn_blindcommunication_BlindCommunication.elkg
@@ -1,0 +1,825 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="75.0" text="AudioReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="119.0" text="CartesianToComplex"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="118.0" text="Baud Rate Estimate"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="70.0" text="Demodulate"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.3/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="25.0" width="264.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="136.0" text="ConvertBinToFrequency"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="264.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="250.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="58.0" text="Mix Down"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="250.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="145.0" text="PlotSpectrumWithCarrier"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="88.0" text="ArrayMaximum"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="597.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="105.0" text="RegenerateCarrier"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="597.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="163.0" text="PlotSpectrumWithoutCarrier"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="73.0" text="Periodogram"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="132.0" text="SmoothedPeriodogram"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.11 //@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.3/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.3/@ports.2" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.1/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="114.0" text="BaudRateEstimator"/>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.4/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N16" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="31.0" text="Chop"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="84.0" text="AbsoluteValue"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="24.0" text="FFT"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="81.0" text="PhaseUnwrap"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="91.0" text="AbsoluteValue2"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="298.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="193.0" text="ConvertBinAndOffsetToFrequency"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="298.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="88.0" text="ArrayMaximum"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="95.0" text="ComplexToPolar"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="31.0" y="5.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="60.0" text="Differential"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.4/@ports.1" targets="//@children.4/@children.8/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.9/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.4/@children.5/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.4/@children.7/@ports.2" targets="//@children.4/@children.6/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.4/@children.8/@ports.2" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.4/@children.9/@ports.1" targets="//@children.4/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="95.0" text="Carrier Estimate"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="63.0" text="Resampler"/>
+    <ports identifier="P57" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11" incomingEdges="//@children.6/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.6/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="157.0" text="GenerateResamplingSignal"/>
+      <ports identifier="P61" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3" incomingEdges="//@children.6/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N29" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="242.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="95.0" text="IncrementPhase"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="242.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.3 //@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="25.0" width="90.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="122.0" text="IdentifyBaudSamples"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E45" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E47" sources="//@children.6/@children.0/@children.0/@ports.1" targets="//@children.6/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E48" sources="//@children.6/@children.0/@children.1/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.6/@children.0/@children.1/@ports.0" targets="//@children.6/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.6/@children.0/@children.2/@ports.0" targets="//@children.6/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N32" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="66.0" text="CountTrues"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E38" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.6/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@ports.3"/>
+  </children>
+  <children identifier="N35">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L35" height="15.0" width="132.0" text="PhaseStatesEstimator"/>
+    <ports identifier="P79" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.7/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N36" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="95.0" text="ComplexToPolar"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="31.0" y="5.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="111.0" text="ComputeHistogram"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="103.0" text="ArrayPeakSearch"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="71.0" text="ArrayLength"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="87.0" text="MovingAverage"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="60.0" text="Differential"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="25.0" width="570.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="32.0" text="Wrap"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="570.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E51" sources="//@children.7/@ports.2" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.7/@children.2/@ports.3" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@ports.1"/>
+    <containedEdges identifier="E56" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.2/@ports.2"/>
+    <containedEdges identifier="E58" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.8/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.7/@children.8/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N45" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="82.0" text="Sample Count"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="77.0" text="Phase states"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L47" height="15.0" width="126.0" text="Plot Phase Difference"/>
+    <ports identifier="P108" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N48" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="95.0" text="ComplexToPolar"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="21.0" text="FIR"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E61" sources="//@children.10/@ports.0" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@children.2/@ports.1"/>
+    <containedEdges identifier="E64" sources="//@children.10/@children.1/@ports.2" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.10/@children.3/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pn_brockackerman_BrockAckerman.elkg
+++ b/realworld/ptolemy/hierarchical/pn_brockackerman_BrockAckerman.elkg
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="40.0" text="ActorA"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="89.0" text="BlockedIdentity"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="49.0" text="Repeat2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Sleep"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="26.5" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="141.0" text="NondeterministicMerge2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="6.5" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="41.0" text="Starver"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="40.0" text="ActorB"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.5/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="89.0" text="BlockedIdentity"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="49.0" text="Repeat2"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="141.0" text="NondeterministicMerge2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.3 //@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="6.5" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.5/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.5/@ports.2" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="48.0" text="Starver2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="73.0" text="Expression2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pn_countermachine_CounterMachine.elkg
+++ b/realworld/ptolemy/hierarchical/pn_countermachine_CounterMachine.elkg
@@ -1,0 +1,2469 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="58.0" text="UpdateC1"/>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="48.0" text="Equals2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.5 //@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="119.0" text="InstanceOfIncrement"/>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.4/@containedEdges.0 //@children.3/@children.4/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.9" incomingEdges="//@children.3/@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.2 //@children.3/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="61.0" text="LogicalNot"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="38.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.3/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.3/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.4/@children.5/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.4/@children.8/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.3/@children.4/@children.0/@ports.1" targets="//@children.3/@children.4/@children.1/@ports.2"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.4/@children.0/@ports.1" targets="//@children.3/@children.4/@children.3/@ports.2"/>
+      <containedEdges identifier="E38" sources="//@children.3/@children.4/@children.1/@ports.3" targets="//@children.3/@children.4/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.4/@children.2/@ports.0" targets="//@children.3/@children.4/@children.1/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.4/@children.3/@ports.3" targets="//@children.3/@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.3/@children.4/@children.4/@ports.0" targets="//@children.3/@children.4/@children.3/@ports.1"/>
+      <containedEdges identifier="E42" sources="//@children.3/@children.4/@children.5/@ports.1" targets="//@children.3/@children.4/@children.3/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.3/@children.4/@children.6/@ports.0" targets="//@children.3/@children.4/@children.8/@ports.2"/>
+      <containedEdges identifier="E44" sources="//@children.3/@children.4/@children.7/@ports.0" targets="//@children.3/@children.4/@children.8/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.3/@children.4/@children.8/@ports.3" targets="//@children.3/@children.4/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N19">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L19" height="15.0" width="125.0" text="InstanceOfDecrement"/>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@containedEdges.0 //@children.3/@children.5/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.10" incomingEdges="//@children.3/@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N20" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.5/@containedEdges.2 //@children.3/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="100.0" text="TransitionFunctio"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.3/@children.5/@containedEdges.5" incomingEdges="//@children.3/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.5/@containedEdges.4" incomingEdges="//@children.3/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L22" height="15.0" width="90.0" text="OutputFunction"/>
+        <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.0 //@children.3/@children.5/@children.2/@containedEdges.1" incomingEdges="//@children.3/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@containedEdges.6" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.2 //@children.3/@children.5/@children.2/@containedEdges.3" incomingEdges="//@children.3/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N23" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L23" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+          <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P56" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N24" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P57" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N25" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P60" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N26" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.1 //@children.3/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P62" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N27" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="42.0" width="46.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="45.0" text="Discard"/>
+          <ports identifier="P67" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E53" sources="//@children.3/@children.5/@children.2/@ports.0" targets="//@children.3/@children.5/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E54" sources="//@children.3/@children.5/@children.2/@ports.0" targets="//@children.3/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E55" sources="//@children.3/@children.5/@children.2/@ports.2" targets="//@children.3/@children.5/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E56" sources="//@children.3/@children.5/@children.2/@ports.2" targets="//@children.3/@children.5/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E57" sources="//@children.3/@children.5/@children.2/@children.0/@ports.3" targets="//@children.3/@children.5/@children.2/@children.4/@ports.0"/>
+        <containedEdges identifier="E58" sources="//@children.3/@children.5/@children.2/@children.1/@ports.0" targets="//@children.3/@children.5/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E59" sources="//@children.3/@children.5/@children.2/@children.2/@ports.1" targets="//@children.3/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E60" sources="//@children.3/@children.5/@children.2/@children.3/@ports.1" targets="//@children.3/@children.5/@children.2/@children.4/@ports.1"/>
+        <containedEdges identifier="E61" sources="//@children.3/@children.5/@children.2/@children.4/@ports.3" targets="//@children.3/@children.5/@children.2/@ports.1"/>
+        <containedEdges identifier="E62" sources="//@children.3/@children.5/@children.2/@children.4/@ports.2" targets="//@children.3/@children.5/@children.2/@children.5/@ports.0"/>
+      </children>
+      <containedEdges identifier="E46" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E47" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.5/@children.2/@ports.2"/>
+      <containedEdges identifier="E48" sources="//@children.3/@children.5/@children.0/@ports.1" targets="//@children.3/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.3/@children.5/@children.0/@ports.1" targets="//@children.3/@children.5/@children.2/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.3/@children.5/@children.1/@ports.2" targets="//@children.3/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.3/@children.5/@children.1/@ports.1" targets="//@children.3/@children.5/@children.1/@ports.2"/>
+      <containedEdges identifier="E52" sources="//@children.3/@children.5/@children.2/@ports.1" targets="//@children.3/@children.5/@ports.1"/>
+    </children>
+    <children identifier="N29">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L29" height="15.0" width="162.0" text="InstanceOfWordLevelSwitch"/>
+      <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.6/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.11" incomingEdges="//@children.3/@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.6/@containedEdges.1 //@children.3/@children.6/@containedEdges.2 //@children.3/@children.6/@containedEdges.3" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.12" incomingEdges="//@children.3/@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N30" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.6/@containedEdges.4 //@children.3/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.6/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.6/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E63" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E65" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.6/@children.2/@ports.1"/>
+      <containedEdges identifier="E66" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.3/@children.6/@children.0/@ports.3" targets="//@children.3/@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.3/@children.6/@children.0/@ports.3" targets="//@children.3/@children.6/@children.3/@ports.1"/>
+      <containedEdges identifier="E69" sources="//@children.3/@children.6/@children.1/@ports.1" targets="//@children.3/@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E70" sources="//@children.3/@children.6/@children.2/@ports.3" targets="//@children.3/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E71" sources="//@children.3/@children.6/@children.2/@ports.2" targets="//@children.3/@children.6/@children.4/@ports.0"/>
+      <containedEdges identifier="E72" sources="//@children.3/@children.6/@children.3/@ports.2" targets="//@children.3/@children.6/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.3/@children.6/@children.3/@ports.3" targets="//@children.3/@children.6/@ports.3"/>
+    </children>
+    <children identifier="N35">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L35" height="15.0" width="169.0" text="InstanceOfWordLevelSwitch2"/>
+      <ports identifier="P87" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.7/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.13" incomingEdges="//@children.3/@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.7/@containedEdges.1 //@children.3/@children.7/@containedEdges.2 //@children.3/@children.7/@containedEdges.3" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.14" incomingEdges="//@children.3/@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N36" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.7/@containedEdges.4 //@children.3/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P98" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.7/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.7/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.7/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P105" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E74" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.7/@children.0/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.7/@children.1/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.7/@children.2/@ports.1"/>
+      <containedEdges identifier="E77" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.7/@children.3/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.3/@children.7/@children.0/@ports.3" targets="//@children.3/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.3/@children.7/@children.0/@ports.3" targets="//@children.3/@children.7/@children.3/@ports.1"/>
+      <containedEdges identifier="E80" sources="//@children.3/@children.7/@children.1/@ports.1" targets="//@children.3/@children.7/@children.0/@ports.2"/>
+      <containedEdges identifier="E81" sources="//@children.3/@children.7/@children.2/@ports.3" targets="//@children.3/@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E82" sources="//@children.3/@children.7/@children.2/@ports.2" targets="//@children.3/@children.7/@children.4/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.3/@children.7/@children.3/@ports.2" targets="//@children.3/@children.7/@ports.1"/>
+      <containedEdges identifier="E84" sources="//@children.3/@children.7/@children.3/@ports.3" targets="//@children.3/@children.7/@ports.3"/>
+    </children>
+    <children identifier="N41">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L41" height="15.0" width="159.0" text="InstanceOfWordLevelSelect"/>
+      <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.8/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.15" incomingEdges="//@children.3/@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.8/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.8/@containedEdges.2" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N42" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.8/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.8/@containedEdges.3 //@children.3/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.8/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.8/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P123" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.8/@containedEdges.8 //@children.3/@children.8/@containedEdges.9 //@children.3/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P124" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E85" sources="//@children.3/@children.8/@ports.0" targets="//@children.3/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.3/@children.8/@ports.2" targets="//@children.3/@children.8/@children.3/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.3/@children.8/@ports.3" targets="//@children.3/@children.8/@children.3/@ports.1"/>
+      <containedEdges identifier="E88" sources="//@children.3/@children.8/@children.0/@ports.3" targets="//@children.3/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.3/@children.8/@children.0/@ports.3" targets="//@children.3/@children.8/@children.3/@ports.2"/>
+      <containedEdges identifier="E90" sources="//@children.3/@children.8/@children.1/@ports.1" targets="//@children.3/@children.8/@children.0/@ports.2"/>
+      <containedEdges identifier="E91" sources="//@children.3/@children.8/@children.2/@ports.3" targets="//@children.3/@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E92" sources="//@children.3/@children.8/@children.2/@ports.2" targets="//@children.3/@children.8/@children.4/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.3/@children.8/@children.3/@ports.3" targets="//@children.3/@children.8/@ports.1"/>
+      <containedEdges identifier="E94" sources="//@children.3/@children.8/@children.3/@ports.3" targets="//@children.3/@children.8/@children.1/@ports.0"/>
+      <containedEdges identifier="E95" sources="//@children.3/@children.8/@children.3/@ports.3" targets="//@children.3/@children.8/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N47">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L47" height="15.0" width="167.0" text="InstanceOfWordLevelSelect2"/>
+      <ports identifier="P125" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.9/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.16" incomingEdges="//@children.3/@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.9/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.9/@containedEdges.2" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N48" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.9/@containedEdges.3 //@children.3/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P134" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P136" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.9/@containedEdges.8 //@children.3/@children.9/@containedEdges.9 //@children.3/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P143" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E96" sources="//@children.3/@children.9/@ports.0" targets="//@children.3/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.3/@children.9/@ports.2" targets="//@children.3/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.3/@children.9/@ports.3" targets="//@children.3/@children.9/@children.3/@ports.1"/>
+      <containedEdges identifier="E99" sources="//@children.3/@children.9/@children.0/@ports.3" targets="//@children.3/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.3/@children.9/@children.0/@ports.3" targets="//@children.3/@children.9/@children.3/@ports.2"/>
+      <containedEdges identifier="E101" sources="//@children.3/@children.9/@children.1/@ports.1" targets="//@children.3/@children.9/@children.0/@ports.2"/>
+      <containedEdges identifier="E102" sources="//@children.3/@children.9/@children.2/@ports.3" targets="//@children.3/@children.9/@children.0/@ports.1"/>
+      <containedEdges identifier="E103" sources="//@children.3/@children.9/@children.2/@ports.2" targets="//@children.3/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.3/@children.9/@children.3/@ports.3" targets="//@children.3/@children.9/@ports.1"/>
+      <containedEdges identifier="E105" sources="//@children.3/@children.9/@children.3/@ports.3" targets="//@children.3/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.3/@children.9/@children.3/@ports.3" targets="//@children.3/@children.9/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.3/@children.6/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.4/@ports.1" targets="//@children.3/@children.8/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.9/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.6/@ports.3" targets="//@children.3/@children.8/@ports.3"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.7/@ports.3" targets="//@children.3/@children.9/@ports.3"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.7/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@ports.2"/>
+  </children>
+  <children identifier="N53" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="85.0" text="SampleDelay3"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L54" height="15.0" width="49.0" text="Program"/>
+    <ports identifier="P146" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11" incomingEdges="//@children.5/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.3" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.5/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N55" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P151" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P153" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P157" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.6 //@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P158" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P160" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N60" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P163" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P164" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P165" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="111.0" text="RecordAssembler2"/>
+      <ports identifier="P168" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N63" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="111.0" text="RecordAssembler3"/>
+      <ports identifier="P171" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N64" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P174" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="64.0" text="Multiplexor"/>
+      <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@containedEdges.12 //@children.5/@containedEdges.13 //@children.5/@containedEdges.14 //@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P178" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N66" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P179" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N67" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+      <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.5/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P183" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P184" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="111.0" text="RecordAssembler4"/>
+      <ports identifier="P185" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P188" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="42.0" text="Const8"/>
+      <ports identifier="P190" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P192" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E107" sources="//@children.5/@ports.4" targets="//@children.5/@children.16/@ports.0"/>
+    <containedEdges identifier="E108" sources="//@children.5/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E109" sources="//@children.5/@ports.0" targets="//@children.5/@children.10/@ports.2"/>
+    <containedEdges identifier="E110" sources="//@children.5/@ports.2" targets="//@children.5/@children.12/@ports.2"/>
+    <containedEdges identifier="E111" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.6/@ports.1"/>
+    <containedEdges identifier="E112" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.7/@ports.1"/>
+    <containedEdges identifier="E113" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.6/@ports.2"/>
+    <containedEdges identifier="E114" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.7/@ports.2"/>
+    <containedEdges identifier="E115" sources="//@children.5/@children.3/@ports.0" targets="//@children.5/@children.8/@ports.1"/>
+    <containedEdges identifier="E116" sources="//@children.5/@children.4/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E117" sources="//@children.5/@children.5/@ports.2" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E118" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@ports.1"/>
+    <containedEdges identifier="E119" sources="//@children.5/@children.6/@ports.0" targets="//@children.5/@children.10/@ports.0"/>
+    <containedEdges identifier="E120" sources="//@children.5/@children.7/@ports.0" targets="//@children.5/@children.10/@ports.0"/>
+    <containedEdges identifier="E121" sources="//@children.5/@children.8/@ports.0" targets="//@children.5/@children.10/@ports.0"/>
+    <containedEdges identifier="E122" sources="//@children.5/@children.9/@ports.0" targets="//@children.5/@children.12/@ports.0"/>
+    <containedEdges identifier="E123" sources="//@children.5/@children.10/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E124" sources="//@children.5/@children.11/@ports.0" targets="//@children.5/@children.12/@ports.1"/>
+    <containedEdges identifier="E125" sources="//@children.5/@children.12/@ports.3" targets="//@children.5/@children.8/@ports.2"/>
+    <containedEdges identifier="E126" sources="//@children.5/@children.13/@ports.0" targets="//@children.5/@children.10/@ports.0"/>
+    <containedEdges identifier="E127" sources="//@children.5/@children.14/@ports.0" targets="//@children.5/@children.13/@ports.2"/>
+    <containedEdges identifier="E128" sources="//@children.5/@children.15/@ports.0" targets="//@children.5/@children.13/@ports.1"/>
+  </children>
+  <children identifier="N72" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N73">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L73" height="15.0" width="58.0" text="UpdateC2"/>
+    <ports identifier="P194" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P195" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P196" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.7/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N74" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P198" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="48.0" text="Equals2"/>
+      <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.1 //@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P200" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.5 //@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P201" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P203" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N78">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L78" height="15.0" width="127.0" text="InstanceOfIncrement2"/>
+      <ports identifier="P205" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.4/@containedEdges.0 //@children.7/@children.4/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P206" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.9" incomingEdges="//@children.7/@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N79" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P208" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.2 //@children.7/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P211" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P212" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P213" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P217" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P218" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P219" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="61.0" text="LogicalNot"/>
+        <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P222" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N85" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L85" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P223" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N86" height="25.0" width="38.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L86" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P225" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N87" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L87" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P229" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.7/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P230" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.7/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E146" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.4/@children.5/@ports.0"/>
+      <containedEdges identifier="E147" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.4/@children.8/@ports.1"/>
+      <containedEdges identifier="E148" sources="//@children.7/@children.4/@children.0/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.2"/>
+      <containedEdges identifier="E149" sources="//@children.7/@children.4/@children.0/@ports.1" targets="//@children.7/@children.4/@children.3/@ports.2"/>
+      <containedEdges identifier="E150" sources="//@children.7/@children.4/@children.1/@ports.3" targets="//@children.7/@children.4/@ports.1"/>
+      <containedEdges identifier="E151" sources="//@children.7/@children.4/@children.2/@ports.0" targets="//@children.7/@children.4/@children.1/@ports.1"/>
+      <containedEdges identifier="E152" sources="//@children.7/@children.4/@children.3/@ports.3" targets="//@children.7/@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E153" sources="//@children.7/@children.4/@children.4/@ports.0" targets="//@children.7/@children.4/@children.3/@ports.1"/>
+      <containedEdges identifier="E154" sources="//@children.7/@children.4/@children.5/@ports.1" targets="//@children.7/@children.4/@children.3/@ports.0"/>
+      <containedEdges identifier="E155" sources="//@children.7/@children.4/@children.6/@ports.0" targets="//@children.7/@children.4/@children.8/@ports.2"/>
+      <containedEdges identifier="E156" sources="//@children.7/@children.4/@children.7/@ports.0" targets="//@children.7/@children.4/@children.8/@ports.0"/>
+      <containedEdges identifier="E157" sources="//@children.7/@children.4/@children.8/@ports.3" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N88">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L88" height="15.0" width="133.0" text="InstanceOfDecrement2"/>
+      <ports identifier="P231" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@containedEdges.0 //@children.7/@children.5/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P232" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.10" incomingEdges="//@children.7/@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N89" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L89" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P234" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.5/@containedEdges.2 //@children.7/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N90" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L90" height="15.0" width="100.0" text="TransitionFunctio"/>
+        <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.7/@children.5/@containedEdges.5" incomingEdges="//@children.7/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P237" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@children.5/@containedEdges.4" incomingEdges="//@children.7/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N91">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L91" height="15.0" width="90.0" text="OutputFunction"/>
+        <ports identifier="P238" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.0 //@children.7/@children.5/@children.2/@containedEdges.1" incomingEdges="//@children.7/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P239" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@containedEdges.6" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P240" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.2 //@children.7/@children.5/@children.2/@containedEdges.3" incomingEdges="//@children.7/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N92" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L92" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+          <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P243" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P244" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N93" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P245" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P248" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N95" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L95" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.1 //@children.7/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P250" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N96" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L96" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P252" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P253" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P254" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N97" height="42.0" width="46.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L97" height="15.0" width="45.0" text="Discard"/>
+          <ports identifier="P255" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E165" sources="//@children.7/@children.5/@children.2/@ports.0" targets="//@children.7/@children.5/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E166" sources="//@children.7/@children.5/@children.2/@ports.0" targets="//@children.7/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E167" sources="//@children.7/@children.5/@children.2/@ports.2" targets="//@children.7/@children.5/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E168" sources="//@children.7/@children.5/@children.2/@ports.2" targets="//@children.7/@children.5/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E169" sources="//@children.7/@children.5/@children.2/@children.0/@ports.3" targets="//@children.7/@children.5/@children.2/@children.4/@ports.0"/>
+        <containedEdges identifier="E170" sources="//@children.7/@children.5/@children.2/@children.1/@ports.0" targets="//@children.7/@children.5/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E171" sources="//@children.7/@children.5/@children.2/@children.2/@ports.1" targets="//@children.7/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E172" sources="//@children.7/@children.5/@children.2/@children.3/@ports.1" targets="//@children.7/@children.5/@children.2/@children.4/@ports.1"/>
+        <containedEdges identifier="E173" sources="//@children.7/@children.5/@children.2/@children.4/@ports.3" targets="//@children.7/@children.5/@children.2/@ports.1"/>
+        <containedEdges identifier="E174" sources="//@children.7/@children.5/@children.2/@children.4/@ports.2" targets="//@children.7/@children.5/@children.2/@children.5/@ports.0"/>
+      </children>
+      <containedEdges identifier="E158" sources="//@children.7/@children.5/@ports.0" targets="//@children.7/@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E159" sources="//@children.7/@children.5/@ports.0" targets="//@children.7/@children.5/@children.2/@ports.2"/>
+      <containedEdges identifier="E160" sources="//@children.7/@children.5/@children.0/@ports.1" targets="//@children.7/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E161" sources="//@children.7/@children.5/@children.0/@ports.1" targets="//@children.7/@children.5/@children.2/@ports.0"/>
+      <containedEdges identifier="E162" sources="//@children.7/@children.5/@children.1/@ports.2" targets="//@children.7/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E163" sources="//@children.7/@children.5/@children.1/@ports.1" targets="//@children.7/@children.5/@children.1/@ports.2"/>
+      <containedEdges identifier="E164" sources="//@children.7/@children.5/@children.2/@ports.1" targets="//@children.7/@children.5/@ports.1"/>
+    </children>
+    <children identifier="N98">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L98" height="15.0" width="162.0" text="InstanceOfWordLevelSwitch"/>
+      <ports identifier="P256" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.6/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P257" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.11" incomingEdges="//@children.7/@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P258" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.6/@containedEdges.1 //@children.7/@children.6/@containedEdges.2 //@children.7/@children.6/@containedEdges.3" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P259" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.12" incomingEdges="//@children.7/@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N99" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P262" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P263" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.6/@containedEdges.4 //@children.7/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N100" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L100" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P265" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N101" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L101" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P267" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P268" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P269" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N102" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L102" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P271" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P272" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.6/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P273" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.6/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N103" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L103" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P274" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E175" sources="//@children.7/@children.6/@ports.0" targets="//@children.7/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E176" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E177" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.6/@children.2/@ports.1"/>
+      <containedEdges identifier="E178" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E179" sources="//@children.7/@children.6/@children.0/@ports.3" targets="//@children.7/@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E180" sources="//@children.7/@children.6/@children.0/@ports.3" targets="//@children.7/@children.6/@children.3/@ports.1"/>
+      <containedEdges identifier="E181" sources="//@children.7/@children.6/@children.1/@ports.1" targets="//@children.7/@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E182" sources="//@children.7/@children.6/@children.2/@ports.3" targets="//@children.7/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E183" sources="//@children.7/@children.6/@children.2/@ports.2" targets="//@children.7/@children.6/@children.4/@ports.0"/>
+      <containedEdges identifier="E184" sources="//@children.7/@children.6/@children.3/@ports.2" targets="//@children.7/@children.6/@ports.1"/>
+      <containedEdges identifier="E185" sources="//@children.7/@children.6/@children.3/@ports.3" targets="//@children.7/@children.6/@ports.3"/>
+    </children>
+    <children identifier="N104">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L104" height="15.0" width="169.0" text="InstanceOfWordLevelSwitch2"/>
+      <ports identifier="P275" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.7/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P276" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.13" incomingEdges="//@children.7/@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P277" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.7/@containedEdges.1 //@children.7/@children.7/@containedEdges.2 //@children.7/@children.7/@containedEdges.3" incomingEdges="//@children.7/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P278" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.14" incomingEdges="//@children.7/@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N105" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L105" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P281" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P282" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.7/@containedEdges.4 //@children.7/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N106" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L106" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P284" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N107" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P286" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P287" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P288" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.7/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P290" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P291" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.7/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P292" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.7/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N109" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L109" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P293" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E186" sources="//@children.7/@children.7/@ports.0" targets="//@children.7/@children.7/@children.0/@ports.0"/>
+      <containedEdges identifier="E187" sources="//@children.7/@children.7/@ports.2" targets="//@children.7/@children.7/@children.1/@ports.0"/>
+      <containedEdges identifier="E188" sources="//@children.7/@children.7/@ports.2" targets="//@children.7/@children.7/@children.2/@ports.1"/>
+      <containedEdges identifier="E189" sources="//@children.7/@children.7/@ports.2" targets="//@children.7/@children.7/@children.3/@ports.0"/>
+      <containedEdges identifier="E190" sources="//@children.7/@children.7/@children.0/@ports.3" targets="//@children.7/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E191" sources="//@children.7/@children.7/@children.0/@ports.3" targets="//@children.7/@children.7/@children.3/@ports.1"/>
+      <containedEdges identifier="E192" sources="//@children.7/@children.7/@children.1/@ports.1" targets="//@children.7/@children.7/@children.0/@ports.2"/>
+      <containedEdges identifier="E193" sources="//@children.7/@children.7/@children.2/@ports.3" targets="//@children.7/@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E194" sources="//@children.7/@children.7/@children.2/@ports.2" targets="//@children.7/@children.7/@children.4/@ports.0"/>
+      <containedEdges identifier="E195" sources="//@children.7/@children.7/@children.3/@ports.2" targets="//@children.7/@children.7/@ports.1"/>
+      <containedEdges identifier="E196" sources="//@children.7/@children.7/@children.3/@ports.3" targets="//@children.7/@children.7/@ports.3"/>
+    </children>
+    <children identifier="N110">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L110" height="15.0" width="159.0" text="InstanceOfWordLevelSelect"/>
+      <ports identifier="P294" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.8/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P295" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.15" incomingEdges="//@children.7/@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P296" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.8/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P297" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.8/@containedEdges.2" incomingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N111" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L111" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.8/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P300" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P301" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.8/@containedEdges.3 //@children.7/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N112" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L112" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.8/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P303" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N113" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L113" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P305" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P306" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P307" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N114" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L114" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.8/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P311" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.8/@containedEdges.8 //@children.7/@children.8/@containedEdges.9 //@children.7/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N115" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L115" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P312" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E197" sources="//@children.7/@children.8/@ports.0" targets="//@children.7/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E198" sources="//@children.7/@children.8/@ports.2" targets="//@children.7/@children.8/@children.3/@ports.0"/>
+      <containedEdges identifier="E199" sources="//@children.7/@children.8/@ports.3" targets="//@children.7/@children.8/@children.3/@ports.1"/>
+      <containedEdges identifier="E200" sources="//@children.7/@children.8/@children.0/@ports.3" targets="//@children.7/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E201" sources="//@children.7/@children.8/@children.0/@ports.3" targets="//@children.7/@children.8/@children.3/@ports.2"/>
+      <containedEdges identifier="E202" sources="//@children.7/@children.8/@children.1/@ports.1" targets="//@children.7/@children.8/@children.0/@ports.2"/>
+      <containedEdges identifier="E203" sources="//@children.7/@children.8/@children.2/@ports.3" targets="//@children.7/@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E204" sources="//@children.7/@children.8/@children.2/@ports.2" targets="//@children.7/@children.8/@children.4/@ports.0"/>
+      <containedEdges identifier="E205" sources="//@children.7/@children.8/@children.3/@ports.3" targets="//@children.7/@children.8/@ports.1"/>
+      <containedEdges identifier="E206" sources="//@children.7/@children.8/@children.3/@ports.3" targets="//@children.7/@children.8/@children.1/@ports.0"/>
+      <containedEdges identifier="E207" sources="//@children.7/@children.8/@children.3/@ports.3" targets="//@children.7/@children.8/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N116">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L116" height="15.0" width="167.0" text="InstanceOfWordLevelSelect2"/>
+      <ports identifier="P313" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.9/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P314" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.16" incomingEdges="//@children.7/@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P315" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.9/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P316" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.9/@containedEdges.2" incomingEdges="//@children.7/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N117" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L117" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P319" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P320" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.9/@containedEdges.3 //@children.7/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N118" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L118" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P322" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N119" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L119" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P324" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P325" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P326" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N120" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L120" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P329" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P330" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.9/@containedEdges.8 //@children.7/@children.9/@containedEdges.9 //@children.7/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N121" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L121" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P331" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E208" sources="//@children.7/@children.9/@ports.0" targets="//@children.7/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E209" sources="//@children.7/@children.9/@ports.2" targets="//@children.7/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E210" sources="//@children.7/@children.9/@ports.3" targets="//@children.7/@children.9/@children.3/@ports.1"/>
+      <containedEdges identifier="E211" sources="//@children.7/@children.9/@children.0/@ports.3" targets="//@children.7/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E212" sources="//@children.7/@children.9/@children.0/@ports.3" targets="//@children.7/@children.9/@children.3/@ports.2"/>
+      <containedEdges identifier="E213" sources="//@children.7/@children.9/@children.1/@ports.1" targets="//@children.7/@children.9/@children.0/@ports.2"/>
+      <containedEdges identifier="E214" sources="//@children.7/@children.9/@children.2/@ports.3" targets="//@children.7/@children.9/@children.0/@ports.1"/>
+      <containedEdges identifier="E215" sources="//@children.7/@children.9/@children.2/@ports.2" targets="//@children.7/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E216" sources="//@children.7/@children.9/@children.3/@ports.3" targets="//@children.7/@children.9/@ports.1"/>
+      <containedEdges identifier="E217" sources="//@children.7/@children.9/@children.3/@ports.3" targets="//@children.7/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E218" sources="//@children.7/@children.9/@children.3/@ports.3" targets="//@children.7/@children.9/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E129" sources="//@children.7/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E130" sources="//@children.7/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E131" sources="//@children.7/@ports.0" targets="//@children.7/@children.6/@ports.2"/>
+    <containedEdges identifier="E132" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E133" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.8/@ports.0"/>
+    <containedEdges identifier="E134" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E135" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.9/@ports.0"/>
+    <containedEdges identifier="E136" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E137" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E138" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.8/@ports.2"/>
+    <containedEdges identifier="E139" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.9/@ports.2"/>
+    <containedEdges identifier="E140" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E141" sources="//@children.7/@children.6/@ports.3" targets="//@children.7/@children.8/@ports.3"/>
+    <containedEdges identifier="E142" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.7/@children.7/@ports.3" targets="//@children.7/@children.9/@ports.3"/>
+    <containedEdges identifier="E144" sources="//@children.7/@children.8/@ports.1" targets="//@children.7/@children.7/@ports.2"/>
+    <containedEdges identifier="E145" sources="//@children.7/@children.9/@ports.1" targets="//@children.7/@ports.2"/>
+  </children>
+  <children identifier="N122" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L122" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N123" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L123" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N124">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L124" height="15.0" width="98.0" text="InstanceOfIsZero"/>
+    <ports identifier="P334" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0 //@children.10/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P335" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.10/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N125" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L125" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.2 //@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N126" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L126" height="15.0" width="100.0" text="TransitionFunctio"/>
+      <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.10/@containedEdges.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P340" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.4" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N127">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L127" height="15.0" width="90.0" text="OutputFunction"/>
+      <ports identifier="P341" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.2/@containedEdges.2" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P342" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.6" incomingEdges="//@children.10/@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P343" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.2/@containedEdges.0 //@children.10/@children.2/@containedEdges.1" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N128" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L128" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.10/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.10/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P346" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.10/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P347" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.10/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N129" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L129" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P348" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.10/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N130" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L130" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P351" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P352" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N131" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L131" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P354" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.10/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E226" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E227" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E228" sources="//@children.10/@children.2/@ports.0" targets="//@children.10/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E229" sources="//@children.10/@children.2/@children.0/@ports.3" targets="//@children.10/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E230" sources="//@children.10/@children.2/@children.1/@ports.0" targets="//@children.10/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E231" sources="//@children.10/@children.2/@children.2/@ports.2" targets="//@children.10/@children.2/@ports.1"/>
+      <containedEdges identifier="E232" sources="//@children.10/@children.2/@children.2/@ports.3" targets="//@children.10/@children.2/@children.3/@ports.0"/>
+    </children>
+    <containedEdges identifier="E219" sources="//@children.10/@ports.0" targets="//@children.10/@children.1/@ports.1"/>
+    <containedEdges identifier="E220" sources="//@children.10/@ports.0" targets="//@children.10/@children.2/@ports.2"/>
+    <containedEdges identifier="E221" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E222" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E223" sources="//@children.10/@children.1/@ports.2" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E224" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.1/@ports.2"/>
+    <containedEdges identifier="E225" sources="//@children.10/@children.2/@ports.1" targets="//@children.10/@ports.1"/>
+  </children>
+  <children identifier="N132">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L132" height="15.0" width="105.0" text="InstanceOfIsZero2"/>
+    <ports identifier="P355" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0 //@children.11/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P356" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.11/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N133" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L133" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P358" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.11/@containedEdges.2 //@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N134" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L134" height="15.0" width="100.0" text="TransitionFunctio"/>
+      <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.11/@containedEdges.5" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P361" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.4" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N135">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L135" height="15.0" width="90.0" text="OutputFunction"/>
+      <ports identifier="P362" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.2" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P363" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.6" incomingEdges="//@children.11/@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P364" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.0 //@children.11/@children.2/@containedEdges.1" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N136" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L136" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.11/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.11/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P367" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.11/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P368" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.11/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N137" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L137" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P369" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.11/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N138" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L138" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P372" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.11/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P373" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.11/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P374" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.11/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N139" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L139" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P375" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.11/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E240" sources="//@children.11/@children.2/@ports.2" targets="//@children.11/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E241" sources="//@children.11/@children.2/@ports.2" targets="//@children.11/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E242" sources="//@children.11/@children.2/@ports.0" targets="//@children.11/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E243" sources="//@children.11/@children.2/@children.0/@ports.3" targets="//@children.11/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E244" sources="//@children.11/@children.2/@children.1/@ports.0" targets="//@children.11/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E245" sources="//@children.11/@children.2/@children.2/@ports.2" targets="//@children.11/@children.2/@ports.1"/>
+      <containedEdges identifier="E246" sources="//@children.11/@children.2/@children.2/@ports.3" targets="//@children.11/@children.2/@children.3/@ports.0"/>
+    </children>
+    <containedEdges identifier="E233" sources="//@children.11/@ports.0" targets="//@children.11/@children.1/@ports.1"/>
+    <containedEdges identifier="E234" sources="//@children.11/@ports.0" targets="//@children.11/@children.2/@ports.2"/>
+    <containedEdges identifier="E235" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.1/@ports.0"/>
+    <containedEdges identifier="E236" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E237" sources="//@children.11/@children.1/@ports.2" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E238" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@children.1/@ports.2"/>
+    <containedEdges identifier="E239" sources="//@children.11/@children.2/@ports.1" targets="//@children.11/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.5/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pn_countermachine_CounterMachinePrelim.elkg
+++ b/realworld/ptolemy/hierarchical/pn_countermachine_CounterMachinePrelim.elkg
@@ -1,0 +1,1049 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="57.0" text="Increment"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.1/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="92.0" text="BooleanSelect2"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="38.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.0" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.3/@ports.3" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.8/@ports.2"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.8/@ports.3" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="63.0" text="Decrement"/>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.4/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.2 //@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="100.0" text="TransitionFunctio"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.4/@containedEdges.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L17" height="15.0" width="90.0" text="OutputFunction"/>
+      <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.0 //@children.4/@children.2/@containedEdges.1" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.6" incomingEdges="//@children.4/@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.2 //@children.4/@children.2/@containedEdges.3" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N18" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.4/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.4/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.4/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.4/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.4/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="82.0" text="LogicFunction"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.2/@containedEdges.1 //@children.4/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.4/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.4/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.4/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E35" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.4/@children.2/@ports.2" targets="//@children.4/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E37" sources="//@children.4/@children.2/@ports.2" targets="//@children.4/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.4/@children.2/@children.0/@ports.3" targets="//@children.4/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.4/@children.2/@children.1/@ports.0" targets="//@children.4/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.4/@children.2/@children.2/@ports.1" targets="//@children.4/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.4/@children.2/@children.3/@ports.1" targets="//@children.4/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E42" sources="//@children.4/@children.2/@children.4/@ports.3" targets="//@children.4/@children.2/@ports.1"/>
+      <containedEdges identifier="E43" sources="//@children.4/@children.2/@children.4/@ports.2" targets="//@children.4/@children.2/@children.5/@ports.0"/>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.4/@ports.0" targets="//@children.4/@children.2/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.4/@children.1/@ports.2" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.1/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N24" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="66.0" text="Sequence2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="36.0" text="IsZero"/>
+    <ports identifier="P58" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.6/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="100.0" text="TransitionFunctio"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.6/@containedEdges.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="90.0" text="OutputFunction"/>
+      <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.2" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.6" incomingEdges="//@children.6/@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.0 //@children.6/@children.2/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N29" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.6/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.6/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.6/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.6/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.6/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.6/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.6/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E51" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E52" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.6/@children.2/@children.0/@ports.3" targets="//@children.6/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.6/@children.2/@children.1/@ports.0" targets="//@children.6/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E56" sources="//@children.6/@children.2/@children.2/@ports.2" targets="//@children.6/@children.2/@ports.1"/>
+      <containedEdges identifier="E57" sources="//@children.6/@children.2/@children.2/@ports.3" targets="//@children.6/@children.2/@children.3/@ports.0"/>
+    </children>
+    <containedEdges identifier="E44" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E45" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.2"/>
+    <containedEdges identifier="E46" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.1/@ports.2"/>
+    <containedEdges identifier="E50" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@ports.1"/>
+  </children>
+  <children identifier="N33" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="66.0" text="Sequence3"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L35" height="15.0" width="97.0" text="WordLevelSelect"/>
+    <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.9/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.2" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N36" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.9/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="92.0" text="BooleanSelect2"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.9/@containedEdges.8 //@children.9/@containedEdges.9 //@children.9/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E58" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.9/@ports.2" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.9/@ports.3" targets="//@children.9/@children.3/@ports.1"/>
+    <containedEdges identifier="E61" sources="//@children.9/@children.0/@ports.3" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.9/@children.0/@ports.3" targets="//@children.9/@children.3/@ports.2"/>
+    <containedEdges identifier="E63" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.0/@ports.2"/>
+    <containedEdges identifier="E64" sources="//@children.9/@children.2/@ports.3" targets="//@children.9/@children.0/@ports.1"/>
+    <containedEdges identifier="E65" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.9/@children.3/@ports.3" targets="//@children.9/@ports.1"/>
+    <containedEdges identifier="E67" sources="//@children.9/@children.3/@ports.3" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.9/@children.3/@ports.3" targets="//@children.9/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N41">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L41" height="15.0" width="100.0" text="WordLevelSwitch"/>
+    <ports identifier="P101" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.10/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1 //@children.10/@containedEdges.2 //@children.10/@containedEdges.3" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.10/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N42" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.10/@containedEdges.4 //@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P119" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E69" sources="//@children.10/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.10/@ports.2" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E71" sources="//@children.10/@ports.2" targets="//@children.10/@children.2/@ports.1"/>
+    <containedEdges identifier="E72" sources="//@children.10/@ports.2" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E73" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E74" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@children.3/@ports.1"/>
+    <containedEdges identifier="E75" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.2"/>
+    <containedEdges identifier="E76" sources="//@children.10/@children.2/@ports.3" targets="//@children.10/@children.0/@ports.1"/>
+    <containedEdges identifier="E77" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@children.4/@ports.0"/>
+    <containedEdges identifier="E78" sources="//@children.10/@children.3/@ports.2" targets="//@children.10/@ports.1"/>
+    <containedEdges identifier="E79" sources="//@children.10/@children.3/@ports.3" targets="//@children.10/@ports.3"/>
+  </children>
+  <children identifier="N47" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="66.0" text="Sequence4"/>
+    <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="66.0" text="Sequence5"/>
+    <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="51.0" text="Display5"/>
+    <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="51.0" text="Display6"/>
+    <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="66.0" text="Sequence6"/>
+    <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="66.0" text="Sequence7"/>
+    <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P130" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="66.0" text="Sequence8"/>
+    <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P132" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N55">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L55" height="15.0" width="128.0" text="IncrementAlmostRight"/>
+    <ports identifier="P133" height="8.0" width="8.0" outgoingEdges="//@children.19/@containedEdges.0 //@children.19/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P134" height="8.0" width="8.0" incomingEdges="//@children.19/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N56" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.19/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P136" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.19/@containedEdges.2 //@children.19/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.19/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.19/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P139" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.19/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P140" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.19/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="25.0" width="38.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P141" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.19/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="92.0" text="BooleanSelect2"/>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.19/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.19/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.19/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P146" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.19/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N60" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P147" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.19/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.19/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.19/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E80" sources="//@children.19/@ports.0" targets="//@children.19/@children.1/@ports.0"/>
+    <containedEdges identifier="E81" sources="//@children.19/@ports.0" targets="//@children.19/@children.5/@ports.0"/>
+    <containedEdges identifier="E82" sources="//@children.19/@children.0/@ports.1" targets="//@children.19/@children.1/@ports.2"/>
+    <containedEdges identifier="E83" sources="//@children.19/@children.0/@ports.1" targets="//@children.19/@children.3/@ports.2"/>
+    <containedEdges identifier="E84" sources="//@children.19/@children.1/@ports.3" targets="//@children.19/@ports.1"/>
+    <containedEdges identifier="E85" sources="//@children.19/@children.2/@ports.0" targets="//@children.19/@children.1/@ports.1"/>
+    <containedEdges identifier="E86" sources="//@children.19/@children.3/@ports.3" targets="//@children.19/@children.0/@ports.0"/>
+    <containedEdges identifier="E87" sources="//@children.19/@children.4/@ports.0" targets="//@children.19/@children.3/@ports.1"/>
+    <containedEdges identifier="E88" sources="//@children.19/@children.5/@ports.1" targets="//@children.19/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N62">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L62" height="15.0" width="122.0" text="IncrementVeryWrong"/>
+    <ports identifier="P151" height="8.0" width="8.0" outgoingEdges="//@children.20/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P152" height="8.0" width="8.0" incomingEdges="//@children.20/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N63" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.20/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.20/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E89" sources="//@children.20/@ports.0" targets="//@children.20/@children.0/@ports.0"/>
+    <containedEdges identifier="E90" sources="//@children.20/@children.0/@ports.1" targets="//@children.20/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.6/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.9/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.10/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.10/@ports.3" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.11/@ports.1" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.12/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.16/@ports.1" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.17/@ports.1" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E14" sources="//@children.18/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pn_countermachine_CounterMachineWithException.elkg
+++ b/realworld/ptolemy/hierarchical/pn_countermachine_CounterMachineWithException.elkg
@@ -1,0 +1,2746 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="58.0" text="UpdateC1"/>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="48.0" text="Equals2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.5 //@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="119.0" text="InstanceOfIncrement"/>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.4/@containedEdges.0 //@children.3/@children.4/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.9" incomingEdges="//@children.3/@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.2 //@children.3/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="61.0" text="LogicalNot"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="38.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.3/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.3/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.3/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.4/@children.5/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.4/@children.8/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.3/@children.4/@children.0/@ports.1" targets="//@children.3/@children.4/@children.1/@ports.2"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.4/@children.0/@ports.1" targets="//@children.3/@children.4/@children.3/@ports.2"/>
+      <containedEdges identifier="E38" sources="//@children.3/@children.4/@children.1/@ports.3" targets="//@children.3/@children.4/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.4/@children.2/@ports.0" targets="//@children.3/@children.4/@children.1/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.4/@children.3/@ports.3" targets="//@children.3/@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.3/@children.4/@children.4/@ports.0" targets="//@children.3/@children.4/@children.3/@ports.1"/>
+      <containedEdges identifier="E42" sources="//@children.3/@children.4/@children.5/@ports.1" targets="//@children.3/@children.4/@children.3/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.3/@children.4/@children.6/@ports.0" targets="//@children.3/@children.4/@children.8/@ports.2"/>
+      <containedEdges identifier="E44" sources="//@children.3/@children.4/@children.7/@ports.0" targets="//@children.3/@children.4/@children.8/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.3/@children.4/@children.8/@ports.3" targets="//@children.3/@children.4/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N19">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L19" height="15.0" width="125.0" text="InstanceOfDecrement"/>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@containedEdges.0 //@children.3/@children.5/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.10" incomingEdges="//@children.3/@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N20" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.5/@containedEdges.2 //@children.3/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="100.0" text="TransitionFunctio"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.3/@children.5/@containedEdges.5" incomingEdges="//@children.3/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.5/@containedEdges.4" incomingEdges="//@children.3/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L22" height="15.0" width="90.0" text="OutputFunction"/>
+        <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.0 //@children.3/@children.5/@children.2/@containedEdges.1" incomingEdges="//@children.3/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@containedEdges.6" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.2 //@children.3/@children.5/@children.2/@containedEdges.3" incomingEdges="//@children.3/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N23" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L23" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+          <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P56" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N24" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P57" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N25" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P60" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N26" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.1 //@children.3/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P62" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N27" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.5/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="42.0" width="46.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="45.0" text="Discard"/>
+          <ports identifier="P67" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E53" sources="//@children.3/@children.5/@children.2/@ports.0" targets="//@children.3/@children.5/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E54" sources="//@children.3/@children.5/@children.2/@ports.0" targets="//@children.3/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E55" sources="//@children.3/@children.5/@children.2/@ports.2" targets="//@children.3/@children.5/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E56" sources="//@children.3/@children.5/@children.2/@ports.2" targets="//@children.3/@children.5/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E57" sources="//@children.3/@children.5/@children.2/@children.0/@ports.3" targets="//@children.3/@children.5/@children.2/@children.4/@ports.0"/>
+        <containedEdges identifier="E58" sources="//@children.3/@children.5/@children.2/@children.1/@ports.0" targets="//@children.3/@children.5/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E59" sources="//@children.3/@children.5/@children.2/@children.2/@ports.1" targets="//@children.3/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E60" sources="//@children.3/@children.5/@children.2/@children.3/@ports.1" targets="//@children.3/@children.5/@children.2/@children.4/@ports.1"/>
+        <containedEdges identifier="E61" sources="//@children.3/@children.5/@children.2/@children.4/@ports.3" targets="//@children.3/@children.5/@children.2/@ports.1"/>
+        <containedEdges identifier="E62" sources="//@children.3/@children.5/@children.2/@children.4/@ports.2" targets="//@children.3/@children.5/@children.2/@children.5/@ports.0"/>
+      </children>
+      <containedEdges identifier="E46" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E47" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.5/@children.2/@ports.2"/>
+      <containedEdges identifier="E48" sources="//@children.3/@children.5/@children.0/@ports.1" targets="//@children.3/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.3/@children.5/@children.0/@ports.1" targets="//@children.3/@children.5/@children.2/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.3/@children.5/@children.1/@ports.2" targets="//@children.3/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.3/@children.5/@children.1/@ports.1" targets="//@children.3/@children.5/@children.1/@ports.2"/>
+      <containedEdges identifier="E52" sources="//@children.3/@children.5/@children.2/@ports.1" targets="//@children.3/@children.5/@ports.1"/>
+    </children>
+    <children identifier="N29">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L29" height="15.0" width="162.0" text="InstanceOfWordLevelSwitch"/>
+      <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.6/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.11" incomingEdges="//@children.3/@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.6/@containedEdges.1 //@children.3/@children.6/@containedEdges.2 //@children.3/@children.6/@containedEdges.3" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.12" incomingEdges="//@children.3/@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N30" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.6/@containedEdges.4 //@children.3/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.6/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.6/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E63" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E65" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.6/@children.2/@ports.1"/>
+      <containedEdges identifier="E66" sources="//@children.3/@children.6/@ports.2" targets="//@children.3/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.3/@children.6/@children.0/@ports.3" targets="//@children.3/@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.3/@children.6/@children.0/@ports.3" targets="//@children.3/@children.6/@children.3/@ports.1"/>
+      <containedEdges identifier="E69" sources="//@children.3/@children.6/@children.1/@ports.1" targets="//@children.3/@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E70" sources="//@children.3/@children.6/@children.2/@ports.3" targets="//@children.3/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E71" sources="//@children.3/@children.6/@children.2/@ports.2" targets="//@children.3/@children.6/@children.4/@ports.0"/>
+      <containedEdges identifier="E72" sources="//@children.3/@children.6/@children.3/@ports.2" targets="//@children.3/@children.6/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.3/@children.6/@children.3/@ports.3" targets="//@children.3/@children.6/@ports.3"/>
+    </children>
+    <children identifier="N35">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L35" height="15.0" width="169.0" text="InstanceOfWordLevelSwitch2"/>
+      <ports identifier="P87" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.7/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.13" incomingEdges="//@children.3/@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.7/@containedEdges.1 //@children.3/@children.7/@containedEdges.2 //@children.3/@children.7/@containedEdges.3" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.14" incomingEdges="//@children.3/@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N36" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.7/@containedEdges.4 //@children.3/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P98" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.7/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.7/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.7/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P105" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E74" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.7/@children.0/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.7/@children.1/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.7/@children.2/@ports.1"/>
+      <containedEdges identifier="E77" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.7/@children.3/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.3/@children.7/@children.0/@ports.3" targets="//@children.3/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.3/@children.7/@children.0/@ports.3" targets="//@children.3/@children.7/@children.3/@ports.1"/>
+      <containedEdges identifier="E80" sources="//@children.3/@children.7/@children.1/@ports.1" targets="//@children.3/@children.7/@children.0/@ports.2"/>
+      <containedEdges identifier="E81" sources="//@children.3/@children.7/@children.2/@ports.3" targets="//@children.3/@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E82" sources="//@children.3/@children.7/@children.2/@ports.2" targets="//@children.3/@children.7/@children.4/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.3/@children.7/@children.3/@ports.2" targets="//@children.3/@children.7/@ports.1"/>
+      <containedEdges identifier="E84" sources="//@children.3/@children.7/@children.3/@ports.3" targets="//@children.3/@children.7/@ports.3"/>
+    </children>
+    <children identifier="N41">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L41" height="15.0" width="159.0" text="InstanceOfWordLevelSelect"/>
+      <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.8/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.15" incomingEdges="//@children.3/@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.8/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.8/@containedEdges.2" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N42" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.8/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.8/@containedEdges.3 //@children.3/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.8/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.8/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P123" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.8/@containedEdges.8 //@children.3/@children.8/@containedEdges.9 //@children.3/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P124" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E85" sources="//@children.3/@children.8/@ports.0" targets="//@children.3/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.3/@children.8/@ports.2" targets="//@children.3/@children.8/@children.3/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.3/@children.8/@ports.3" targets="//@children.3/@children.8/@children.3/@ports.1"/>
+      <containedEdges identifier="E88" sources="//@children.3/@children.8/@children.0/@ports.3" targets="//@children.3/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.3/@children.8/@children.0/@ports.3" targets="//@children.3/@children.8/@children.3/@ports.2"/>
+      <containedEdges identifier="E90" sources="//@children.3/@children.8/@children.1/@ports.1" targets="//@children.3/@children.8/@children.0/@ports.2"/>
+      <containedEdges identifier="E91" sources="//@children.3/@children.8/@children.2/@ports.3" targets="//@children.3/@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E92" sources="//@children.3/@children.8/@children.2/@ports.2" targets="//@children.3/@children.8/@children.4/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.3/@children.8/@children.3/@ports.3" targets="//@children.3/@children.8/@ports.1"/>
+      <containedEdges identifier="E94" sources="//@children.3/@children.8/@children.3/@ports.3" targets="//@children.3/@children.8/@children.1/@ports.0"/>
+      <containedEdges identifier="E95" sources="//@children.3/@children.8/@children.3/@ports.3" targets="//@children.3/@children.8/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N47">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L47" height="15.0" width="167.0" text="InstanceOfWordLevelSelect2"/>
+      <ports identifier="P125" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.9/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.16" incomingEdges="//@children.3/@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.9/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.9/@containedEdges.2" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N48" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.9/@containedEdges.3 //@children.3/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P134" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P136" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.3/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.3/@children.9/@containedEdges.8 //@children.3/@children.9/@containedEdges.9 //@children.3/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P143" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.3/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E96" sources="//@children.3/@children.9/@ports.0" targets="//@children.3/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.3/@children.9/@ports.2" targets="//@children.3/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.3/@children.9/@ports.3" targets="//@children.3/@children.9/@children.3/@ports.1"/>
+      <containedEdges identifier="E99" sources="//@children.3/@children.9/@children.0/@ports.3" targets="//@children.3/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.3/@children.9/@children.0/@ports.3" targets="//@children.3/@children.9/@children.3/@ports.2"/>
+      <containedEdges identifier="E101" sources="//@children.3/@children.9/@children.1/@ports.1" targets="//@children.3/@children.9/@children.0/@ports.2"/>
+      <containedEdges identifier="E102" sources="//@children.3/@children.9/@children.2/@ports.3" targets="//@children.3/@children.9/@children.0/@ports.1"/>
+      <containedEdges identifier="E103" sources="//@children.3/@children.9/@children.2/@ports.2" targets="//@children.3/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.3/@children.9/@children.3/@ports.3" targets="//@children.3/@children.9/@ports.1"/>
+      <containedEdges identifier="E105" sources="//@children.3/@children.9/@children.3/@ports.3" targets="//@children.3/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.3/@children.9/@children.3/@ports.3" targets="//@children.3/@children.9/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.3/@children.6/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.4/@ports.1" targets="//@children.3/@children.8/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.9/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.6/@ports.3" targets="//@children.3/@children.8/@ports.3"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.7/@ports.3" targets="//@children.3/@children.9/@ports.3"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.7/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@ports.2"/>
+  </children>
+  <children identifier="N53" height="25.0" width="26.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="85.0" text="SampleDelay3"/>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N54">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L54" height="15.0" width="49.0" text="Program"/>
+    <ports identifier="P146" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.2 //@children.5/@containedEdges.3 //@children.5/@containedEdges.4 //@children.5/@containedEdges.5 //@children.5/@containedEdges.6" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11" incomingEdges="//@children.5/@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.7" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.5/@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P150" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N55" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P151" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P153" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P155" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+      <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P159" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P161" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <children identifier="N60" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.5/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P164" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.5/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P167" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P168" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P169" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="37.0" text="Select"/>
+      <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@containedEdges.35 //@children.5/@containedEdges.36 //@children.5/@containedEdges.37 //@children.5/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P171" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P172" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N63" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.3 //@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P174" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.16 //@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N64" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="42.0" text="Const9"/>
+      <ports identifier="P175" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="48.0" text="Equals2"/>
+      <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.4 //@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P178" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.19 //@children.5/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N66" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="49.0" text="Const10"/>
+      <ports identifier="P179" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N67" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="48.0" text="Equals3"/>
+      <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.5 //@children.5/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P182" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.22 //@children.5/@containedEdges.23 //@children.5/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="48.0" text="Const11"/>
+      <ports identifier="P183" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="48.0" text="Equals4"/>
+      <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.6 //@children.5/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P186" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.26 //@children.5/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="49.0" text="Const12"/>
+      <ports identifier="P187" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.8 //@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P191" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N72" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L72" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P193" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P194" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P195" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.5/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N73" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="92.0" text="BooleanSelect2"/>
+      <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.5/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.5/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P198" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.5/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P199" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.31 //@children.5/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P202" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="49.0" text="Const13"/>
+      <ports identifier="P203" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P205" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P207" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N78" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L78" height="15.0" width="49.0" text="Const14"/>
+      <ports identifier="P209" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N79" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L79" height="15.0" width="94.0" text="BooleanSwitch3"/>
+      <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P212" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P213" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P214" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.5/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N80" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L80" height="15.0" width="92.0" text="BooleanSelect3"/>
+      <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.5/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.5/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P217" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.5/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P218" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N81" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L81" height="15.0" width="94.0" text="BooleanSwitch4"/>
+      <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P220" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P221" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P222" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.5/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N82" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L82" height="15.0" width="92.0" text="BooleanSelect4"/>
+      <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="10.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.5/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P225" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.5/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P226" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.5/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N83" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L83" height="15.0" width="52.0" text="Discard2"/>
+      <ports identifier="P227" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.5/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <children identifier="N84" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L84" height="15.0" width="52.0" text="Discard3"/>
+      <ports identifier="P228" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.5/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <children identifier="N85" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P229" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="94.0" text="BooleanSwitch5"/>
+      <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P232" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P233" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P234" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.5/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L87" height="15.0" width="52.0" text="Discard4"/>
+      <ports identifier="P235" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.5/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E107" sources="//@children.5/@ports.4" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E108" sources="//@children.5/@ports.0" targets="//@children.5/@children.6/@ports.0"/>
+    <containedEdges identifier="E109" sources="//@children.5/@ports.0" targets="//@children.5/@children.7/@ports.2"/>
+    <containedEdges identifier="E110" sources="//@children.5/@ports.0" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E111" sources="//@children.5/@ports.0" targets="//@children.5/@children.10/@ports.0"/>
+    <containedEdges identifier="E112" sources="//@children.5/@ports.0" targets="//@children.5/@children.12/@ports.0"/>
+    <containedEdges identifier="E113" sources="//@children.5/@ports.0" targets="//@children.5/@children.14/@ports.0"/>
+    <containedEdges identifier="E114" sources="//@children.5/@ports.2" targets="//@children.5/@children.3/@ports.2"/>
+    <containedEdges identifier="E115" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.16/@ports.0"/>
+    <containedEdges identifier="E116" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E117" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.3/@ports.1"/>
+    <containedEdges identifier="E118" sources="//@children.5/@children.3/@ports.3" targets="//@children.5/@children.31/@ports.0"/>
+    <containedEdges identifier="E119" sources="//@children.5/@children.5/@ports.3" targets="//@children.5/@children.17/@ports.0"/>
+    <containedEdges identifier="E120" sources="//@children.5/@children.6/@ports.3" targets="//@children.5/@children.5/@ports.1"/>
+    <containedEdges identifier="E121" sources="//@children.5/@children.6/@ports.2" targets="//@children.5/@children.16/@ports.0"/>
+    <containedEdges identifier="E122" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@ports.1"/>
+    <containedEdges identifier="E123" sources="//@children.5/@children.8/@ports.1" targets="//@children.5/@children.5/@ports.2"/>
+    <containedEdges identifier="E124" sources="//@children.5/@children.8/@ports.1" targets="//@children.5/@children.6/@ports.1"/>
+    <containedEdges identifier="E125" sources="//@children.5/@children.9/@ports.0" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E126" sources="//@children.5/@children.10/@ports.1" targets="//@children.5/@children.17/@ports.1"/>
+    <containedEdges identifier="E127" sources="//@children.5/@children.10/@ports.1" targets="//@children.5/@children.18/@ports.2"/>
+    <containedEdges identifier="E128" sources="//@children.5/@children.11/@ports.0" targets="//@children.5/@children.10/@ports.0"/>
+    <containedEdges identifier="E129" sources="//@children.5/@children.12/@ports.1" targets="//@children.5/@children.24/@ports.1"/>
+    <containedEdges identifier="E130" sources="//@children.5/@children.12/@ports.1" targets="//@children.5/@children.25/@ports.2"/>
+    <containedEdges identifier="E131" sources="//@children.5/@children.12/@ports.1" targets="//@children.5/@children.31/@ports.1"/>
+    <containedEdges identifier="E132" sources="//@children.5/@children.13/@ports.0" targets="//@children.5/@children.12/@ports.0"/>
+    <containedEdges identifier="E133" sources="//@children.5/@children.14/@ports.1" targets="//@children.5/@children.26/@ports.1"/>
+    <containedEdges identifier="E134" sources="//@children.5/@children.14/@ports.1" targets="//@children.5/@children.27/@ports.2"/>
+    <containedEdges identifier="E135" sources="//@children.5/@children.15/@ports.0" targets="//@children.5/@children.14/@ports.0"/>
+    <containedEdges identifier="E136" sources="//@children.5/@children.16/@ports.2" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E137" sources="//@children.5/@children.17/@ports.3" targets="//@children.5/@children.18/@ports.1"/>
+    <containedEdges identifier="E138" sources="//@children.5/@children.17/@ports.2" targets="//@children.5/@children.19/@ports.0"/>
+    <containedEdges identifier="E139" sources="//@children.5/@children.18/@ports.3" targets="//@children.5/@children.24/@ports.0"/>
+    <containedEdges identifier="E140" sources="//@children.5/@children.19/@ports.2" targets="//@children.5/@children.18/@ports.0"/>
+    <containedEdges identifier="E141" sources="//@children.5/@children.20/@ports.0" targets="//@children.5/@children.19/@ports.0"/>
+    <containedEdges identifier="E142" sources="//@children.5/@children.21/@ports.0" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.5/@children.22/@ports.0" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.5/@children.23/@ports.0" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E145" sources="//@children.5/@children.24/@ports.3" targets="//@children.5/@children.25/@ports.1"/>
+    <containedEdges identifier="E146" sources="//@children.5/@children.24/@ports.2" targets="//@children.5/@children.28/@ports.0"/>
+    <containedEdges identifier="E147" sources="//@children.5/@children.25/@ports.3" targets="//@children.5/@children.26/@ports.0"/>
+    <containedEdges identifier="E148" sources="//@children.5/@children.26/@ports.3" targets="//@children.5/@children.27/@ports.1"/>
+    <containedEdges identifier="E149" sources="//@children.5/@children.26/@ports.2" targets="//@children.5/@children.29/@ports.0"/>
+    <containedEdges identifier="E150" sources="//@children.5/@children.27/@ports.3" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E151" sources="//@children.5/@children.30/@ports.0" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E152" sources="//@children.5/@children.31/@ports.2" targets="//@children.5/@children.25/@ports.0"/>
+    <containedEdges identifier="E153" sources="//@children.5/@children.31/@ports.3" targets="//@children.5/@children.32/@ports.0"/>
+  </children>
+  <children identifier="N88" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L88" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N89">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L89" height="15.0" width="58.0" text="UpdateC2"/>
+    <ports identifier="P237" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.7/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N90" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L90" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P241" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N91" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L91" height="15.0" width="48.0" text="Equals2"/>
+      <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.1 //@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P243" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.5 //@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N92" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L92" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P244" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N93" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L93" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P246" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N94">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L94" height="15.0" width="127.0" text="InstanceOfIncrement2"/>
+      <ports identifier="P248" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.4/@containedEdges.0 //@children.7/@children.4/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P249" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.9" incomingEdges="//@children.7/@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N95" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L95" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P251" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.2 //@children.7/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N96" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L96" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P254" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P255" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N97" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L97" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P256" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N98" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L98" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P260" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P261" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N99" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P262" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N100" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L100" height="15.0" width="61.0" text="LogicalNot"/>
+        <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P265" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@children.4/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N101" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L101" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P266" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N102" height="25.0" width="38.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L102" height="15.0" width="42.0" text="Const4"/>
+        <ports identifier="P268" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.7/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N103" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L103" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.4/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P272" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.7/@children.4/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P273" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.7/@children.4/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E171" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.4/@children.5/@ports.0"/>
+      <containedEdges identifier="E172" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.4/@children.8/@ports.1"/>
+      <containedEdges identifier="E173" sources="//@children.7/@children.4/@children.0/@ports.1" targets="//@children.7/@children.4/@children.1/@ports.2"/>
+      <containedEdges identifier="E174" sources="//@children.7/@children.4/@children.0/@ports.1" targets="//@children.7/@children.4/@children.3/@ports.2"/>
+      <containedEdges identifier="E175" sources="//@children.7/@children.4/@children.1/@ports.3" targets="//@children.7/@children.4/@ports.1"/>
+      <containedEdges identifier="E176" sources="//@children.7/@children.4/@children.2/@ports.0" targets="//@children.7/@children.4/@children.1/@ports.1"/>
+      <containedEdges identifier="E177" sources="//@children.7/@children.4/@children.3/@ports.3" targets="//@children.7/@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E178" sources="//@children.7/@children.4/@children.4/@ports.0" targets="//@children.7/@children.4/@children.3/@ports.1"/>
+      <containedEdges identifier="E179" sources="//@children.7/@children.4/@children.5/@ports.1" targets="//@children.7/@children.4/@children.3/@ports.0"/>
+      <containedEdges identifier="E180" sources="//@children.7/@children.4/@children.6/@ports.0" targets="//@children.7/@children.4/@children.8/@ports.2"/>
+      <containedEdges identifier="E181" sources="//@children.7/@children.4/@children.7/@ports.0" targets="//@children.7/@children.4/@children.8/@ports.0"/>
+      <containedEdges identifier="E182" sources="//@children.7/@children.4/@children.8/@ports.3" targets="//@children.7/@children.4/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N104">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L104" height="15.0" width="133.0" text="InstanceOfDecrement2"/>
+      <ports identifier="P274" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@containedEdges.0 //@children.7/@children.5/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P275" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.10" incomingEdges="//@children.7/@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N105" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L105" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P277" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.5/@containedEdges.2 //@children.7/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N106" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L106" height="15.0" width="100.0" text="TransitionFunctio"/>
+        <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.7/@children.5/@containedEdges.5" incomingEdges="//@children.7/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P280" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@children.5/@containedEdges.4" incomingEdges="//@children.7/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N107">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L107" height="15.0" width="90.0" text="OutputFunction"/>
+        <ports identifier="P281" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.0 //@children.7/@children.5/@children.2/@containedEdges.1" incomingEdges="//@children.7/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P282" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@containedEdges.6" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P283" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.2 //@children.7/@children.5/@children.2/@containedEdges.3" incomingEdges="//@children.7/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N108" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L108" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+          <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P286" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P287" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N109" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L109" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P288" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N110" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L110" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P291" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N111" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L111" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.1 //@children.7/@children.5/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P293" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N112" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P295" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P296" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P297" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.5/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="42.0" width="46.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="45.0" text="Discard"/>
+          <ports identifier="P298" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.5/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E190" sources="//@children.7/@children.5/@children.2/@ports.0" targets="//@children.7/@children.5/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E191" sources="//@children.7/@children.5/@children.2/@ports.0" targets="//@children.7/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E192" sources="//@children.7/@children.5/@children.2/@ports.2" targets="//@children.7/@children.5/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E193" sources="//@children.7/@children.5/@children.2/@ports.2" targets="//@children.7/@children.5/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E194" sources="//@children.7/@children.5/@children.2/@children.0/@ports.3" targets="//@children.7/@children.5/@children.2/@children.4/@ports.0"/>
+        <containedEdges identifier="E195" sources="//@children.7/@children.5/@children.2/@children.1/@ports.0" targets="//@children.7/@children.5/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E196" sources="//@children.7/@children.5/@children.2/@children.2/@ports.1" targets="//@children.7/@children.5/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E197" sources="//@children.7/@children.5/@children.2/@children.3/@ports.1" targets="//@children.7/@children.5/@children.2/@children.4/@ports.1"/>
+        <containedEdges identifier="E198" sources="//@children.7/@children.5/@children.2/@children.4/@ports.3" targets="//@children.7/@children.5/@children.2/@ports.1"/>
+        <containedEdges identifier="E199" sources="//@children.7/@children.5/@children.2/@children.4/@ports.2" targets="//@children.7/@children.5/@children.2/@children.5/@ports.0"/>
+      </children>
+      <containedEdges identifier="E183" sources="//@children.7/@children.5/@ports.0" targets="//@children.7/@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E184" sources="//@children.7/@children.5/@ports.0" targets="//@children.7/@children.5/@children.2/@ports.2"/>
+      <containedEdges identifier="E185" sources="//@children.7/@children.5/@children.0/@ports.1" targets="//@children.7/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E186" sources="//@children.7/@children.5/@children.0/@ports.1" targets="//@children.7/@children.5/@children.2/@ports.0"/>
+      <containedEdges identifier="E187" sources="//@children.7/@children.5/@children.1/@ports.2" targets="//@children.7/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E188" sources="//@children.7/@children.5/@children.1/@ports.1" targets="//@children.7/@children.5/@children.1/@ports.2"/>
+      <containedEdges identifier="E189" sources="//@children.7/@children.5/@children.2/@ports.1" targets="//@children.7/@children.5/@ports.1"/>
+    </children>
+    <children identifier="N114">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L114" height="15.0" width="162.0" text="InstanceOfWordLevelSwitch"/>
+      <ports identifier="P299" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.6/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P300" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.11" incomingEdges="//@children.7/@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P301" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.6/@containedEdges.1 //@children.7/@children.6/@containedEdges.2 //@children.7/@children.6/@containedEdges.3" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P302" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.12" incomingEdges="//@children.7/@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N115" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L115" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P305" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P306" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.6/@containedEdges.4 //@children.7/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N116" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L116" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P308" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N117" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L117" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P311" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P312" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N118" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L118" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P314" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P315" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.6/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P316" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.6/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N119" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L119" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P317" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E200" sources="//@children.7/@children.6/@ports.0" targets="//@children.7/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E201" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E202" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.6/@children.2/@ports.1"/>
+      <containedEdges identifier="E203" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E204" sources="//@children.7/@children.6/@children.0/@ports.3" targets="//@children.7/@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E205" sources="//@children.7/@children.6/@children.0/@ports.3" targets="//@children.7/@children.6/@children.3/@ports.1"/>
+      <containedEdges identifier="E206" sources="//@children.7/@children.6/@children.1/@ports.1" targets="//@children.7/@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E207" sources="//@children.7/@children.6/@children.2/@ports.3" targets="//@children.7/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E208" sources="//@children.7/@children.6/@children.2/@ports.2" targets="//@children.7/@children.6/@children.4/@ports.0"/>
+      <containedEdges identifier="E209" sources="//@children.7/@children.6/@children.3/@ports.2" targets="//@children.7/@children.6/@ports.1"/>
+      <containedEdges identifier="E210" sources="//@children.7/@children.6/@children.3/@ports.3" targets="//@children.7/@children.6/@ports.3"/>
+    </children>
+    <children identifier="N120">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L120" height="15.0" width="169.0" text="InstanceOfWordLevelSwitch2"/>
+      <ports identifier="P318" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.7/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P319" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.13" incomingEdges="//@children.7/@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P320" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.7/@containedEdges.1 //@children.7/@children.7/@containedEdges.2 //@children.7/@children.7/@containedEdges.3" incomingEdges="//@children.7/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P321" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.14" incomingEdges="//@children.7/@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N121" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L121" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P324" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P325" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.7/@containedEdges.4 //@children.7/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N122" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L122" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P327" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N123" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L123" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P329" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P330" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P331" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N124" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L124" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.7/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P333" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P334" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.7/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P335" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.7/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N125" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L125" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P336" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E211" sources="//@children.7/@children.7/@ports.0" targets="//@children.7/@children.7/@children.0/@ports.0"/>
+      <containedEdges identifier="E212" sources="//@children.7/@children.7/@ports.2" targets="//@children.7/@children.7/@children.1/@ports.0"/>
+      <containedEdges identifier="E213" sources="//@children.7/@children.7/@ports.2" targets="//@children.7/@children.7/@children.2/@ports.1"/>
+      <containedEdges identifier="E214" sources="//@children.7/@children.7/@ports.2" targets="//@children.7/@children.7/@children.3/@ports.0"/>
+      <containedEdges identifier="E215" sources="//@children.7/@children.7/@children.0/@ports.3" targets="//@children.7/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E216" sources="//@children.7/@children.7/@children.0/@ports.3" targets="//@children.7/@children.7/@children.3/@ports.1"/>
+      <containedEdges identifier="E217" sources="//@children.7/@children.7/@children.1/@ports.1" targets="//@children.7/@children.7/@children.0/@ports.2"/>
+      <containedEdges identifier="E218" sources="//@children.7/@children.7/@children.2/@ports.3" targets="//@children.7/@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E219" sources="//@children.7/@children.7/@children.2/@ports.2" targets="//@children.7/@children.7/@children.4/@ports.0"/>
+      <containedEdges identifier="E220" sources="//@children.7/@children.7/@children.3/@ports.2" targets="//@children.7/@children.7/@ports.1"/>
+      <containedEdges identifier="E221" sources="//@children.7/@children.7/@children.3/@ports.3" targets="//@children.7/@children.7/@ports.3"/>
+    </children>
+    <children identifier="N126">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L126" height="15.0" width="159.0" text="InstanceOfWordLevelSelect"/>
+      <ports identifier="P337" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.8/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P338" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.15" incomingEdges="//@children.7/@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P339" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.8/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P340" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.8/@containedEdges.2" incomingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N127" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L127" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.8/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P343" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P344" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.8/@containedEdges.3 //@children.7/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N128" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L128" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.8/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P346" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N129" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L129" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P348" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P349" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P350" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N130" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L130" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.8/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P354" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.8/@containedEdges.8 //@children.7/@children.8/@containedEdges.9 //@children.7/@children.8/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N131" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L131" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P355" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E222" sources="//@children.7/@children.8/@ports.0" targets="//@children.7/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E223" sources="//@children.7/@children.8/@ports.2" targets="//@children.7/@children.8/@children.3/@ports.0"/>
+      <containedEdges identifier="E224" sources="//@children.7/@children.8/@ports.3" targets="//@children.7/@children.8/@children.3/@ports.1"/>
+      <containedEdges identifier="E225" sources="//@children.7/@children.8/@children.0/@ports.3" targets="//@children.7/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E226" sources="//@children.7/@children.8/@children.0/@ports.3" targets="//@children.7/@children.8/@children.3/@ports.2"/>
+      <containedEdges identifier="E227" sources="//@children.7/@children.8/@children.1/@ports.1" targets="//@children.7/@children.8/@children.0/@ports.2"/>
+      <containedEdges identifier="E228" sources="//@children.7/@children.8/@children.2/@ports.3" targets="//@children.7/@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E229" sources="//@children.7/@children.8/@children.2/@ports.2" targets="//@children.7/@children.8/@children.4/@ports.0"/>
+      <containedEdges identifier="E230" sources="//@children.7/@children.8/@children.3/@ports.3" targets="//@children.7/@children.8/@ports.1"/>
+      <containedEdges identifier="E231" sources="//@children.7/@children.8/@children.3/@ports.3" targets="//@children.7/@children.8/@children.1/@ports.0"/>
+      <containedEdges identifier="E232" sources="//@children.7/@children.8/@children.3/@ports.3" targets="//@children.7/@children.8/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N132">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L132" height="15.0" width="167.0" text="InstanceOfWordLevelSelect2"/>
+      <ports identifier="P356" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.9/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P357" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.16" incomingEdges="//@children.7/@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P358" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.9/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P359" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.9/@containedEdges.2" incomingEdges="//@children.7/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N133" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L133" height="15.0" width="84.0" text="BooleanSelect"/>
+        <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.9/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P361" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P362" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P363" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.9/@containedEdges.3 //@children.7/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N134" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L134" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P365" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.7/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N135" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L135" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P367" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.7/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P368" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.7/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P369" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.7/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N136" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L136" height="15.0" width="92.0" text="BooleanSelect2"/>
+        <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P372" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P373" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.9/@containedEdges.8 //@children.7/@children.9/@containedEdges.9 //@children.7/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N137" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L137" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P374" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.7/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E233" sources="//@children.7/@children.9/@ports.0" targets="//@children.7/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E234" sources="//@children.7/@children.9/@ports.2" targets="//@children.7/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E235" sources="//@children.7/@children.9/@ports.3" targets="//@children.7/@children.9/@children.3/@ports.1"/>
+      <containedEdges identifier="E236" sources="//@children.7/@children.9/@children.0/@ports.3" targets="//@children.7/@children.9/@children.2/@ports.0"/>
+      <containedEdges identifier="E237" sources="//@children.7/@children.9/@children.0/@ports.3" targets="//@children.7/@children.9/@children.3/@ports.2"/>
+      <containedEdges identifier="E238" sources="//@children.7/@children.9/@children.1/@ports.1" targets="//@children.7/@children.9/@children.0/@ports.2"/>
+      <containedEdges identifier="E239" sources="//@children.7/@children.9/@children.2/@ports.3" targets="//@children.7/@children.9/@children.0/@ports.1"/>
+      <containedEdges identifier="E240" sources="//@children.7/@children.9/@children.2/@ports.2" targets="//@children.7/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E241" sources="//@children.7/@children.9/@children.3/@ports.3" targets="//@children.7/@children.9/@ports.1"/>
+      <containedEdges identifier="E242" sources="//@children.7/@children.9/@children.3/@ports.3" targets="//@children.7/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E243" sources="//@children.7/@children.9/@children.3/@ports.3" targets="//@children.7/@children.9/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E154" sources="//@children.7/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E155" sources="//@children.7/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E156" sources="//@children.7/@ports.0" targets="//@children.7/@children.6/@ports.2"/>
+    <containedEdges identifier="E157" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E158" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.8/@ports.0"/>
+    <containedEdges identifier="E159" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E160" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.9/@ports.0"/>
+    <containedEdges identifier="E161" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E162" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E163" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.8/@ports.2"/>
+    <containedEdges identifier="E164" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.9/@ports.2"/>
+    <containedEdges identifier="E165" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E166" sources="//@children.7/@children.6/@ports.3" targets="//@children.7/@children.8/@ports.3"/>
+    <containedEdges identifier="E167" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E168" sources="//@children.7/@children.7/@ports.3" targets="//@children.7/@children.9/@ports.3"/>
+    <containedEdges identifier="E169" sources="//@children.7/@children.8/@ports.1" targets="//@children.7/@children.7/@ports.2"/>
+    <containedEdges identifier="E170" sources="//@children.7/@children.9/@ports.1" targets="//@children.7/@ports.2"/>
+  </children>
+  <children identifier="N138" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L138" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N139" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N140">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L140" height="15.0" width="98.0" text="InstanceOfIsZero"/>
+    <ports identifier="P377" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0 //@children.10/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P378" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.10/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N141" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L141" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P379" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P380" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.2 //@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N142" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L142" height="15.0" width="100.0" text="TransitionFunctio"/>
+      <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.10/@containedEdges.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P383" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.4" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N143">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L143" height="15.0" width="90.0" text="OutputFunction"/>
+      <ports identifier="P384" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.2/@containedEdges.2" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P385" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.6" incomingEdges="//@children.10/@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P386" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.2/@containedEdges.0 //@children.10/@children.2/@containedEdges.1" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N144" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L144" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.10/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P388" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.10/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P389" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.10/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P390" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.10/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N145" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L145" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P391" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.10/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N146" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L146" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P394" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P395" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P396" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N147" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L147" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P397" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.10/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E251" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E252" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E253" sources="//@children.10/@children.2/@ports.0" targets="//@children.10/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E254" sources="//@children.10/@children.2/@children.0/@ports.3" targets="//@children.10/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E255" sources="//@children.10/@children.2/@children.1/@ports.0" targets="//@children.10/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E256" sources="//@children.10/@children.2/@children.2/@ports.2" targets="//@children.10/@children.2/@ports.1"/>
+      <containedEdges identifier="E257" sources="//@children.10/@children.2/@children.2/@ports.3" targets="//@children.10/@children.2/@children.3/@ports.0"/>
+    </children>
+    <containedEdges identifier="E244" sources="//@children.10/@ports.0" targets="//@children.10/@children.1/@ports.1"/>
+    <containedEdges identifier="E245" sources="//@children.10/@ports.0" targets="//@children.10/@children.2/@ports.2"/>
+    <containedEdges identifier="E246" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E247" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E248" sources="//@children.10/@children.1/@ports.2" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E249" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.1/@ports.2"/>
+    <containedEdges identifier="E250" sources="//@children.10/@children.2/@ports.1" targets="//@children.10/@ports.1"/>
+  </children>
+  <children identifier="N148">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L148" height="15.0" width="105.0" text="InstanceOfIsZero2"/>
+    <ports identifier="P398" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0 //@children.11/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P399" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.11/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N149" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L149" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P401" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.11/@containedEdges.2 //@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N150" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L150" height="15.0" width="100.0" text="TransitionFunctio"/>
+      <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.11/@containedEdges.5" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P404" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.4" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N151">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L151" height="15.0" width="90.0" text="OutputFunction"/>
+      <ports identifier="P405" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.2" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P406" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.6" incomingEdges="//@children.11/@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P407" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@containedEdges.0 //@children.11/@children.2/@containedEdges.1" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N152" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L152" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P408" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.11/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.11/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P410" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.11/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P411" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.11/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N153" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L153" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P412" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.11/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P413" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N154" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L154" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P415" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.11/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P416" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.11/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P417" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.11/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N155" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L155" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P418" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.11/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E265" sources="//@children.11/@children.2/@ports.2" targets="//@children.11/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E266" sources="//@children.11/@children.2/@ports.2" targets="//@children.11/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E267" sources="//@children.11/@children.2/@ports.0" targets="//@children.11/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E268" sources="//@children.11/@children.2/@children.0/@ports.3" targets="//@children.11/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E269" sources="//@children.11/@children.2/@children.1/@ports.0" targets="//@children.11/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E270" sources="//@children.11/@children.2/@children.2/@ports.2" targets="//@children.11/@children.2/@ports.1"/>
+      <containedEdges identifier="E271" sources="//@children.11/@children.2/@children.2/@ports.3" targets="//@children.11/@children.2/@children.3/@ports.0"/>
+    </children>
+    <containedEdges identifier="E258" sources="//@children.11/@ports.0" targets="//@children.11/@children.1/@ports.1"/>
+    <containedEdges identifier="E259" sources="//@children.11/@ports.0" targets="//@children.11/@children.2/@ports.2"/>
+    <containedEdges identifier="E260" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.1/@ports.0"/>
+    <containedEdges identifier="E261" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E262" sources="//@children.11/@children.1/@ports.2" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E263" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@children.1/@ports.2"/>
+    <containedEdges identifier="E264" sources="//@children.11/@children.2/@ports.1" targets="//@children.11/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.1" targets="//@children.5/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pn_stack_Stack.elkg
+++ b/realworld/ptolemy/hierarchical/pn_stack_Stack.elkg
@@ -1,0 +1,550 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="80.0" text="StackCounter"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="92.0" text="BooleanSelect2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="92.0" text="BooleanSelect3"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="85.0" text="SampleDelay2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="72.0" text="CondConst1"/>
+      <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.8/@containedEdges.0 //@children.0/@children.8/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.19" incomingEdges="//@children.0/@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N11" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.8/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.8/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="40.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.0/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E37" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.8/@children.0/@ports.2" targets="//@children.0/@children.8/@children.1/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.8/@children.0/@ports.3" targets="//@children.0/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.8/@children.1/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    </children>
+    <children identifier="N14" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="72.0" text="CondConst2"/>
+      <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.10/@containedEdges.0 //@children.0/@children.10/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.21" incomingEdges="//@children.0/@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N16" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.10/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="40.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.0/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E42" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.10/@children.0/@ports.2" targets="//@children.0/@children.10/@children.1/@ports.1"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.10/@children.0/@ports.3" targets="//@children.0/@children.10/@children.2/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.0/@children.10/@children.1/@ports.0" targets="//@children.0/@children.10/@ports.1"/>
+    </children>
+    <children identifier="N19">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L19" height="15.0" width="72.0" text="CondConst3"/>
+      <ports identifier="P48" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.11/@containedEdges.0 //@children.0/@children.11/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.22" incomingEdges="//@children.0/@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N20" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.11/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.11/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="40.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@children.11/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.0/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E47" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.11/@children.0/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.11/@children.0/@ports.1"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.11/@children.0/@ports.2" targets="//@children.0/@children.11/@children.1/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.11/@children.0/@ports.3" targets="//@children.0/@children.11/@children.2/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.11/@children.1/@ports.0" targets="//@children.0/@children.11/@ports.1"/>
+    </children>
+    <children identifier="N23" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="69.0" text="LogicalNot2"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.5/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.5/@ports.3" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.11/@ports.1" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+  </children>
+  <children identifier="N24" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="25.0" width="30.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="94.0" text="BooleanSwitch2"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.3/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/psdf_blindcommunication_BlindCommunication.elkg
+++ b/realworld/ptolemy/hierarchical/psdf_blindcommunication_BlindCommunication.elkg
@@ -1,0 +1,825 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="75.0" text="AudioReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="119.0" text="CartesianToComplex"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="118.0" text="Baud Rate Estimate"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="70.0" text="Demodulate"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.3/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="25.0" width="264.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="136.0" text="ConvertBinToFrequency"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="264.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="250.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="58.0" text="Mix Down"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="250.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="145.0" text="PlotSpectrumWithCarrier"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="88.0" text="ArrayMaximum"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="597.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="105.0" text="RegenerateCarrier"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="597.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="163.0" text="PlotSpectrumWithoutCarrier"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="73.0" text="Periodogram"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="132.0" text="SmoothedPeriodogram"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.11 //@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.3/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.3/@ports.2" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.1/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="114.0" text="BaudRateEstimator"/>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.4/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N16" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="31.0" text="Chop"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="84.0" text="AbsoluteValue"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="24.0" text="FFT"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="81.0" text="PhaseUnwrap"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="91.0" text="AbsoluteValue2"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="298.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="193.0" text="ConvertBinAndOffsetToFrequency"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="298.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="88.0" text="ArrayMaximum"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="95.0" text="ComplexToPolar"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="31.0" y="5.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="60.0" text="Differential"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.4/@ports.1" targets="//@children.4/@children.8/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.9/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.4/@children.5/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.4/@children.7/@ports.2" targets="//@children.4/@children.6/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.4/@children.8/@ports.2" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.4/@children.9/@ports.1" targets="//@children.4/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="95.0" text="Carrier Estimate"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="63.0" text="Resampler"/>
+    <ports identifier="P57" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11" incomingEdges="//@children.6/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.6/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="157.0" text="GenerateResamplingSignal"/>
+      <ports identifier="P61" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3" incomingEdges="//@children.6/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N29" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="242.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="95.0" text="IncrementPhase"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="242.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.3 //@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="25.0" width="90.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="122.0" text="IdentifyBaudSamples"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E45" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E47" sources="//@children.6/@children.0/@children.0/@ports.1" targets="//@children.6/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E48" sources="//@children.6/@children.0/@children.1/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.6/@children.0/@children.1/@ports.0" targets="//@children.6/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.6/@children.0/@children.2/@ports.0" targets="//@children.6/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N32" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="66.0" text="CountTrues"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E38" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.6/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@ports.3"/>
+  </children>
+  <children identifier="N35">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L35" height="15.0" width="132.0" text="PhaseStatesEstimator"/>
+    <ports identifier="P79" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.7/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N36" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="95.0" text="ComplexToPolar"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="31.0" y="5.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="111.0" text="ComputeHistogram"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="103.0" text="ArrayPeakSearch"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="71.0" text="ArrayLength"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="87.0" text="MovingAverage"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="60.0" text="Differential"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="25.0" width="570.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="32.0" text="Wrap"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="570.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E51" sources="//@children.7/@ports.2" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.7/@children.2/@ports.3" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@ports.1"/>
+    <containedEdges identifier="E56" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.2/@ports.2"/>
+    <containedEdges identifier="E58" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.8/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.7/@children.8/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N45" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="82.0" text="Sample Count"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="77.0" text="Phase states"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L47" height="15.0" width="126.0" text="Plot Phase Difference"/>
+    <ports identifier="P108" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N48" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="95.0" text="ComplexToPolar"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="21.0" text="FIR"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E61" sources="//@children.10/@ports.0" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@children.2/@ports.1"/>
+    <containedEdges identifier="E64" sources="//@children.10/@children.1/@ports.2" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.10/@children.3/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/psdf_speech_Speech.elkg
+++ b/realworld/ptolemy/hierarchical/psdf_speech_Speech.elkg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="88.0" text="process blocks"/>
+    <ports identifier="P3" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="64.0" text="Quantizer2"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L6" height="15.0" width="49.0" text="Decoder"/>
+      <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@children.1/@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.3/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N7" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="96.0" text="RecursiveLattice"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.3/@children.0/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.1/@children.3/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="88.0" text="Autocorrelation"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="88.0" text="LevinsonDurbin"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="49.0" text="Encoder"/>
+      <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.7" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N11" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="40.0" text="Lattice"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="64.0" text="Quantizer2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.1/@children.6/@children.0/@ports.1" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.1/@children.6/@children.1/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="75.0" text="AudioReader"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="71.0" text="AudioPlayer"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E2" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.5/@ports.3" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptalon_smallworld_SmallWorldMultiInstanceComposite.elkg
+++ b/realworld/ptolemy/hierarchical/ptalon_smallworld_SmallWorldMultiInstanceComposite.elkg
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Initiator"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="WirelessToWired"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="47.0" text="Average"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="134.0" text="AverageNumberOfHops"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="46.0" text="Counter"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="89.0" text="NumberOfLinks"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="101.0" text="ExpressionWriter"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="140.0" text="MultiInstanceComposite"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="49.0" text="Previous"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.4 //@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.7 //@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="113.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="113.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.8/@containedEdges.8 //@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="38.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.8/@children.5/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.8/@children.7/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.5/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@children.6/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.8/@children.4/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.8/@children.5/@ports.2" targets="//@children.8/@children.2/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.8/@children.5/@ports.2" targets="//@children.8/@children.4/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.8/@children.7/@ports.0" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.8/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_chat_ChatClient.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_chat_ChatClient.elkg
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="87.0" text="InteractiveShell"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="HttpPost"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="143.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="143.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="45.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="45.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="45.0" text="HttpGet"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="132.0" text="FilterEmptyResponses"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.9/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="31.0" width="81.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="85.0" text="StringFunction"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@children.9/@containedEdges.1 //@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="87.0" text="StringCompare"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="18.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.9/@children.1/@ports.2" targets="//@children.9/@children.2/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.9/@children.2/@ports.3" targets="//@children.9/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_chat_ChatServer.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_chat_ChatServer.elkg
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="63.0" text="HttpActor2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="63.0" text="HttpActor3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="92.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="135.0" text="InstanceOfWaitForPost"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.8/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.1 //@children.8/@containedEdges.2" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N10" height="36.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="39.0" text="Queue"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="28.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="102.0" text="RespondIfNeeded"/>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.2/@containedEdges.0" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.2/@containedEdges.1" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.5 //@children.8/@containedEdges.6" incomingEdges="//@children.8/@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="95.0" text="ResettableTimer"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="25.0" width="154.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="154.0" y="8.5" outgoingEdges="//@children.8/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="25.0" width="114.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="68.0" text="StringConst"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="114.0" y="8.5" outgoingEdges="//@children.8/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@containedEdges.1 //@children.8/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E21" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E22" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.8/@children.2/@children.0/@ports.1" targets="//@children.8/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.8/@children.2/@children.1/@ports.0" targets="//@children.8/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.8/@children.2/@children.2/@ports.0" targets="//@children.8/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.8/@children.2/@children.3/@ports.1" targets="//@children.8/@children.2/@ports.2"/>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.8/@ports.2" targets="//@children.8/@children.2/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.8/@ports.1" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.1/@ports.2"/>
+    <containedEdges identifier="E18" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.8/@children.2/@ports.2" targets="//@children.8/@children.0/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.2/@ports.2" targets="//@children.8/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="143.0" text="InstanceOfWaitForPost2"/>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.9/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1 //@children.9/@containedEdges.2" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N18" height="36.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="39.0" text="Queue"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="46.0" y="14.0" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="10.0" y="36.0" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="28.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N20">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L20" height="15.0" width="102.0" text="RespondIfNeeded"/>
+      <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.2/@containedEdges.0" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.2/@containedEdges.1" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.5 //@children.9/@containedEdges.6" incomingEdges="//@children.9/@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N21" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="95.0" text="ResettableTimer"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="25.0" width="154.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="154.0" y="8.5" outgoingEdges="//@children.9/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="114.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="68.0" text="StringConst"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="114.0" y="8.5" outgoingEdges="//@children.9/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.2/@containedEdges.1 //@children.9/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.9/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.9/@children.2/@ports.0" targets="//@children.9/@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.9/@children.2/@children.0/@ports.1" targets="//@children.9/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E37" sources="//@children.9/@children.2/@children.1/@ports.0" targets="//@children.9/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.9/@children.2/@children.2/@ports.0" targets="//@children.9/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.9/@children.2/@children.3/@ports.1" targets="//@children.9/@children.2/@ports.2"/>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.9/@ports.2" targets="//@children.9/@children.2/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.9/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.9/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.1/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.0/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_eplus70actuator_EPlus70Actuator.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_eplus70actuator_EPlus70Actuator.elkg
@@ -1,0 +1,1286 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="EPlusSimulator"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.0/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="70.0" text="TOutRecord"/>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.10" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.5 //@children.0/@children.0/@containedEdges.6" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.9" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.8" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.7" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1 //@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.4" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@children.0/@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@children.0/@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="8"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3" incomingEdges="//@children.0/@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="9"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@children.0/@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="10"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="111.0" text="RecordAssembler2"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="111.0" text="RecordAssembler3"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="111.0" text="RecordAssembler4"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="25.0" width="353.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="353.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="111.0" text="RecordAssembler5"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="25.0" width="64.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="25.0" width="178.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="178.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="25.0" width="165.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="165.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="64.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E43" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E47" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.0/@ports.4" targets="//@children.0/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@children.0/@children.5/@ports.2"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@ports.9"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.7"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.8"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.10"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.3"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.6"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.0/@children.6/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.0/@children.7/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.0/@children.8/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.0/@children.9/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.3"/>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="117.0" text="VectorDisassembler"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11 //@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14 //@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="52.0" text="RunTime"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="88.0" text="WallClockTime"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="90.0" text="SimulationTime"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.17 //@children.0/@containedEdges.18 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="78.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="110.0" text="PlotterTemperature"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="56.0" text="Simulator"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="125.0" text="PlotterSolarIrradiation"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="101.0" text="shadingController"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.22 //@children.0/@containedEdges.23 //@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="79.0" text="PlotterControl"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="150.0" text="PlotterFractionShadingOn"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.0/@children.0/@ports.6" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.0/@ports.7" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.0/@ports.8" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.0/@ports.9" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.0/@ports.10" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="28.0" text="TOut"/>
+    <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.1/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="59.0" text="TOutArray"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="25.0" width="80.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="63.0" text="EmptyItem"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E64" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E67" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E68" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E69" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E70" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.4/@ports.3"/>
+    <containedEdges identifier="E71" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E72" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N36">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L36" height="15.0" width="95.0" text="FractionShading"/>
+    <ports identifier="P90" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.2/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N37" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="59.0" text="TOutArray"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="25.0" width="80.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="63.0" text="EmptyItem"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P108" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P110" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E73" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E74" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E75" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E76" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E77" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.2"/>
+    <containedEdges identifier="E78" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E79" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.4/@ports.3"/>
+    <containedEdges identifier="E80" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E81" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N45">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L45" height="15.0" width="77.0" text="extWinSolinc"/>
+    <ports identifier="P112" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N46" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="59.0" text="TOutArray"/>
+      <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P117" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="25.0" width="80.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+      <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="63.0" text="EmptyItem"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P128" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E82" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E83" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E84" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E85" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E86" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.1/@ports.2"/>
+    <containedEdges identifier="E87" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.3/@ports.2"/>
+    <containedEdges identifier="E88" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.4/@ports.3"/>
+    <containedEdges identifier="E89" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E90" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N54">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L54" height="15.0" width="45.0" text="yShade"/>
+    <ports identifier="P134" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N55" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="59.0" text="TOutArray"/>
+      <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P137" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P139" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="25.0" width="80.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P142" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P144" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="63.0" text="EmptyItem"/>
+      <ports identifier="P146" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N60" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P150" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P152" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P154" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E91" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E92" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E93" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+    <containedEdges identifier="E94" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E95" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.1/@ports.2"/>
+    <containedEdges identifier="E96" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.3/@ports.2"/>
+    <containedEdges identifier="E97" sources="//@children.4/@children.5/@ports.0" targets="//@children.4/@children.4/@ports.3"/>
+    <containedEdges identifier="E98" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E99" sources="//@children.4/@children.7/@ports.0" targets="//@children.4/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N63">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L63" height="15.0" width="36.0" text="TZone"/>
+    <ports identifier="P156" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.5/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N64" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="59.0" text="TOutArray"/>
+      <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P159" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P161" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N66" height="25.0" width="80.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P164" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N67" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+      <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="63.0" text="EmptyItem"/>
+      <ports identifier="P168" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P172" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P174" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P176" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E100" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E101" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E102" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+    <containedEdges identifier="E103" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E104" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.1/@ports.2"/>
+    <containedEdges identifier="E105" sources="//@children.5/@children.4/@ports.0" targets="//@children.5/@children.3/@ports.2"/>
+    <containedEdges identifier="E106" sources="//@children.5/@children.5/@ports.0" targets="//@children.5/@children.4/@ports.3"/>
+    <containedEdges identifier="E107" sources="//@children.5/@children.6/@ports.0" targets="//@children.5/@children.4/@ports.1"/>
+    <containedEdges identifier="E108" sources="//@children.5/@children.7/@ports.0" targets="//@children.5/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N72" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L72" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5 //@containedEdges.7 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P179" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N73" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L73" height="15.0" width="107.0" text="ElementsToArray2"/>
+    <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P181" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N74" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P183" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L75" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P185" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N76" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="109.0" text="DygraphsJSPlotter"/>
+    <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N78" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="89.0" text="TokenToJSON2"/>
+    <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P190" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.4" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_guidance_Guidance.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_guidance_Guidance.elkg
@@ -1,0 +1,1143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.51 //@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="32.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="119.0" text="HTMLModelExporter"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="-4.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="12.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="36.0" incomingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="42.0" text="Const6"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="42.0" text="Const7"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Const8"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const9"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="49.0" text="Const10"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="90.0" text="AssignLocation"/>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.10 //@children.13/@containedEdges.11 //@children.13/@containedEdges.12 //@children.13/@containedEdges.13 //@children.13/@containedEdges.14" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.15 //@children.13/@containedEdges.16 //@children.13/@containedEdges.17 //@children.13/@containedEdges.18 //@children.13/@containedEdges.19" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.0 //@children.13/@containedEdges.1 //@children.13/@containedEdges.2 //@children.13/@containedEdges.3 //@children.13/@containedEdges.4 //@children.13/@containedEdges.5 //@children.13/@containedEdges.6 //@children.13/@containedEdges.7 //@children.13/@containedEdges.8 //@children.13/@containedEdges.9" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@containedEdges.26 //@containedEdges.27 //@containedEdges.28 //@containedEdges.29 //@containedEdges.30 //@containedEdges.31 //@containedEdges.32 //@containedEdges.33 //@containedEdges.34 //@containedEdges.35 //@containedEdges.36" incomingEdges="//@children.13/@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="25.0" width="30.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="30.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="30.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="30.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="30.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="30.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@containedEdges.10 //@children.13/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@containedEdges.25 //@children.13/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="74.0" text="SetVariable4"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="84.0" text="StringMatches"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.29 //@children.13/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.13/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.13/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.13/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.13/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="92.0" text="StringMatches2"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.32 //@children.13/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="92.0" text="StringMatches3"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.34 //@children.13/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="92.0" text="StringMatches4"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.36 //@children.13/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="92.0" text="StringMatches5"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.38 //@children.13/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@containedEdges.11 //@children.13/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@containedEdges.40 //@children.13/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="92.0" text="BooleanSelect2"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.13/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.13/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.13/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.13/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="92.0" text="BooleanSelect3"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.13/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.13/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.13/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.13/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="94.0" text="BooleanSwitch3"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@containedEdges.12 //@children.13/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@containedEdges.44 //@children.13/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="74.0" text="SetVariable5"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="74.0" text="SetVariable6"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="94.0" text="BooleanSwitch4"/>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@containedEdges.13 //@children.13/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@containedEdges.47 //@children.13/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="92.0" text="BooleanSelect4"/>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.13/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.13/@containedEdges.54">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.13/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.13/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="74.0" text="SetVariable7"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="74.0" text="SetVariable8"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="94.0" text="BooleanSwitch5"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@containedEdges.14 //@children.13/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.13/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.13/@containedEdges.51 //@children.13/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.13/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="92.0" text="BooleanSelect5"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.13/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.13/@containedEdges.56">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.13/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.13/@containedEdges.54">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="74.0" text="SetVariable9"/>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="81.0" text="SetVariable10"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.52">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.56">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E54" sources="//@children.13/@ports.2" targets="//@children.13/@children.0/@ports.1"/>
+    <containedEdges identifier="E55" sources="//@children.13/@ports.2" targets="//@children.13/@children.1/@ports.1"/>
+    <containedEdges identifier="E56" sources="//@children.13/@ports.2" targets="//@children.13/@children.2/@ports.1"/>
+    <containedEdges identifier="E57" sources="//@children.13/@ports.2" targets="//@children.13/@children.3/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.13/@ports.2" targets="//@children.13/@children.4/@ports.1"/>
+    <containedEdges identifier="E59" sources="//@children.13/@ports.2" targets="//@children.13/@children.10/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.13/@ports.2" targets="//@children.13/@children.12/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.13/@ports.2" targets="//@children.13/@children.13/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.13/@ports.2" targets="//@children.13/@children.14/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.13/@ports.2" targets="//@children.13/@children.15/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.13/@ports.0" targets="//@children.13/@children.5/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.13/@ports.0" targets="//@children.13/@children.16/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.13/@ports.0" targets="//@children.13/@children.19/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.13/@ports.0" targets="//@children.13/@children.22/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.13/@ports.0" targets="//@children.13/@children.26/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.13/@ports.1" targets="//@children.13/@children.5/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.13/@ports.1" targets="//@children.13/@children.16/@ports.0"/>
+    <containedEdges identifier="E71" sources="//@children.13/@ports.1" targets="//@children.13/@children.19/@ports.0"/>
+    <containedEdges identifier="E72" sources="//@children.13/@ports.1" targets="//@children.13/@children.22/@ports.0"/>
+    <containedEdges identifier="E73" sources="//@children.13/@ports.1" targets="//@children.13/@children.26/@ports.0"/>
+    <containedEdges identifier="E74" sources="//@children.13/@children.0/@ports.0" targets="//@children.13/@children.10/@ports.1"/>
+    <containedEdges identifier="E75" sources="//@children.13/@children.1/@ports.0" targets="//@children.13/@children.12/@ports.1"/>
+    <containedEdges identifier="E76" sources="//@children.13/@children.2/@ports.0" targets="//@children.13/@children.13/@ports.1"/>
+    <containedEdges identifier="E77" sources="//@children.13/@children.3/@ports.0" targets="//@children.13/@children.14/@ports.1"/>
+    <containedEdges identifier="E78" sources="//@children.13/@children.4/@ports.0" targets="//@children.13/@children.15/@ports.1"/>
+    <containedEdges identifier="E79" sources="//@children.13/@children.5/@ports.2" targets="//@children.13/@children.6/@ports.0"/>
+    <containedEdges identifier="E80" sources="//@children.13/@children.5/@ports.2" targets="//@children.13/@children.7/@ports.0"/>
+    <containedEdges identifier="E81" sources="//@children.13/@children.6/@ports.1" targets="//@children.13/@children.11/@ports.0"/>
+    <containedEdges identifier="E82" sources="//@children.13/@children.8/@ports.1" targets="//@children.13/@children.17/@ports.0"/>
+    <containedEdges identifier="E83" sources="//@children.13/@children.10/@ports.2" targets="//@children.13/@children.5/@ports.1"/>
+    <containedEdges identifier="E84" sources="//@children.13/@children.10/@ports.2" targets="//@children.13/@children.11/@ports.2"/>
+    <containedEdges identifier="E85" sources="//@children.13/@children.11/@ports.3" targets="//@children.13/@ports.3"/>
+    <containedEdges identifier="E86" sources="//@children.13/@children.12/@ports.2" targets="//@children.13/@children.16/@ports.1"/>
+    <containedEdges identifier="E87" sources="//@children.13/@children.12/@ports.2" targets="//@children.13/@children.17/@ports.2"/>
+    <containedEdges identifier="E88" sources="//@children.13/@children.13/@ports.2" targets="//@children.13/@children.18/@ports.2"/>
+    <containedEdges identifier="E89" sources="//@children.13/@children.13/@ports.2" targets="//@children.13/@children.19/@ports.1"/>
+    <containedEdges identifier="E90" sources="//@children.13/@children.14/@ports.2" targets="//@children.13/@children.22/@ports.1"/>
+    <containedEdges identifier="E91" sources="//@children.13/@children.14/@ports.2" targets="//@children.13/@children.23/@ports.2"/>
+    <containedEdges identifier="E92" sources="//@children.13/@children.15/@ports.2" targets="//@children.13/@children.26/@ports.1"/>
+    <containedEdges identifier="E93" sources="//@children.13/@children.15/@ports.2" targets="//@children.13/@children.27/@ports.2"/>
+    <containedEdges identifier="E94" sources="//@children.13/@children.16/@ports.2" targets="//@children.13/@children.8/@ports.0"/>
+    <containedEdges identifier="E95" sources="//@children.13/@children.16/@ports.2" targets="//@children.13/@children.9/@ports.0"/>
+    <containedEdges identifier="E96" sources="//@children.13/@children.17/@ports.3" targets="//@children.13/@children.11/@ports.1"/>
+    <containedEdges identifier="E97" sources="//@children.13/@children.18/@ports.3" targets="//@children.13/@children.17/@ports.1"/>
+    <containedEdges identifier="E98" sources="//@children.13/@children.19/@ports.2" targets="//@children.13/@children.20/@ports.0"/>
+    <containedEdges identifier="E99" sources="//@children.13/@children.19/@ports.2" targets="//@children.13/@children.21/@ports.0"/>
+    <containedEdges identifier="E100" sources="//@children.13/@children.20/@ports.1" targets="//@children.13/@children.18/@ports.0"/>
+    <containedEdges identifier="E101" sources="//@children.13/@children.22/@ports.2" targets="//@children.13/@children.24/@ports.0"/>
+    <containedEdges identifier="E102" sources="//@children.13/@children.22/@ports.2" targets="//@children.13/@children.25/@ports.0"/>
+    <containedEdges identifier="E103" sources="//@children.13/@children.23/@ports.3" targets="//@children.13/@children.18/@ports.1"/>
+    <containedEdges identifier="E104" sources="//@children.13/@children.24/@ports.1" targets="//@children.13/@children.23/@ports.0"/>
+    <containedEdges identifier="E105" sources="//@children.13/@children.26/@ports.2" targets="//@children.13/@children.28/@ports.0"/>
+    <containedEdges identifier="E106" sources="//@children.13/@children.26/@ports.2" targets="//@children.13/@children.29/@ports.0"/>
+    <containedEdges identifier="E107" sources="//@children.13/@children.26/@ports.3" targets="//@children.13/@children.30/@ports.1"/>
+    <containedEdges identifier="E108" sources="//@children.13/@children.27/@ports.3" targets="//@children.13/@children.23/@ports.1"/>
+    <containedEdges identifier="E109" sources="//@children.13/@children.28/@ports.1" targets="//@children.13/@children.27/@ports.0"/>
+    <containedEdges identifier="E110" sources="//@children.13/@children.30/@ports.0" targets="//@children.13/@children.27/@ports.1"/>
+  </children>
+  <children identifier="N46" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="126.0" text="HTMLModelExporter2"/>
+    <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="-4.0" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P135" height="8.0" width="8.0" x="-8.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="12.0" incomingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="36.0" incomingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="48.0" text="Const11"/>
+    <ports identifier="P146" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="49.0" text="Const12"/>
+    <ports identifier="P148" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N49" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L49" height="15.0" width="49.0" text="Const13"/>
+    <ports identifier="P150" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N50" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="49.0" text="Const14"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N51" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L51" height="15.0" width="49.0" text="Const15"/>
+    <ports identifier="P154" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N52" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L52" height="15.0" width="49.0" text="Const16"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N53" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L53" height="15.0" width="49.0" text="Const17"/>
+    <ports identifier="P158" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N54" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L54" height="15.0" width="49.0" text="Const18"/>
+    <ports identifier="P160" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N55" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="49.0" text="Const19"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="25.0" width="25.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="49.0" text="Const20"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N57" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L57" height="15.0" width="49.0" text="Const32"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N58" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L58" height="15.0" width="128.0" text="RecordDisassembler3"/>
+    <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N59" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L59" height="15.0" width="120.0" text="ExpressionToToken2"/>
+    <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.49">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N60" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L60" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.51">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N61" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L61" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P175" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.3" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.5" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.3" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.3" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.3" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.3" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.3" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.3" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.3" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.1/@ports.3" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.1/@ports.4" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.11" targets="//@children.28/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.5/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.6/@ports.0" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E21" sources="//@children.7/@ports.0" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E22" sources="//@children.8/@ports.0" targets="//@children.2/@ports.5"/>
+  <containedEdges identifier="E23" sources="//@children.9/@ports.0" targets="//@children.2/@ports.6"/>
+  <containedEdges identifier="E24" sources="//@children.10/@ports.0" targets="//@children.2/@ports.7"/>
+  <containedEdges identifier="E25" sources="//@children.11/@ports.0" targets="//@children.2/@ports.8"/>
+  <containedEdges identifier="E26" sources="//@children.12/@ports.0" targets="//@children.2/@ports.9"/>
+  <containedEdges identifier="E27" sources="//@children.13/@ports.3" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.13/@ports.3" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.13/@ports.3" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.13/@ports.3" targets="//@children.18/@ports.1"/>
+  <containedEdges identifier="E31" sources="//@children.13/@ports.3" targets="//@children.19/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.13/@ports.3" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E33" sources="//@children.13/@ports.3" targets="//@children.21/@ports.1"/>
+  <containedEdges identifier="E34" sources="//@children.13/@ports.3" targets="//@children.22/@ports.1"/>
+  <containedEdges identifier="E35" sources="//@children.13/@ports.3" targets="//@children.23/@ports.1"/>
+  <containedEdges identifier="E36" sources="//@children.13/@ports.3" targets="//@children.24/@ports.1"/>
+  <containedEdges identifier="E37" sources="//@children.13/@ports.3" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E38" sources="//@children.14/@ports.11" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E39" sources="//@children.15/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E40" sources="//@children.16/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.17/@ports.0" targets="//@children.14/@ports.2"/>
+  <containedEdges identifier="E42" sources="//@children.18/@ports.0" targets="//@children.14/@ports.3"/>
+  <containedEdges identifier="E43" sources="//@children.19/@ports.0" targets="//@children.14/@ports.4"/>
+  <containedEdges identifier="E44" sources="//@children.20/@ports.0" targets="//@children.14/@ports.5"/>
+  <containedEdges identifier="E45" sources="//@children.21/@ports.0" targets="//@children.14/@ports.6"/>
+  <containedEdges identifier="E46" sources="//@children.22/@ports.0" targets="//@children.14/@ports.7"/>
+  <containedEdges identifier="E47" sources="//@children.23/@ports.0" targets="//@children.14/@ports.8"/>
+  <containedEdges identifier="E48" sources="//@children.24/@ports.0" targets="//@children.14/@ports.9"/>
+  <containedEdges identifier="E49" sources="//@children.25/@ports.0" targets="//@children.14/@ports.10"/>
+  <containedEdges identifier="E50" sources="//@children.26/@ports.1" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E51" sources="//@children.27/@ports.1" targets="//@children.2/@ports.10"/>
+  <containedEdges identifier="E52" sources="//@children.28/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E53" sources="//@children.29/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_optimizationadvisor_OptimizationAdvisor.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_optimizationadvisor_OptimizationAdvisor.elkg
@@ -1,0 +1,1852 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Simulator"/>
+    <ports identifier="P6" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L3" height="15.0" width="90.0" text="RoomSimulator"/>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@children.1/@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@children.1/@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@children.1/@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N4">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L4" height="15.0" width="29.0" text="room"/>
+        <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0 //@children.1/@children.0/@containedEdges.1 //@children.1/@children.0/@containedEdges.2" incomingEdges="//@children.1/@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N5" height="25.0" width="274.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P20" height="8.0" width="8.0" x="274.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.1/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.1/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N6" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L6" height="15.0" width="74.0" text="Accumulator"/>
+          <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.0/@containedEdges.3 //@children.1/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N7" height="25.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L7" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P28" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E52" sources="//@children.1/@children.0/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E53" sources="//@children.1/@children.0/@children.0/@ports.2" targets="//@children.1/@children.0/@children.0/@children.0/@ports.3"/>
+        <containedEdges identifier="E54" sources="//@children.1/@children.0/@children.0/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E55" sources="//@children.1/@children.0/@children.0/@children.1/@ports.1" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E56" sources="//@children.1/@children.0/@children.0/@children.1/@ports.1" targets="//@children.1/@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E57" sources="//@children.1/@children.0/@children.0/@children.2/@ports.1" targets="//@children.1/@children.0/@children.0/@children.0/@ports.2"/>
+      </children>
+      <children identifier="N8" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="28.0" text="TOut"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L9" height="15.0" width="65.0" text="PController"/>
+        <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.2/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.4 //@children.1/@children.0/@containedEdges.5" incomingEdges="//@children.1/@children.0/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N10" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L10" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N11" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L11" height="15.0" width="17.0" text="Kp"/>
+          <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N12" height="25.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L12" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P38" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E58" sources="//@children.1/@children.0/@children.2/@ports.0" targets="//@children.1/@children.0/@children.2/@children.1/@ports.0"/>
+        <containedEdges identifier="E59" sources="//@children.1/@children.0/@children.2/@children.0/@ports.1" targets="//@children.1/@children.0/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E60" sources="//@children.1/@children.0/@children.2/@children.1/@ports.1" targets="//@children.1/@children.0/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E61" sources="//@children.1/@children.0/@children.2/@children.2/@ports.1" targets="//@children.1/@children.0/@children.2/@ports.1"/>
+      </children>
+      <children identifier="N13" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="68.0" text="controlError"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L14" height="15.0" width="46.0" text="TSetPoi"/>
+        <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.7 //@children.1/@children.0/@containedEdges.8 //@children.1/@children.0/@containedEdges.9" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N15" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="72.0" text="pastMorning"/>
+          <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="25.0" width="51.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="49.0" text="dayStart"/>
+          <ports identifier="P47" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="48.0" text="pastDay"/>
+          <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="25.0" width="58.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="56.0" text="nightStart"/>
+          <ports identifier="P52" height="8.0" width="8.0" x="58.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N19" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L19" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.1 //@children.1/@children.0/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N20" height="25.0" width="125.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L20" height="15.0" width="46.0" text="TSetPoi"/>
+          <ports identifier="P56" height="8.0" width="8.0" x="125.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N21" height="25.0" width="76.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L21" height="15.0" width="61.0" text="timeOfDay"/>
+          <ports identifier="P58" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.4/@containedEdges.7 //@children.1/@children.0/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.4/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E62" sources="//@children.1/@children.0/@children.4/@ports.0" targets="//@children.1/@children.0/@children.4/@children.6/@ports.1"/>
+        <containedEdges identifier="E63" sources="//@children.1/@children.0/@children.4/@children.0/@ports.2" targets="//@children.1/@children.0/@children.4/@children.4/@ports.0"/>
+        <containedEdges identifier="E64" sources="//@children.1/@children.0/@children.4/@children.1/@ports.0" targets="//@children.1/@children.0/@children.4/@children.0/@ports.1"/>
+        <containedEdges identifier="E65" sources="//@children.1/@children.0/@children.4/@children.2/@ports.2" targets="//@children.1/@children.0/@children.4/@children.4/@ports.0"/>
+        <containedEdges identifier="E66" sources="//@children.1/@children.0/@children.4/@children.3/@ports.0" targets="//@children.1/@children.0/@children.4/@children.2/@ports.0"/>
+        <containedEdges identifier="E67" sources="//@children.1/@children.0/@children.4/@children.4/@ports.1" targets="//@children.1/@children.0/@children.4/@children.5/@ports.1"/>
+        <containedEdges identifier="E68" sources="//@children.1/@children.0/@children.4/@children.5/@ports.0" targets="//@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E69" sources="//@children.1/@children.0/@children.4/@children.6/@ports.0" targets="//@children.1/@children.0/@children.4/@children.0/@ports.0"/>
+        <containedEdges identifier="E70" sources="//@children.1/@children.0/@children.4/@children.6/@ports.0" targets="//@children.1/@children.0/@children.4/@children.2/@ports.1"/>
+      </children>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.10 //@children.1/@children.0/@containedEdges.11 //@children.1/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="76.0" text="HeaterStates"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.13 //@children.1/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="97.0" text="SequencePlotter"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.1 //@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L25" height="15.0" width="70.0" text="TOutRecord"/>
+        <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.7 //@children.1/@children.0/@children.8/@containedEdges.8" incomingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.3" incomingEdges="//@children.1/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.4 //@children.1/@children.0/@children.8/@containedEdges.5 //@children.1/@children.0/@children.8/@containedEdges.6" incomingEdges="//@children.1/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.0 //@children.1/@children.0/@children.8/@containedEdges.1 //@children.1/@children.0/@children.8/@containedEdges.2" incomingEdges="//@children.1/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.16" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.15" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.17" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N26" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="111.0" text="RecordAssembler5"/>
+          <ports identifier="P72" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N27" height="25.0" width="147.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="73.0" text="Expression4"/>
+          <ports identifier="P75" height="8.0" width="8.0" x="147.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="111.0" text="RecordAssembler2"/>
+          <ports identifier="P78" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N29" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="104.0" text="RecordAssembler"/>
+          <ports identifier="P81" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N30" height="25.0" width="147.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L30" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P85" height="8.0" width="8.0" x="147.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.8/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@children.0/@children.8/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E71" sources="//@children.1/@children.0/@children.8/@ports.3" targets="//@children.1/@children.0/@children.8/@children.0/@ports.1"/>
+        <containedEdges identifier="E72" sources="//@children.1/@children.0/@children.8/@ports.3" targets="//@children.1/@children.0/@children.8/@children.1/@ports.1"/>
+        <containedEdges identifier="E73" sources="//@children.1/@children.0/@children.8/@ports.3" targets="//@children.1/@children.0/@children.8/@children.2/@ports.1"/>
+        <containedEdges identifier="E74" sources="//@children.1/@children.0/@children.8/@ports.1" targets="//@children.1/@children.0/@children.8/@children.2/@ports.2"/>
+        <containedEdges identifier="E75" sources="//@children.1/@children.0/@children.8/@ports.2" targets="//@children.1/@children.0/@children.8/@children.1/@ports.2"/>
+        <containedEdges identifier="E76" sources="//@children.1/@children.0/@children.8/@ports.2" targets="//@children.1/@children.0/@children.8/@children.3/@ports.3"/>
+        <containedEdges identifier="E77" sources="//@children.1/@children.0/@children.8/@ports.2" targets="//@children.1/@children.0/@children.8/@children.4/@ports.2"/>
+        <containedEdges identifier="E78" sources="//@children.1/@children.0/@children.8/@ports.0" targets="//@children.1/@children.0/@children.8/@children.0/@ports.2"/>
+        <containedEdges identifier="E79" sources="//@children.1/@children.0/@children.8/@ports.0" targets="//@children.1/@children.0/@children.8/@children.4/@ports.1"/>
+        <containedEdges identifier="E80" sources="//@children.1/@children.0/@children.8/@children.0/@ports.0" targets="//@children.1/@children.0/@children.8/@ports.4"/>
+        <containedEdges identifier="E81" sources="//@children.1/@children.0/@children.8/@children.1/@ports.0" targets="//@children.1/@children.0/@children.8/@children.3/@ports.1"/>
+        <containedEdges identifier="E82" sources="//@children.1/@children.0/@children.8/@children.2/@ports.0" targets="//@children.1/@children.0/@children.8/@ports.5"/>
+        <containedEdges identifier="E83" sources="//@children.1/@children.0/@children.8/@children.3/@ports.0" targets="//@children.1/@children.0/@children.8/@ports.6"/>
+        <containedEdges identifier="E84" sources="//@children.1/@children.0/@children.8/@children.4/@ports.0" targets="//@children.1/@children.0/@children.8/@children.3/@ports.2"/>
+      </children>
+      <children identifier="N31" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="25.0" width="95.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="95.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L33" height="15.0" width="49.0" text="IdleTime"/>
+        <ports identifier="P92" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.1" incomingEdges="//@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.20" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N34" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L34" height="15.0" width="72.0" text="pastMorning"/>
+          <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P97" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N35" height="25.0" width="78.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L35" height="15.0" width="49.0" text="dayStart"/>
+          <ports identifier="P98" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N36" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L36" height="15.0" width="48.0" text="pastDay"/>
+          <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N37" height="25.0" width="119.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L37" height="15.0" width="56.0" text="nightStart"/>
+          <ports identifier="P103" height="8.0" width="8.0" x="119.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N38" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L38" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.2 //@children.1/@children.0/@children.11/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P106" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N39" height="25.0" width="116.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L39" height="15.0" width="46.0" text="TSetPoi"/>
+          <ports identifier="P107" height="8.0" width="8.0" x="116.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N40" height="25.0" width="76.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L40" height="15.0" width="61.0" text="timeOfDay"/>
+          <ports identifier="P110" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.11/@containedEdges.8 //@children.1/@children.0/@children.11/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.11/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E85" sources="//@children.1/@children.0/@children.11/@ports.2" targets="//@children.1/@children.0/@children.11/@children.6/@ports.1"/>
+        <containedEdges identifier="E86" sources="//@children.1/@children.0/@children.11/@ports.0" targets="//@children.1/@children.0/@children.11/@children.5/@ports.2"/>
+        <containedEdges identifier="E87" sources="//@children.1/@children.0/@children.11/@children.0/@ports.2" targets="//@children.1/@children.0/@children.11/@children.4/@ports.0"/>
+        <containedEdges identifier="E88" sources="//@children.1/@children.0/@children.11/@children.1/@ports.0" targets="//@children.1/@children.0/@children.11/@children.0/@ports.1"/>
+        <containedEdges identifier="E89" sources="//@children.1/@children.0/@children.11/@children.2/@ports.2" targets="//@children.1/@children.0/@children.11/@children.4/@ports.0"/>
+        <containedEdges identifier="E90" sources="//@children.1/@children.0/@children.11/@children.3/@ports.0" targets="//@children.1/@children.0/@children.11/@children.2/@ports.0"/>
+        <containedEdges identifier="E91" sources="//@children.1/@children.0/@children.11/@children.4/@ports.1" targets="//@children.1/@children.0/@children.11/@children.5/@ports.1"/>
+        <containedEdges identifier="E92" sources="//@children.1/@children.0/@children.11/@children.5/@ports.0" targets="//@children.1/@children.0/@children.11/@ports.1"/>
+        <containedEdges identifier="E93" sources="//@children.1/@children.0/@children.11/@children.6/@ports.0" targets="//@children.1/@children.0/@children.11/@children.0/@ports.0"/>
+        <containedEdges identifier="E94" sources="//@children.1/@children.0/@children.11/@children.6/@ports.0" targets="//@children.1/@children.0/@children.11/@children.2/@ports.1"/>
+      </children>
+      <children identifier="N41" height="25.0" width="86.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P112" height="8.0" width="8.0" x="86.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E29" sources="//@children.1/@children.0/@children.0/@ports.1" targets="//@children.1/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.0/@children.0/@ports.1" targets="//@children.1/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.1/@children.0/@children.0/@ports.1" targets="//@children.1/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.0/@children.1/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.0/@children.2/@ports.1" targets="//@children.1/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.0/@children.2/@ports.1" targets="//@children.1/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.0/@children.3/@ports.2" targets="//@children.1/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.0/@children.4/@ports.1" targets="//@children.1/@children.0/@children.11/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.0/@children.4/@ports.1" targets="//@children.1/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.1/@children.0/@children.4/@ports.1" targets="//@children.1/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.0/@children.5/@ports.0" targets="//@children.1/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.0/@children.5/@ports.0" targets="//@children.1/@children.0/@children.11/@ports.2"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.0/@children.5/@ports.0" targets="//@children.1/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.0/@children.6/@ports.1" targets="//@children.1/@children.0/@children.8/@ports.2"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.0/@children.6/@ports.1" targets="//@children.1/@children.0/@children.12/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.0/@children.8/@ports.5" targets="//@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E45" sources="//@children.1/@children.0/@children.8/@ports.4" targets="//@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.1/@children.0/@children.8/@ports.6" targets="//@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E47" sources="//@children.1/@children.0/@children.9/@ports.1" targets="//@children.1/@children.0/@children.8/@ports.3"/>
+      <containedEdges identifier="E48" sources="//@children.1/@children.0/@children.10/@ports.0" targets="//@children.1/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.1/@children.0/@children.11/@ports.1" targets="//@children.1/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.1/@children.0/@children.12/@ports.0" targets="//@children.1/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.1/@children.0/@children.13/@ports.1" targets="//@children.1/@children.0/@ports.3"/>
+    </children>
+    <children identifier="N43">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L43" height="15.0" width="97.0" text="ResultProcessor"/>
+      <ports identifier="P117" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@children.1/@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@children.1/@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N44">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L44" height="15.0" width="52.0" text="TDesired"/>
+        <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.0" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.3" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N45" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L45" height="15.0" width="59.0" text="TOutArray"/>
+          <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P125" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="28.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N46" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L46" height="15.0" width="104.0" text="RecordAssembler"/>
+          <ports identifier="P127" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N47" height="25.0" width="80.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L47" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P130" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N48" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L48" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+          <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P132" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N49" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L49" height="15.0" width="63.0" text="EmptyItem"/>
+          <ports identifier="P134" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N50" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L50" height="15.0" width="68.0" text="StringConst"/>
+          <ports identifier="P138" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N51" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L51" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P140" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N52" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L52" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P142" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E105" sources="//@children.1/@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E106" sources="//@children.1/@children.1/@children.0/@children.0/@ports.1" targets="//@children.1/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E107" sources="//@children.1/@children.1/@children.0/@children.1/@ports.0" targets="//@children.1/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E108" sources="//@children.1/@children.1/@children.0/@children.2/@ports.0" targets="//@children.1/@children.1/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E109" sources="//@children.1/@children.1/@children.0/@children.3/@ports.1" targets="//@children.1/@children.1/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E110" sources="//@children.1/@children.1/@children.0/@children.4/@ports.0" targets="//@children.1/@children.1/@children.0/@children.3/@ports.2"/>
+        <containedEdges identifier="E111" sources="//@children.1/@children.1/@children.0/@children.5/@ports.0" targets="//@children.1/@children.1/@children.0/@children.4/@ports.3"/>
+        <containedEdges identifier="E112" sources="//@children.1/@children.1/@children.0/@children.6/@ports.0" targets="//@children.1/@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E113" sources="//@children.1/@children.1/@children.0/@children.7/@ports.0" targets="//@children.1/@children.1/@children.0/@children.4/@ports.2"/>
+      </children>
+      <children identifier="N53">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L53" height="15.0" width="70.0" text="HeaterState"/>
+        <ports identifier="P144" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.0" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P145" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.4" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N54" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L54" height="15.0" width="59.0" text="TOutArray"/>
+          <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P147" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="28.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N55" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L55" height="15.0" width="104.0" text="RecordAssembler"/>
+          <ports identifier="P149" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N56" height="25.0" width="80.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L56" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P152" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N57" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L57" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+          <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P154" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N58" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L58" height="15.0" width="63.0" text="EmptyItem"/>
+          <ports identifier="P156" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@children.1/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N59" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="68.0" text="StringConst"/>
+          <ports identifier="P160" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N60" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L60" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P162" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N61" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L61" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P164" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E114" sources="//@children.1/@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E115" sources="//@children.1/@children.1/@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E116" sources="//@children.1/@children.1/@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.1/@ports.1"/>
+        <containedEdges identifier="E117" sources="//@children.1/@children.1/@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@children.1/@children.1/@ports.1"/>
+        <containedEdges identifier="E118" sources="//@children.1/@children.1/@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@children.1/@children.1/@ports.2"/>
+        <containedEdges identifier="E119" sources="//@children.1/@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.1/@children.3/@ports.2"/>
+        <containedEdges identifier="E120" sources="//@children.1/@children.1/@children.1/@children.5/@ports.0" targets="//@children.1/@children.1/@children.1/@children.4/@ports.3"/>
+        <containedEdges identifier="E121" sources="//@children.1/@children.1/@children.1/@children.6/@ports.0" targets="//@children.1/@children.1/@children.1/@children.4/@ports.1"/>
+        <containedEdges identifier="E122" sources="//@children.1/@children.1/@children.1/@children.7/@ports.0" targets="//@children.1/@children.1/@children.1/@children.4/@ports.2"/>
+      </children>
+      <children identifier="N62">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L62" height="15.0" width="41.0" text="TRoom"/>
+        <ports identifier="P166" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.0" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P167" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.5" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N63" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L63" height="15.0" width="59.0" text="TOutArray"/>
+          <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P169" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="28.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N64" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L64" height="15.0" width="104.0" text="RecordAssembler"/>
+          <ports identifier="P171" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N65" height="25.0" width="80.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L65" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P174" height="8.0" width="8.0" x="80.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N66" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L66" height="15.0" width="125.0" text="ArrayRemoveElement"/>
+          <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P176" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N67" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L67" height="15.0" width="63.0" text="EmptyItem"/>
+          <ports identifier="P178" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@children.1/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N68" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="68.0" text="StringConst"/>
+          <ports identifier="P182" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P184" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P186" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.1/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E123" sources="//@children.1/@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E124" sources="//@children.1/@children.1/@children.2/@children.0/@ports.1" targets="//@children.1/@children.1/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E125" sources="//@children.1/@children.1/@children.2/@children.1/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.1"/>
+        <containedEdges identifier="E126" sources="//@children.1/@children.1/@children.2/@children.2/@ports.0" targets="//@children.1/@children.1/@children.2/@children.1/@ports.1"/>
+        <containedEdges identifier="E127" sources="//@children.1/@children.1/@children.2/@children.3/@ports.1" targets="//@children.1/@children.1/@children.2/@children.1/@ports.2"/>
+        <containedEdges identifier="E128" sources="//@children.1/@children.1/@children.2/@children.4/@ports.0" targets="//@children.1/@children.1/@children.2/@children.3/@ports.2"/>
+        <containedEdges identifier="E129" sources="//@children.1/@children.1/@children.2/@children.5/@ports.0" targets="//@children.1/@children.1/@children.2/@children.4/@ports.3"/>
+        <containedEdges identifier="E130" sources="//@children.1/@children.1/@children.2/@children.6/@ports.0" targets="//@children.1/@children.1/@children.2/@children.4/@ports.1"/>
+        <containedEdges identifier="E131" sources="//@children.1/@children.1/@children.2/@children.7/@ports.0" targets="//@children.1/@children.1/@children.2/@children.4/@ports.2"/>
+      </children>
+      <children identifier="N71" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L71" height="15.0" width="99.0" text="ElementsToArray"/>
+        <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.1/@containedEdges.3 //@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P189" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N72" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="107.0" text="ElementsToArray2"/>
+        <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P191" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N73" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="82.0" text="TokenToJSON"/>
+        <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P193" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N74" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L74" height="15.0" width="89.0" text="TokenToJSON2"/>
+        <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P195" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E95" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E96" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.1/@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.1/@children.1/@children.1/@ports.1" targets="//@children.1/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.1/@children.1/@children.2/@ports.1" targets="//@children.1/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.1/@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.1/@children.1/@children.4/@ports.1" targets="//@children.1/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.1/@children.1/@children.5/@ports.1" targets="//@children.1/@children.1/@ports.3"/>
+      <containedEdges identifier="E104" sources="//@children.1/@children.1/@children.6/@ports.1" targets="//@children.1/@children.1/@ports.4"/>
+    </children>
+    <children identifier="N75" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P197" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P199" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P201" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.0/@ports.3" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.4" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N78">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L78" height="15.0" width="101.0" text="ParseParameters"/>
+    <ports identifier="P202" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.2/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.2/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.2/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N79" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L79" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P208" height="8.0" width="8.0" x="10.0" y="1.7999999523162842" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P209" height="8.0" width="8.0" x="10.0" y="11.600000381469727" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P210" height="8.0" width="8.0" x="10.0" y="21.399999618530273" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P211" height="8.0" width="8.0" x="10.0" y="31.200000762939453" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N80" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L80" height="15.0" width="113.0" text="ExpressionToToken"/>
+      <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P213" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N81" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L81" height="15.0" width="120.0" text="ExpressionToToken2"/>
+      <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P215" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N82" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L82" height="15.0" width="120.0" text="ExpressionToToken3"/>
+      <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P217" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N83" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L83" height="15.0" width="120.0" text="ExpressionToToken4"/>
+      <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P219" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E132" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E133" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E134" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E135" sources="//@children.2/@children.0/@ports.3" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E136" sources="//@children.2/@children.0/@ports.4" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E137" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E138" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E139" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E140" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@ports.4"/>
+  </children>
+  <children identifier="N84">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L84" height="15.0" width="49.0" text="Initiation"/>
+    <ports identifier="P220" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2 //@children.3/@containedEdges.3" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.3/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N85" height="25.0" width="141.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P222" height="8.0" width="8.0" x="141.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="25.0" width="148.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P224" height="8.0" width="8.0" x="148.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N87" height="25.0" width="146.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L87" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P226" height="8.0" width="8.0" x="146.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N88" height="25.0" width="149.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L88" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P228" height="8.0" width="8.0" x="149.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N89" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L89" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P230" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E141" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E142" sources="//@children.3/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E143" sources="//@children.3/@ports.0" targets="//@children.3/@children.2/@ports.1"/>
+    <containedEdges identifier="E144" sources="//@children.3/@ports.0" targets="//@children.3/@children.3/@ports.1"/>
+    <containedEdges identifier="E145" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E146" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.4/@ports.2"/>
+    <containedEdges identifier="E147" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.4/@ports.3"/>
+    <containedEdges identifier="E148" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.4/@ports.4"/>
+    <containedEdges identifier="E149" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  </children>
+  <children identifier="N90" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="49.0" text="Previous"/>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="57.0" text="Previous2"/>
+    <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N92">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L92" height="15.0" width="88.0" text="PageGenerator"/>
+    <ports identifier="P239" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.7 //@children.6/@containedEdges.8" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.4" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.3" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P244" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P245" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.6/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P246" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P247" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.6" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N93" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L93" height="15.0" width="127.0" text="HTMLPageAssembler"/>
+      <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="-2.0" incomingEdges="//@children.6/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@children.6/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.6/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="22.0" incomingEdges="//@children.6/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.6/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.6/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P255" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N94" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L94" height="15.0" width="63.0" text="FileReader"/>
+      <ports identifier="P256" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N95" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L95" height="15.0" width="60.0" text="StringSplit"/>
+      <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P260" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N96" height="25.0" width="260.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L96" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P261" height="8.0" width="8.0" x="260.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N97" height="100.0" width="591.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L97" height="15.0" width="73.0" text="Expression5"/>
+      <ports identifier="P263" height="8.0" width="8.0" x="591.0" y="46.0" outgoingEdges="//@children.6/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="13.600000381469727" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="35.20000076293945" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="56.79999923706055" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="78.4000015258789" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N98" height="25.0" width="272.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L98" height="15.0" width="73.0" text="Expression6"/>
+      <ports identifier="P268" height="8.0" width="8.0" x="272.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N99" height="25.0" width="266.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L99" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P270" height="8.0" width="8.0" x="266.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N100" height="25.0" width="278.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L100" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P272" height="8.0" width="8.0" x="278.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N101" height="71.0" width="329.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L101" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P274" height="8.0" width="8.0" x="329.0" y="31.5" outgoingEdges="//@children.6/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="31.5" incomingEdges="//@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E150" sources="//@children.6/@ports.4" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E151" sources="//@children.6/@ports.5" targets="//@children.6/@children.5/@ports.1"/>
+    <containedEdges identifier="E152" sources="//@children.6/@ports.2" targets="//@children.6/@children.6/@ports.1"/>
+    <containedEdges identifier="E153" sources="//@children.6/@ports.3" targets="//@children.6/@children.7/@ports.1"/>
+    <containedEdges identifier="E154" sources="//@children.6/@ports.1" targets="//@children.6/@children.4/@ports.2"/>
+    <containedEdges identifier="E155" sources="//@children.6/@ports.7" targets="//@children.6/@children.4/@ports.3"/>
+    <containedEdges identifier="E156" sources="//@children.6/@ports.8" targets="//@children.6/@children.4/@ports.4"/>
+    <containedEdges identifier="E157" sources="//@children.6/@ports.0" targets="//@children.6/@children.4/@ports.1"/>
+    <containedEdges identifier="E158" sources="//@children.6/@ports.0" targets="//@children.6/@children.8/@ports.1"/>
+    <containedEdges identifier="E159" sources="//@children.6/@children.0/@ports.7" targets="//@children.6/@ports.6"/>
+    <containedEdges identifier="E160" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E161" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.0/@ports.4"/>
+    <containedEdges identifier="E162" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E163" sources="//@children.6/@children.4/@ports.0" targets="//@children.6/@children.0/@ports.5"/>
+    <containedEdges identifier="E164" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E165" sources="//@children.6/@children.6/@ports.0" targets="//@children.6/@children.0/@ports.2"/>
+    <containedEdges identifier="E166" sources="//@children.6/@children.7/@ports.0" targets="//@children.6/@children.0/@ports.3"/>
+    <containedEdges identifier="E167" sources="//@children.6/@children.8/@ports.0" targets="//@children.6/@children.0/@ports.6"/>
+  </children>
+  <children identifier="N102" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P277" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="57.0" text="Previous3"/>
+    <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P279" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="57.0" text="Previous4"/>
+    <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P281" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.4" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.4" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.4" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.5" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.5" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.6" targets="//@children.6/@ports.7"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.6" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.3" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.4" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E13" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.4/@ports.1" targets="//@children.6/@ports.4"/>
+  <containedEdges identifier="E15" sources="//@children.5/@ports.1" targets="//@children.6/@ports.5"/>
+  <containedEdges identifier="E16" sources="//@children.6/@ports.6" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.7/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.8/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.9/@ports.1" targets="//@children.6/@ports.8"/>
+  <containedEdges identifier="E22" sources="//@children.10/@ports.1" targets="//@children.0/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_smartroom_SmartRoom.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_smartroom_SmartRoom.elkg
@@ -1,0 +1,640 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="HttpActor3"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="63.0" text="HttpActor2"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="4.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10 //@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="RecordAssembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="56.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="56.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="130.0" text="VisualModelReference"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="89.0" text="TokenToJSON2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="56.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const4"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="56.0" y="8.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="98.0" text="MicrostepDelay4"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L19" height="15.0" width="93.0" text="IterateOverArray"/>
+    <ports identifier="P44" height="8.0" width="8.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N20">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L20" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.18/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" incomingEdges="//@children.18/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N21" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="113.0" text="ExpressionToToken"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.18/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.18/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="120.0" text="ExpressionToToken2"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.18/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.18/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.18/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.18/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.18/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.18/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.18/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.18/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.18/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.18/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.18/@children.0/@ports.0" targets="//@children.18/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.18/@children.0/@children.0/@ports.1" targets="//@children.18/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E33" sources="//@children.18/@children.0/@children.1/@ports.1" targets="//@children.18/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E34" sources="//@children.18/@children.0/@children.2/@ports.0" targets="//@children.18/@children.0/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.18/@children.0/@children.3/@ports.1" targets="//@children.18/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.18/@children.0/@children.3/@ports.2" targets="//@children.18/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.18/@children.0/@children.3/@ports.3" targets="//@children.18/@children.0/@children.2/@ports.3"/>
+    </children>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="89.0" text="JSONToToken2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="101.0" text="IterateOverArray2"/>
+    <ports identifier="P64" height="8.0" width="8.0" incomingEdges="//@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.21/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" incomingEdges="//@children.21/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N29" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="113.0" text="ExpressionToToken"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.21/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.21/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="120.0" text="ExpressionToToken2"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.21/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.21/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.21/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.21/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.21/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.21/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.21/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.21/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="10.0" y="1.7999999523162842" outgoingEdges="//@children.21/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="11.600000381469727" outgoingEdges="//@children.21/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="21.399999618530273" outgoingEdges="//@children.21/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="10.0" y="31.200000762939453" outgoingEdges="//@children.21/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="120.0" text="ExpressionToToken3"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.21/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.21/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E38" sources="//@children.21/@children.0/@ports.0" targets="//@children.21/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.21/@children.0/@children.0/@ports.1" targets="//@children.21/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.21/@children.0/@children.1/@ports.1" targets="//@children.21/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E41" sources="//@children.21/@children.0/@children.2/@ports.0" targets="//@children.21/@children.0/@ports.1"/>
+      <containedEdges identifier="E42" sources="//@children.21/@children.0/@children.3/@ports.1" targets="//@children.21/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.21/@children.0/@children.3/@ports.2" targets="//@children.21/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.21/@children.0/@children.3/@ports.3" targets="//@children.21/@children.0/@children.2/@ports.3"/>
+      <containedEdges identifier="E45" sources="//@children.21/@children.0/@children.3/@ports.4" targets="//@children.21/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.21/@children.0/@children.4/@ports.1" targets="//@children.21/@children.0/@children.2/@ports.4"/>
+    </children>
+  </children>
+  <children identifier="N34" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="25.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="42.0" text="Const5"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="89.0" text="TokenToJSON3"/>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.3" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.24/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.0" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.16/@ports.1" targets="//@children.17/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.16/@ports.2" targets="//@children.20/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.17/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E25" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E26" sources="//@children.20/@ports.0" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.21/@ports.1" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E28" sources="//@children.24/@ports.1" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E29" sources="//@children.25/@ports.0" targets="//@children.26/@ports.0"/>
+  <containedEdges identifier="E30" sources="//@children.26/@ports.1" targets="//@children.15/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_temperaturesimulation_EPlusSimulation.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_temperaturesimulation_EPlusSimulation.elkg
@@ -1,0 +1,6479 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="52.0" text="RunTime"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="90.0" text="SimulationTime"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="78.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="26.0" text="hvac"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.5/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0 //@children.5/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="46.0" text="TReturn"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="69.0" text="TRooSetPoi"/>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.3 //@children.5/@containedEdges.4" incomingEdges="//@children.5/@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@containedEdges.0" incomingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.5" incomingEdges="//@children.5/@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N9" height="25.0" width="149.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="70.0" text="TSetPoiCoo"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="149.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="25.0" width="458.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="68.0" text="TSetCooOn"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="458.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="25.0" width="85.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="52.0" text="TOutLow"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="83.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="50.0" text="TRooHig"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="44.0" text="TOutDif"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="53.0" text="Minimum"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.2 //@children.5/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.5/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="57.0" text="Maximum"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.6 //@children.5/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.5/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="87.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="57.0" text="TRooHig2"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L17" height="15.0" width="33.0" text="isDay"/>
+        <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.0" incomingEdges="//@children.5/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@containedEdges.9 //@children.5/@children.1/@containedEdges.10" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@containedEdges.11" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N18" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="72.0" text="pastMorning"/>
+          <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N19" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L19" height="15.0" width="49.0" text="dayStart"/>
+          <ports identifier="P44" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N20" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L20" height="15.0" width="48.0" text="pastDay"/>
+          <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.3 //@children.5/@children.1/@children.8/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N21" height="25.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L21" height="15.0" width="56.0" text="nightStart"/>
+          <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="8.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N22" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L22" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.1 //@children.5/@children.1/@children.8/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P52" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N23" height="25.0" width="91.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L23" height="15.0" width="61.0" text="timeOfDay"/>
+          <ports identifier="P53" height="8.0" width="8.0" x="91.0" y="8.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.7 //@children.5/@children.1/@children.8/@containedEdges.8 //@children.5/@children.1/@children.8/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N24" height="25.0" width="108.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L24" height="15.0" width="91.0" text="occupancyStart"/>
+          <ports identifier="P55" height="8.0" width="8.0" x="108.0" y="8.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N25" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="119.0" text="pastOccupancyStart"/>
+          <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N26" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="89.0" text="LogicFunction2"/>
+          <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@children.8/@containedEdges.4 //@children.5/@children.1/@children.8/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P61" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.5/@children.1/@children.8/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E57" sources="//@children.5/@children.1/@children.8/@ports.0" targets="//@children.5/@children.1/@children.8/@children.5/@ports.1"/>
+        <containedEdges identifier="E58" sources="//@children.5/@children.1/@children.8/@children.0/@ports.2" targets="//@children.5/@children.1/@children.8/@children.4/@ports.0"/>
+        <containedEdges identifier="E59" sources="//@children.5/@children.1/@children.8/@children.1/@ports.0" targets="//@children.5/@children.1/@children.8/@children.0/@ports.1"/>
+        <containedEdges identifier="E60" sources="//@children.5/@children.1/@children.8/@children.2/@ports.2" targets="//@children.5/@children.1/@children.8/@children.4/@ports.0"/>
+        <containedEdges identifier="E61" sources="//@children.5/@children.1/@children.8/@children.2/@ports.2" targets="//@children.5/@children.1/@children.8/@children.8/@ports.0"/>
+        <containedEdges identifier="E62" sources="//@children.5/@children.1/@children.8/@children.3/@ports.0" targets="//@children.5/@children.1/@children.8/@children.2/@ports.0"/>
+        <containedEdges identifier="E63" sources="//@children.5/@children.1/@children.8/@children.4/@ports.1" targets="//@children.5/@children.1/@children.8/@ports.1"/>
+        <containedEdges identifier="E64" sources="//@children.5/@children.1/@children.8/@children.5/@ports.0" targets="//@children.5/@children.1/@children.8/@children.0/@ports.0"/>
+        <containedEdges identifier="E65" sources="//@children.5/@children.1/@children.8/@children.5/@ports.0" targets="//@children.5/@children.1/@children.8/@children.2/@ports.1"/>
+        <containedEdges identifier="E66" sources="//@children.5/@children.1/@children.8/@children.5/@ports.0" targets="//@children.5/@children.1/@children.8/@children.7/@ports.0"/>
+        <containedEdges identifier="E67" sources="//@children.5/@children.1/@children.8/@children.6/@ports.0" targets="//@children.5/@children.1/@children.8/@children.7/@ports.1"/>
+        <containedEdges identifier="E68" sources="//@children.5/@children.1/@children.8/@children.7/@ports.2" targets="//@children.5/@children.1/@children.8/@children.8/@ports.0"/>
+        <containedEdges identifier="E69" sources="//@children.5/@children.1/@children.8/@children.8/@ports.1" targets="//@children.5/@children.1/@children.8/@ports.2"/>
+      </children>
+      <children identifier="N27" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="25.0" width="172.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="70.0" text="TSetPoiHea"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="172.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="100.0" text="VectorAssembler"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.1 //@children.5/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="87.0" text="MovingAverage"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E41" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.5/@children.1/@children.0/@ports.0" targets="//@children.5/@children.1/@children.11/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.5/@children.1/@children.1/@ports.0" targets="//@children.5/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.5/@children.1/@children.2/@ports.0" targets="//@children.5/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E45" sources="//@children.5/@children.1/@children.3/@ports.0" targets="//@children.5/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.5/@children.1/@children.4/@ports.2" targets="//@children.5/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E47" sources="//@children.5/@children.1/@children.5/@ports.1" targets="//@children.5/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.5/@children.1/@children.6/@ports.1" targets="//@children.5/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E49" sources="//@children.5/@children.1/@children.7/@ports.0" targets="//@children.5/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.5/@children.1/@children.8/@ports.1" targets="//@children.5/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E51" sources="//@children.5/@children.1/@children.8/@ports.1" targets="//@children.5/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E52" sources="//@children.5/@children.1/@children.8/@ports.2" targets="//@children.5/@children.1/@ports.2"/>
+      <containedEdges identifier="E53" sources="//@children.5/@children.1/@children.9/@ports.0" targets="//@children.5/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.5/@children.1/@children.10/@ports.0" targets="//@children.5/@children.1/@children.11/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.5/@children.1/@children.11/@ports.1" targets="//@children.5/@children.1/@children.12/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.5/@children.1/@children.12/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N31">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L31" height="15.0" width="48.0" text="VAVBox"/>
+      <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.26 //@children.5/@children.2/@containedEdges.27" incomingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.0 //@children.5/@children.2/@containedEdges.1 //@children.5/@children.2/@containedEdges.2 //@children.5/@children.2/@containedEdges.3 //@children.5/@children.2/@containedEdges.4 //@children.5/@children.2/@containedEdges.5 //@children.5/@children.2/@containedEdges.6 //@children.5/@children.2/@containedEdges.7 //@children.5/@children.2/@containedEdges.8 //@children.5/@children.2/@containedEdges.9 //@children.5/@children.2/@containedEdges.10 //@children.5/@children.2/@containedEdges.11 //@children.5/@children.2/@containedEdges.12" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.13 //@children.5/@children.2/@containedEdges.14 //@children.5/@children.2/@containedEdges.15 //@children.5/@children.2/@containedEdges.16 //@children.5/@children.2/@containedEdges.17 //@children.5/@children.2/@containedEdges.18 //@children.5/@children.2/@containedEdges.19 //@children.5/@children.2/@containedEdges.20 //@children.5/@children.2/@containedEdges.21 //@children.5/@children.2/@containedEdges.22 //@children.5/@children.2/@containedEdges.23 //@children.5/@children.2/@containedEdges.24 //@children.5/@children.2/@containedEdges.25" incomingEdges="//@children.5/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.61">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.8" incomingEdges="//@children.5/@children.2/@containedEdges.58">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.7" incomingEdges="//@children.5/@children.2/@containedEdges.62">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.28" incomingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N32">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L32" height="15.0" width="56.0" text="VAVPeri1"/>
+        <ports identifier="P77" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.0 //@children.5/@children.2/@children.0/@containedEdges.1 //@children.5/@children.2/@children.0/@containedEdges.2 //@children.5/@children.2/@children.0/@containedEdges.3 //@children.5/@children.2/@children.0/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.44">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.7 //@children.5/@children.2/@children.0/@containedEdges.8 //@children.5/@children.2/@children.0/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.29 //@children.5/@children.2/@containedEdges.30" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.5 //@children.5/@children.2/@children.0/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.31" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N33" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L33" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N34" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L34" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P86" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.11 //@children.5/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N35" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L35" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.11 //@children.5/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P89" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.13 //@children.5/@children.2/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N36" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L36" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P90" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N37" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L37" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P94" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N38" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L38" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N39" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L39" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.16 //@children.5/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P99" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N40" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L40" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P101" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.19 //@children.5/@children.2/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N41" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L41" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.25 //@children.5/@children.2/@children.0/@containedEdges.29 //@children.5/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P103" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P104" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N42" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L42" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P106" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N43" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L43" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P108" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.23 //@children.5/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N44" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L44" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P109" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N45" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L45" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P112" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N46" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L46" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P114" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N47" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L47" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P116" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N48" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L48" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P119" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N49" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L49" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P120" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N50" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L50" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.22 //@children.5/@children.2/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P126" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N51" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L51" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P127" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N52" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L52" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.26 //@children.5/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P132" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N53" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L53" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P134" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.0/@containedEdges.32 //@children.5/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E176" sources="//@children.5/@children.2/@children.0/@ports.0" targets="//@children.5/@children.2/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E177" sources="//@children.5/@children.2/@children.0/@ports.0" targets="//@children.5/@children.2/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E178" sources="//@children.5/@children.2/@children.0/@ports.0" targets="//@children.5/@children.2/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E179" sources="//@children.5/@children.2/@children.0/@ports.0" targets="//@children.5/@children.2/@children.0/@children.16/@ports.1"/>
+        <containedEdges identifier="E180" sources="//@children.5/@children.2/@children.0/@ports.0" targets="//@children.5/@children.2/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E181" sources="//@children.5/@children.2/@children.0/@ports.3" targets="//@children.5/@children.2/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E182" sources="//@children.5/@children.2/@children.0/@ports.3" targets="//@children.5/@children.2/@children.0/@children.18/@ports.2"/>
+        <containedEdges identifier="E183" sources="//@children.5/@children.2/@children.0/@ports.1" targets="//@children.5/@children.2/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E184" sources="//@children.5/@children.2/@children.0/@ports.1" targets="//@children.5/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E185" sources="//@children.5/@children.2/@children.0/@ports.1" targets="//@children.5/@children.2/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E186" sources="//@children.5/@children.2/@children.0/@children.0/@ports.2" targets="//@children.5/@children.2/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E187" sources="//@children.5/@children.2/@children.0/@children.1/@ports.1" targets="//@children.5/@children.2/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E188" sources="//@children.5/@children.2/@children.0/@children.1/@ports.1" targets="//@children.5/@children.2/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E189" sources="//@children.5/@children.2/@children.0/@children.2/@ports.2" targets="//@children.5/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E190" sources="//@children.5/@children.2/@children.0/@children.2/@ports.2" targets="//@children.5/@children.2/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E191" sources="//@children.5/@children.2/@children.0/@children.3/@ports.0" targets="//@children.5/@children.2/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E192" sources="//@children.5/@children.2/@children.0/@children.4/@ports.2" targets="//@children.5/@children.2/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E193" sources="//@children.5/@children.2/@children.0/@children.5/@ports.1" targets="//@children.5/@children.2/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E194" sources="//@children.5/@children.2/@children.0/@children.6/@ports.2" targets="//@children.5/@children.2/@children.0/@ports.4"/>
+        <containedEdges identifier="E195" sources="//@children.5/@children.2/@children.0/@children.7/@ports.1" targets="//@children.5/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E196" sources="//@children.5/@children.2/@children.0/@children.7/@ports.1" targets="//@children.5/@children.2/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E197" sources="//@children.5/@children.2/@children.0/@children.8/@ports.1" targets="//@children.5/@children.2/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E198" sources="//@children.5/@children.2/@children.0/@children.9/@ports.1" targets="//@children.5/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E199" sources="//@children.5/@children.2/@children.0/@children.10/@ports.1" targets="//@children.5/@children.2/@children.0/@children.16/@ports.2"/>
+        <containedEdges identifier="E200" sources="//@children.5/@children.2/@children.0/@children.10/@ports.1" targets="//@children.5/@children.2/@children.0/@children.16/@ports.3"/>
+        <containedEdges identifier="E201" sources="//@children.5/@children.2/@children.0/@children.11/@ports.0" targets="//@children.5/@children.2/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E202" sources="//@children.5/@children.2/@children.0/@children.13/@ports.1" targets="//@children.5/@children.2/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E203" sources="//@children.5/@children.2/@children.0/@children.15/@ports.2" targets="//@children.5/@children.2/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E204" sources="//@children.5/@children.2/@children.0/@children.16/@ports.0" targets="//@children.5/@children.2/@children.0/@children.8/@ports.2"/>
+        <containedEdges identifier="E205" sources="//@children.5/@children.2/@children.0/@children.17/@ports.2" targets="//@children.5/@children.2/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E206" sources="//@children.5/@children.2/@children.0/@children.18/@ports.0" targets="//@children.5/@children.2/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E207" sources="//@children.5/@children.2/@children.0/@children.19/@ports.2" targets="//@children.5/@children.2/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E208" sources="//@children.5/@children.2/@children.0/@children.20/@ports.1" targets="//@children.5/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E209" sources="//@children.5/@children.2/@children.0/@children.20/@ports.1" targets="//@children.5/@children.2/@children.0/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N54">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L54" height="15.0" width="56.0" text="VAVPeri2"/>
+        <ports identifier="P135" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.0 //@children.5/@children.2/@children.1/@containedEdges.1 //@children.5/@children.2/@children.1/@containedEdges.2 //@children.5/@children.2/@children.1/@containedEdges.3 //@children.5/@children.2/@children.1/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.45">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P136" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.7 //@children.5/@children.2/@children.1/@containedEdges.8 //@children.5/@children.2/@children.1/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.32 //@children.5/@children.2/@containedEdges.33" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.5 //@children.5/@children.2/@children.1/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.34" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N55" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L55" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P142" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N56" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L56" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P144" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.11 //@children.5/@children.2/@children.1/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N57" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L57" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.11 //@children.5/@children.2/@children.1/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P147" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.13 //@children.5/@children.2/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N58" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L58" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P148" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N59" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N60" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L60" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P154" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N61" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L61" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.16 //@children.5/@children.2/@children.1/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P157" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N62" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L62" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P159" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.19 //@children.5/@children.2/@children.1/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N63" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L63" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.25 //@children.5/@children.2/@children.1/@containedEdges.29 //@children.5/@children.2/@children.1/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P161" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P162" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N64" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L64" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P164" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N65" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L65" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P166" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.23 //@children.5/@children.2/@children.1/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N66" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L66" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P167" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N67" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L67" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P170" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N68" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P172" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P174" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P177" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N71" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P178" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.22 //@children.5/@children.2/@children.1/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P184" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N73" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P185" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N74" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.26 //@children.5/@children.2/@children.1/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P190" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N75" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L75" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.1/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P192" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.1/@containedEdges.32 //@children.5/@children.2/@children.1/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E210" sources="//@children.5/@children.2/@children.1/@ports.0" targets="//@children.5/@children.2/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E211" sources="//@children.5/@children.2/@children.1/@ports.0" targets="//@children.5/@children.2/@children.1/@children.4/@ports.1"/>
+        <containedEdges identifier="E212" sources="//@children.5/@children.2/@children.1/@ports.0" targets="//@children.5/@children.2/@children.1/@children.15/@ports.1"/>
+        <containedEdges identifier="E213" sources="//@children.5/@children.2/@children.1/@ports.0" targets="//@children.5/@children.2/@children.1/@children.16/@ports.1"/>
+        <containedEdges identifier="E214" sources="//@children.5/@children.2/@children.1/@ports.0" targets="//@children.5/@children.2/@children.1/@children.18/@ports.1"/>
+        <containedEdges identifier="E215" sources="//@children.5/@children.2/@children.1/@ports.3" targets="//@children.5/@children.2/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E216" sources="//@children.5/@children.2/@children.1/@ports.3" targets="//@children.5/@children.2/@children.1/@children.18/@ports.2"/>
+        <containedEdges identifier="E217" sources="//@children.5/@children.2/@children.1/@ports.1" targets="//@children.5/@children.2/@children.1/@children.7/@ports.0"/>
+        <containedEdges identifier="E218" sources="//@children.5/@children.2/@children.1/@ports.1" targets="//@children.5/@children.2/@children.1/@children.10/@ports.0"/>
+        <containedEdges identifier="E219" sources="//@children.5/@children.2/@children.1/@ports.1" targets="//@children.5/@children.2/@children.1/@children.14/@ports.0"/>
+        <containedEdges identifier="E220" sources="//@children.5/@children.2/@children.1/@children.0/@ports.2" targets="//@children.5/@children.2/@children.1/@children.9/@ports.0"/>
+        <containedEdges identifier="E221" sources="//@children.5/@children.2/@children.1/@children.1/@ports.1" targets="//@children.5/@children.2/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E222" sources="//@children.5/@children.2/@children.1/@children.1/@ports.1" targets="//@children.5/@children.2/@children.1/@children.12/@ports.0"/>
+        <containedEdges identifier="E223" sources="//@children.5/@children.2/@children.1/@children.2/@ports.2" targets="//@children.5/@children.2/@children.1/@ports.2"/>
+        <containedEdges identifier="E224" sources="//@children.5/@children.2/@children.1/@children.2/@ports.2" targets="//@children.5/@children.2/@children.1/@children.5/@ports.0"/>
+        <containedEdges identifier="E225" sources="//@children.5/@children.2/@children.1/@children.3/@ports.0" targets="//@children.5/@children.2/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E226" sources="//@children.5/@children.2/@children.1/@children.4/@ports.2" targets="//@children.5/@children.2/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E227" sources="//@children.5/@children.2/@children.1/@children.5/@ports.1" targets="//@children.5/@children.2/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E228" sources="//@children.5/@children.2/@children.1/@children.6/@ports.2" targets="//@children.5/@children.2/@children.1/@ports.4"/>
+        <containedEdges identifier="E229" sources="//@children.5/@children.2/@children.1/@children.7/@ports.1" targets="//@children.5/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E230" sources="//@children.5/@children.2/@children.1/@children.7/@ports.1" targets="//@children.5/@children.2/@children.1/@children.15/@ports.0"/>
+        <containedEdges identifier="E231" sources="//@children.5/@children.2/@children.1/@children.8/@ports.1" targets="//@children.5/@children.2/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E232" sources="//@children.5/@children.2/@children.1/@children.9/@ports.1" targets="//@children.5/@children.2/@children.1/@children.17/@ports.0"/>
+        <containedEdges identifier="E233" sources="//@children.5/@children.2/@children.1/@children.10/@ports.1" targets="//@children.5/@children.2/@children.1/@children.16/@ports.2"/>
+        <containedEdges identifier="E234" sources="//@children.5/@children.2/@children.1/@children.10/@ports.1" targets="//@children.5/@children.2/@children.1/@children.16/@ports.3"/>
+        <containedEdges identifier="E235" sources="//@children.5/@children.2/@children.1/@children.11/@ports.0" targets="//@children.5/@children.2/@children.1/@children.8/@ports.0"/>
+        <containedEdges identifier="E236" sources="//@children.5/@children.2/@children.1/@children.13/@ports.1" targets="//@children.5/@children.2/@children.1/@children.19/@ports.0"/>
+        <containedEdges identifier="E237" sources="//@children.5/@children.2/@children.1/@children.15/@ports.2" targets="//@children.5/@children.2/@children.1/@children.13/@ports.0"/>
+        <containedEdges identifier="E238" sources="//@children.5/@children.2/@children.1/@children.16/@ports.0" targets="//@children.5/@children.2/@children.1/@children.8/@ports.2"/>
+        <containedEdges identifier="E239" sources="//@children.5/@children.2/@children.1/@children.17/@ports.2" targets="//@children.5/@children.2/@children.1/@children.8/@ports.0"/>
+        <containedEdges identifier="E240" sources="//@children.5/@children.2/@children.1/@children.18/@ports.0" targets="//@children.5/@children.2/@children.1/@children.20/@ports.0"/>
+        <containedEdges identifier="E241" sources="//@children.5/@children.2/@children.1/@children.19/@ports.2" targets="//@children.5/@children.2/@children.1/@children.8/@ports.0"/>
+        <containedEdges identifier="E242" sources="//@children.5/@children.2/@children.1/@children.20/@ports.1" targets="//@children.5/@children.2/@children.1/@children.17/@ports.0"/>
+        <containedEdges identifier="E243" sources="//@children.5/@children.2/@children.1/@children.20/@ports.1" targets="//@children.5/@children.2/@children.1/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N76">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L76" height="15.0" width="56.0" text="VAVPeri3"/>
+        <ports identifier="P193" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.0 //@children.5/@children.2/@children.2/@containedEdges.1 //@children.5/@children.2/@children.2/@containedEdges.2 //@children.5/@children.2/@children.2/@containedEdges.3 //@children.5/@children.2/@children.2/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.46">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P194" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.7 //@children.5/@children.2/@children.2/@containedEdges.8 //@children.5/@children.2/@children.2/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P195" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.35 //@children.5/@children.2/@containedEdges.36" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P196" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.5 //@children.5/@children.2/@children.2/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P197" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.37" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N77" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L77" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P200" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N78" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L78" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P202" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.11 //@children.5/@children.2/@children.2/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N79" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L79" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.11 //@children.5/@children.2/@children.2/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P205" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.13 //@children.5/@children.2/@children.2/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N80" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L80" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P206" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N81" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L81" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P210" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N82" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L82" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P212" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N83" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L83" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.16 //@children.5/@children.2/@children.2/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P215" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N84" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L84" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P217" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.19 //@children.5/@children.2/@children.2/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N85" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L85" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.25 //@children.5/@children.2/@children.2/@containedEdges.29 //@children.5/@children.2/@children.2/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P219" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P220" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N86" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L86" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P222" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N87" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L87" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P224" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.23 //@children.5/@children.2/@children.2/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N88" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L88" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P225" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N89" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L89" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P228" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N90" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L90" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P230" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N91" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L91" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P232" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N92" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L92" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P235" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N93" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P236" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.22 //@children.5/@children.2/@children.2/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P242" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N95" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L95" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P243" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N96" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L96" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.26 //@children.5/@children.2/@children.2/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P248" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N97" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L97" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.2/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P250" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.2/@containedEdges.32 //@children.5/@children.2/@children.2/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E244" sources="//@children.5/@children.2/@children.2/@ports.0" targets="//@children.5/@children.2/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E245" sources="//@children.5/@children.2/@children.2/@ports.0" targets="//@children.5/@children.2/@children.2/@children.4/@ports.1"/>
+        <containedEdges identifier="E246" sources="//@children.5/@children.2/@children.2/@ports.0" targets="//@children.5/@children.2/@children.2/@children.15/@ports.1"/>
+        <containedEdges identifier="E247" sources="//@children.5/@children.2/@children.2/@ports.0" targets="//@children.5/@children.2/@children.2/@children.16/@ports.1"/>
+        <containedEdges identifier="E248" sources="//@children.5/@children.2/@children.2/@ports.0" targets="//@children.5/@children.2/@children.2/@children.18/@ports.1"/>
+        <containedEdges identifier="E249" sources="//@children.5/@children.2/@children.2/@ports.3" targets="//@children.5/@children.2/@children.2/@children.4/@ports.0"/>
+        <containedEdges identifier="E250" sources="//@children.5/@children.2/@children.2/@ports.3" targets="//@children.5/@children.2/@children.2/@children.18/@ports.2"/>
+        <containedEdges identifier="E251" sources="//@children.5/@children.2/@children.2/@ports.1" targets="//@children.5/@children.2/@children.2/@children.7/@ports.0"/>
+        <containedEdges identifier="E252" sources="//@children.5/@children.2/@children.2/@ports.1" targets="//@children.5/@children.2/@children.2/@children.10/@ports.0"/>
+        <containedEdges identifier="E253" sources="//@children.5/@children.2/@children.2/@ports.1" targets="//@children.5/@children.2/@children.2/@children.14/@ports.0"/>
+        <containedEdges identifier="E254" sources="//@children.5/@children.2/@children.2/@children.0/@ports.2" targets="//@children.5/@children.2/@children.2/@children.9/@ports.0"/>
+        <containedEdges identifier="E255" sources="//@children.5/@children.2/@children.2/@children.1/@ports.1" targets="//@children.5/@children.2/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E256" sources="//@children.5/@children.2/@children.2/@children.1/@ports.1" targets="//@children.5/@children.2/@children.2/@children.12/@ports.0"/>
+        <containedEdges identifier="E257" sources="//@children.5/@children.2/@children.2/@children.2/@ports.2" targets="//@children.5/@children.2/@children.2/@ports.2"/>
+        <containedEdges identifier="E258" sources="//@children.5/@children.2/@children.2/@children.2/@ports.2" targets="//@children.5/@children.2/@children.2/@children.5/@ports.0"/>
+        <containedEdges identifier="E259" sources="//@children.5/@children.2/@children.2/@children.3/@ports.0" targets="//@children.5/@children.2/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E260" sources="//@children.5/@children.2/@children.2/@children.4/@ports.2" targets="//@children.5/@children.2/@children.2/@children.6/@ports.0"/>
+        <containedEdges identifier="E261" sources="//@children.5/@children.2/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.2/@children.6/@ports.0"/>
+        <containedEdges identifier="E262" sources="//@children.5/@children.2/@children.2/@children.6/@ports.2" targets="//@children.5/@children.2/@children.2/@ports.4"/>
+        <containedEdges identifier="E263" sources="//@children.5/@children.2/@children.2/@children.7/@ports.1" targets="//@children.5/@children.2/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E264" sources="//@children.5/@children.2/@children.2/@children.7/@ports.1" targets="//@children.5/@children.2/@children.2/@children.15/@ports.0"/>
+        <containedEdges identifier="E265" sources="//@children.5/@children.2/@children.2/@children.8/@ports.1" targets="//@children.5/@children.2/@children.2/@children.1/@ports.0"/>
+        <containedEdges identifier="E266" sources="//@children.5/@children.2/@children.2/@children.9/@ports.1" targets="//@children.5/@children.2/@children.2/@children.17/@ports.0"/>
+        <containedEdges identifier="E267" sources="//@children.5/@children.2/@children.2/@children.10/@ports.1" targets="//@children.5/@children.2/@children.2/@children.16/@ports.2"/>
+        <containedEdges identifier="E268" sources="//@children.5/@children.2/@children.2/@children.10/@ports.1" targets="//@children.5/@children.2/@children.2/@children.16/@ports.3"/>
+        <containedEdges identifier="E269" sources="//@children.5/@children.2/@children.2/@children.11/@ports.0" targets="//@children.5/@children.2/@children.2/@children.8/@ports.0"/>
+        <containedEdges identifier="E270" sources="//@children.5/@children.2/@children.2/@children.13/@ports.1" targets="//@children.5/@children.2/@children.2/@children.19/@ports.0"/>
+        <containedEdges identifier="E271" sources="//@children.5/@children.2/@children.2/@children.15/@ports.2" targets="//@children.5/@children.2/@children.2/@children.13/@ports.0"/>
+        <containedEdges identifier="E272" sources="//@children.5/@children.2/@children.2/@children.16/@ports.0" targets="//@children.5/@children.2/@children.2/@children.8/@ports.2"/>
+        <containedEdges identifier="E273" sources="//@children.5/@children.2/@children.2/@children.17/@ports.2" targets="//@children.5/@children.2/@children.2/@children.8/@ports.0"/>
+        <containedEdges identifier="E274" sources="//@children.5/@children.2/@children.2/@children.18/@ports.0" targets="//@children.5/@children.2/@children.2/@children.20/@ports.0"/>
+        <containedEdges identifier="E275" sources="//@children.5/@children.2/@children.2/@children.19/@ports.2" targets="//@children.5/@children.2/@children.2/@children.8/@ports.0"/>
+        <containedEdges identifier="E276" sources="//@children.5/@children.2/@children.2/@children.20/@ports.1" targets="//@children.5/@children.2/@children.2/@children.17/@ports.0"/>
+        <containedEdges identifier="E277" sources="//@children.5/@children.2/@children.2/@children.20/@ports.1" targets="//@children.5/@children.2/@children.2/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N98">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L98" height="15.0" width="56.0" text="VAVPeri4"/>
+        <ports identifier="P251" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.0 //@children.5/@children.2/@children.3/@containedEdges.1 //@children.5/@children.2/@children.3/@containedEdges.2 //@children.5/@children.2/@children.3/@containedEdges.3 //@children.5/@children.2/@children.3/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.47">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P252" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.7 //@children.5/@children.2/@children.3/@containedEdges.8 //@children.5/@children.2/@children.3/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P253" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.38 //@children.5/@children.2/@containedEdges.39" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P254" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.5 //@children.5/@children.2/@children.3/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P255" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.40" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N99" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L99" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P258" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N100" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L100" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P260" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.11 //@children.5/@children.2/@children.3/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N101" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L101" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.11 //@children.5/@children.2/@children.3/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P263" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.13 //@children.5/@children.2/@children.3/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N102" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L102" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P264" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N103" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L103" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P268" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N104" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L104" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P270" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N105" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L105" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.16 //@children.5/@children.2/@children.3/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P273" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N106" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L106" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P275" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.19 //@children.5/@children.2/@children.3/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N107" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L107" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.25 //@children.5/@children.2/@children.3/@containedEdges.29 //@children.5/@children.2/@children.3/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P277" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P278" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N108" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L108" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P280" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N109" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L109" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P282" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.23 //@children.5/@children.2/@children.3/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N110" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L110" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P283" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N111" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L111" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P286" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N112" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P288" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P290" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N114" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L114" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P293" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N115" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L115" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P294" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N116" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L116" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.22 //@children.5/@children.2/@children.3/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P300" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N117" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P301" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N118" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L118" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.26 //@children.5/@children.2/@children.3/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P306" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N119" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.3/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P308" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.3/@containedEdges.32 //@children.5/@children.2/@children.3/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E278" sources="//@children.5/@children.2/@children.3/@ports.0" targets="//@children.5/@children.2/@children.3/@children.0/@ports.1"/>
+        <containedEdges identifier="E279" sources="//@children.5/@children.2/@children.3/@ports.0" targets="//@children.5/@children.2/@children.3/@children.4/@ports.1"/>
+        <containedEdges identifier="E280" sources="//@children.5/@children.2/@children.3/@ports.0" targets="//@children.5/@children.2/@children.3/@children.15/@ports.1"/>
+        <containedEdges identifier="E281" sources="//@children.5/@children.2/@children.3/@ports.0" targets="//@children.5/@children.2/@children.3/@children.16/@ports.1"/>
+        <containedEdges identifier="E282" sources="//@children.5/@children.2/@children.3/@ports.0" targets="//@children.5/@children.2/@children.3/@children.18/@ports.1"/>
+        <containedEdges identifier="E283" sources="//@children.5/@children.2/@children.3/@ports.3" targets="//@children.5/@children.2/@children.3/@children.4/@ports.0"/>
+        <containedEdges identifier="E284" sources="//@children.5/@children.2/@children.3/@ports.3" targets="//@children.5/@children.2/@children.3/@children.18/@ports.2"/>
+        <containedEdges identifier="E285" sources="//@children.5/@children.2/@children.3/@ports.1" targets="//@children.5/@children.2/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E286" sources="//@children.5/@children.2/@children.3/@ports.1" targets="//@children.5/@children.2/@children.3/@children.10/@ports.0"/>
+        <containedEdges identifier="E287" sources="//@children.5/@children.2/@children.3/@ports.1" targets="//@children.5/@children.2/@children.3/@children.14/@ports.0"/>
+        <containedEdges identifier="E288" sources="//@children.5/@children.2/@children.3/@children.0/@ports.2" targets="//@children.5/@children.2/@children.3/@children.9/@ports.0"/>
+        <containedEdges identifier="E289" sources="//@children.5/@children.2/@children.3/@children.1/@ports.1" targets="//@children.5/@children.2/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E290" sources="//@children.5/@children.2/@children.3/@children.1/@ports.1" targets="//@children.5/@children.2/@children.3/@children.12/@ports.0"/>
+        <containedEdges identifier="E291" sources="//@children.5/@children.2/@children.3/@children.2/@ports.2" targets="//@children.5/@children.2/@children.3/@ports.2"/>
+        <containedEdges identifier="E292" sources="//@children.5/@children.2/@children.3/@children.2/@ports.2" targets="//@children.5/@children.2/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E293" sources="//@children.5/@children.2/@children.3/@children.3/@ports.0" targets="//@children.5/@children.2/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E294" sources="//@children.5/@children.2/@children.3/@children.4/@ports.2" targets="//@children.5/@children.2/@children.3/@children.6/@ports.0"/>
+        <containedEdges identifier="E295" sources="//@children.5/@children.2/@children.3/@children.5/@ports.1" targets="//@children.5/@children.2/@children.3/@children.6/@ports.0"/>
+        <containedEdges identifier="E296" sources="//@children.5/@children.2/@children.3/@children.6/@ports.2" targets="//@children.5/@children.2/@children.3/@ports.4"/>
+        <containedEdges identifier="E297" sources="//@children.5/@children.2/@children.3/@children.7/@ports.1" targets="//@children.5/@children.2/@children.3/@children.0/@ports.0"/>
+        <containedEdges identifier="E298" sources="//@children.5/@children.2/@children.3/@children.7/@ports.1" targets="//@children.5/@children.2/@children.3/@children.15/@ports.0"/>
+        <containedEdges identifier="E299" sources="//@children.5/@children.2/@children.3/@children.8/@ports.1" targets="//@children.5/@children.2/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E300" sources="//@children.5/@children.2/@children.3/@children.9/@ports.1" targets="//@children.5/@children.2/@children.3/@children.17/@ports.0"/>
+        <containedEdges identifier="E301" sources="//@children.5/@children.2/@children.3/@children.10/@ports.1" targets="//@children.5/@children.2/@children.3/@children.16/@ports.2"/>
+        <containedEdges identifier="E302" sources="//@children.5/@children.2/@children.3/@children.10/@ports.1" targets="//@children.5/@children.2/@children.3/@children.16/@ports.3"/>
+        <containedEdges identifier="E303" sources="//@children.5/@children.2/@children.3/@children.11/@ports.0" targets="//@children.5/@children.2/@children.3/@children.8/@ports.0"/>
+        <containedEdges identifier="E304" sources="//@children.5/@children.2/@children.3/@children.13/@ports.1" targets="//@children.5/@children.2/@children.3/@children.19/@ports.0"/>
+        <containedEdges identifier="E305" sources="//@children.5/@children.2/@children.3/@children.15/@ports.2" targets="//@children.5/@children.2/@children.3/@children.13/@ports.0"/>
+        <containedEdges identifier="E306" sources="//@children.5/@children.2/@children.3/@children.16/@ports.0" targets="//@children.5/@children.2/@children.3/@children.8/@ports.2"/>
+        <containedEdges identifier="E307" sources="//@children.5/@children.2/@children.3/@children.17/@ports.2" targets="//@children.5/@children.2/@children.3/@children.8/@ports.0"/>
+        <containedEdges identifier="E308" sources="//@children.5/@children.2/@children.3/@children.18/@ports.0" targets="//@children.5/@children.2/@children.3/@children.20/@ports.0"/>
+        <containedEdges identifier="E309" sources="//@children.5/@children.2/@children.3/@children.19/@ports.2" targets="//@children.5/@children.2/@children.3/@children.8/@ports.0"/>
+        <containedEdges identifier="E310" sources="//@children.5/@children.2/@children.3/@children.20/@ports.1" targets="//@children.5/@children.2/@children.3/@children.17/@ports.0"/>
+        <containedEdges identifier="E311" sources="//@children.5/@children.2/@children.3/@children.20/@ports.1" targets="//@children.5/@children.2/@children.3/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N120">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L120" height="15.0" width="56.0" text="VAVPeri5"/>
+        <ports identifier="P309" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.0 //@children.5/@children.2/@children.4/@containedEdges.1 //@children.5/@children.2/@children.4/@containedEdges.2 //@children.5/@children.2/@children.4/@containedEdges.3 //@children.5/@children.2/@children.4/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.48">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.7 //@children.5/@children.2/@children.4/@containedEdges.8 //@children.5/@children.2/@children.4/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P311" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.41 //@children.5/@children.2/@containedEdges.42" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P312" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.5 //@children.5/@children.2/@children.4/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P313" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.43" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N121" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L121" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P316" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N122" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L122" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P318" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.11 //@children.5/@children.2/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N123" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L123" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.11 //@children.5/@children.2/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P321" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.13 //@children.5/@children.2/@children.4/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N124" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L124" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P322" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N125" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L125" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P326" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N126" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L126" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P328" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N127" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L127" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.16 //@children.5/@children.2/@children.4/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P331" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N128" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L128" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P333" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.19 //@children.5/@children.2/@children.4/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N129" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L129" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.25 //@children.5/@children.2/@children.4/@containedEdges.29 //@children.5/@children.2/@children.4/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P335" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P336" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N130" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L130" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P338" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N131" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L131" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P340" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.23 //@children.5/@children.2/@children.4/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N132" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L132" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P341" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N133" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L133" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P344" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N134" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L134" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P346" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N135" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L135" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P347" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P348" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N136" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L136" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P351" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N137" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L137" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P352" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N138" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L138" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P356" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.22 //@children.5/@children.2/@children.4/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P358" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N139" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L139" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P359" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P361" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N140" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L140" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.26 //@children.5/@children.2/@children.4/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P364" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N141" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L141" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.4/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P366" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.4/@containedEdges.32 //@children.5/@children.2/@children.4/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E312" sources="//@children.5/@children.2/@children.4/@ports.0" targets="//@children.5/@children.2/@children.4/@children.0/@ports.1"/>
+        <containedEdges identifier="E313" sources="//@children.5/@children.2/@children.4/@ports.0" targets="//@children.5/@children.2/@children.4/@children.4/@ports.1"/>
+        <containedEdges identifier="E314" sources="//@children.5/@children.2/@children.4/@ports.0" targets="//@children.5/@children.2/@children.4/@children.15/@ports.1"/>
+        <containedEdges identifier="E315" sources="//@children.5/@children.2/@children.4/@ports.0" targets="//@children.5/@children.2/@children.4/@children.16/@ports.1"/>
+        <containedEdges identifier="E316" sources="//@children.5/@children.2/@children.4/@ports.0" targets="//@children.5/@children.2/@children.4/@children.18/@ports.1"/>
+        <containedEdges identifier="E317" sources="//@children.5/@children.2/@children.4/@ports.3" targets="//@children.5/@children.2/@children.4/@children.4/@ports.0"/>
+        <containedEdges identifier="E318" sources="//@children.5/@children.2/@children.4/@ports.3" targets="//@children.5/@children.2/@children.4/@children.18/@ports.2"/>
+        <containedEdges identifier="E319" sources="//@children.5/@children.2/@children.4/@ports.1" targets="//@children.5/@children.2/@children.4/@children.7/@ports.0"/>
+        <containedEdges identifier="E320" sources="//@children.5/@children.2/@children.4/@ports.1" targets="//@children.5/@children.2/@children.4/@children.10/@ports.0"/>
+        <containedEdges identifier="E321" sources="//@children.5/@children.2/@children.4/@ports.1" targets="//@children.5/@children.2/@children.4/@children.14/@ports.0"/>
+        <containedEdges identifier="E322" sources="//@children.5/@children.2/@children.4/@children.0/@ports.2" targets="//@children.5/@children.2/@children.4/@children.9/@ports.0"/>
+        <containedEdges identifier="E323" sources="//@children.5/@children.2/@children.4/@children.1/@ports.1" targets="//@children.5/@children.2/@children.4/@children.2/@ports.0"/>
+        <containedEdges identifier="E324" sources="//@children.5/@children.2/@children.4/@children.1/@ports.1" targets="//@children.5/@children.2/@children.4/@children.12/@ports.0"/>
+        <containedEdges identifier="E325" sources="//@children.5/@children.2/@children.4/@children.2/@ports.2" targets="//@children.5/@children.2/@children.4/@ports.2"/>
+        <containedEdges identifier="E326" sources="//@children.5/@children.2/@children.4/@children.2/@ports.2" targets="//@children.5/@children.2/@children.4/@children.5/@ports.0"/>
+        <containedEdges identifier="E327" sources="//@children.5/@children.2/@children.4/@children.3/@ports.0" targets="//@children.5/@children.2/@children.4/@children.2/@ports.0"/>
+        <containedEdges identifier="E328" sources="//@children.5/@children.2/@children.4/@children.4/@ports.2" targets="//@children.5/@children.2/@children.4/@children.6/@ports.0"/>
+        <containedEdges identifier="E329" sources="//@children.5/@children.2/@children.4/@children.5/@ports.1" targets="//@children.5/@children.2/@children.4/@children.6/@ports.0"/>
+        <containedEdges identifier="E330" sources="//@children.5/@children.2/@children.4/@children.6/@ports.2" targets="//@children.5/@children.2/@children.4/@ports.4"/>
+        <containedEdges identifier="E331" sources="//@children.5/@children.2/@children.4/@children.7/@ports.1" targets="//@children.5/@children.2/@children.4/@children.0/@ports.0"/>
+        <containedEdges identifier="E332" sources="//@children.5/@children.2/@children.4/@children.7/@ports.1" targets="//@children.5/@children.2/@children.4/@children.15/@ports.0"/>
+        <containedEdges identifier="E333" sources="//@children.5/@children.2/@children.4/@children.8/@ports.1" targets="//@children.5/@children.2/@children.4/@children.1/@ports.0"/>
+        <containedEdges identifier="E334" sources="//@children.5/@children.2/@children.4/@children.9/@ports.1" targets="//@children.5/@children.2/@children.4/@children.17/@ports.0"/>
+        <containedEdges identifier="E335" sources="//@children.5/@children.2/@children.4/@children.10/@ports.1" targets="//@children.5/@children.2/@children.4/@children.16/@ports.2"/>
+        <containedEdges identifier="E336" sources="//@children.5/@children.2/@children.4/@children.10/@ports.1" targets="//@children.5/@children.2/@children.4/@children.16/@ports.3"/>
+        <containedEdges identifier="E337" sources="//@children.5/@children.2/@children.4/@children.11/@ports.0" targets="//@children.5/@children.2/@children.4/@children.8/@ports.0"/>
+        <containedEdges identifier="E338" sources="//@children.5/@children.2/@children.4/@children.13/@ports.1" targets="//@children.5/@children.2/@children.4/@children.19/@ports.0"/>
+        <containedEdges identifier="E339" sources="//@children.5/@children.2/@children.4/@children.15/@ports.2" targets="//@children.5/@children.2/@children.4/@children.13/@ports.0"/>
+        <containedEdges identifier="E340" sources="//@children.5/@children.2/@children.4/@children.16/@ports.0" targets="//@children.5/@children.2/@children.4/@children.8/@ports.2"/>
+        <containedEdges identifier="E341" sources="//@children.5/@children.2/@children.4/@children.17/@ports.2" targets="//@children.5/@children.2/@children.4/@children.8/@ports.0"/>
+        <containedEdges identifier="E342" sources="//@children.5/@children.2/@children.4/@children.18/@ports.0" targets="//@children.5/@children.2/@children.4/@children.20/@ports.0"/>
+        <containedEdges identifier="E343" sources="//@children.5/@children.2/@children.4/@children.19/@ports.2" targets="//@children.5/@children.2/@children.4/@children.8/@ports.0"/>
+        <containedEdges identifier="E344" sources="//@children.5/@children.2/@children.4/@children.20/@ports.1" targets="//@children.5/@children.2/@children.4/@children.17/@ports.0"/>
+        <containedEdges identifier="E345" sources="//@children.5/@children.2/@children.4/@children.20/@ports.1" targets="//@children.5/@children.2/@children.4/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N142" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L142" height="15.0" width="31.0" text="TRoo"/>
+        <ports identifier="P367" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.26">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P368" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.44 //@children.5/@children.2/@containedEdges.45 //@children.5/@children.2/@containedEdges.46 //@children.5/@children.2/@containedEdges.47 //@children.5/@children.2/@containedEdges.48 //@children.5/@children.2/@containedEdges.49 //@children.5/@children.2/@containedEdges.50 //@children.5/@children.2/@containedEdges.51 //@children.5/@children.2/@containedEdges.52 //@children.5/@children.2/@containedEdges.53 //@children.5/@children.2/@containedEdges.54 //@children.5/@children.2/@containedEdges.55">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N143" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@containedEdges.29 //@children.5/@children.2/@containedEdges.32 //@children.5/@children.2/@containedEdges.35 //@children.5/@children.2/@containedEdges.38 //@children.5/@children.2/@containedEdges.41">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P371" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.56 //@children.5/@children.2/@containedEdges.57">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N144" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L144" height="15.0" width="62.0" text="CSup_flow"/>
+        <ports identifier="P372" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@containedEdges.56">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P373" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@containedEdges.58">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N145" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L145" height="15.0" width="52.0" text="mRooms"/>
+        <ports identifier="P374" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.30 //@children.5/@children.2/@containedEdges.33 //@children.5/@children.2/@containedEdges.36 //@children.5/@children.2/@containedEdges.39 //@children.5/@children.2/@containedEdges.42 //@children.5/@children.2/@containedEdges.91 //@children.5/@children.2/@containedEdges.93 //@children.5/@children.2/@containedEdges.95 //@children.5/@children.2/@containedEdges.98 //@children.5/@children.2/@containedEdges.99 //@children.5/@children.2/@containedEdges.102 //@children.5/@children.2/@containedEdges.104">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P375" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.59 //@children.5/@children.2/@containedEdges.60">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N146" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L146" height="15.0" width="77.0" text="mNormalized"/>
+        <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@containedEdges.59">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P377" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@containedEdges.57">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P378" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.61">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N147" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L147" height="15.0" width="51.0" text="QRooms"/>
+        <ports identifier="P379" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.31 //@children.5/@children.2/@containedEdges.34 //@children.5/@children.2/@containedEdges.37 //@children.5/@children.2/@containedEdges.40 //@children.5/@children.2/@containedEdges.43 //@children.5/@children.2/@containedEdges.92 //@children.5/@children.2/@containedEdges.94 //@children.5/@children.2/@containedEdges.96 //@children.5/@children.2/@containedEdges.97 //@children.5/@children.2/@containedEdges.100 //@children.5/@children.2/@containedEdges.101 //@children.5/@children.2/@containedEdges.103">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P380" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.62">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N148" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L148" height="15.0" width="78.0" text="Temperatures"/>
+        <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.18 //@children.5/@children.2/@containedEdges.28 //@children.5/@children.2/@containedEdges.63 //@children.5/@children.2/@containedEdges.65 //@children.5/@children.2/@containedEdges.67 //@children.5/@children.2/@containedEdges.69 //@children.5/@children.2/@containedEdges.71 //@children.5/@children.2/@containedEdges.73 //@children.5/@children.2/@containedEdges.75 //@children.5/@children.2/@containedEdges.77 //@children.5/@children.2/@containedEdges.79 //@children.5/@children.2/@containedEdges.81 //@children.5/@children.2/@containedEdges.83 //@children.5/@children.2/@containedEdges.85 //@children.5/@children.2/@containedEdges.87 //@children.5/@children.2/@containedEdges.88">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N149" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L149" height="15.0" width="38.0" text="TRoo2"/>
+        <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P383" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.63 //@children.5/@children.2/@containedEdges.64 //@children.5/@children.2/@containedEdges.65 //@children.5/@children.2/@containedEdges.66 //@children.5/@children.2/@containedEdges.67 //@children.5/@children.2/@containedEdges.68 //@children.5/@children.2/@containedEdges.69 //@children.5/@children.2/@containedEdges.70 //@children.5/@children.2/@containedEdges.71 //@children.5/@children.2/@containedEdges.72 //@children.5/@children.2/@containedEdges.73 //@children.5/@children.2/@containedEdges.74 //@children.5/@children.2/@containedEdges.75 //@children.5/@children.2/@containedEdges.76 //@children.5/@children.2/@containedEdges.77 //@children.5/@children.2/@containedEdges.78 //@children.5/@children.2/@containedEdges.79 //@children.5/@children.2/@containedEdges.80 //@children.5/@children.2/@containedEdges.81 //@children.5/@children.2/@containedEdges.82 //@children.5/@children.2/@containedEdges.83 //@children.5/@children.2/@containedEdges.84 //@children.5/@children.2/@containedEdges.85 //@children.5/@children.2/@containedEdges.86">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N150" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L150" height="15.0" width="48.0" text="TRooSP"/>
+        <ports identifier="P384" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P385" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.87 //@children.5/@children.2/@containedEdges.88 //@children.5/@children.2/@containedEdges.89">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N151" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L151" height="15.0" width="93.0" text="massFlowRates"/>
+        <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.90">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N152" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L152" height="15.0" width="56.0" text="TRooSP2"/>
+        <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.60">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P388" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.90">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N153">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L153" height="15.0" width="56.0" text="VAVPeri6"/>
+        <ports identifier="P389" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.0 //@children.5/@children.2/@children.16/@containedEdges.1 //@children.5/@children.2/@children.16/@containedEdges.2 //@children.5/@children.2/@children.16/@containedEdges.3 //@children.5/@children.2/@children.16/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.49">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P390" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.7 //@children.5/@children.2/@children.16/@containedEdges.8 //@children.5/@children.2/@children.16/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P391" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.91" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P392" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.5 //@children.5/@children.2/@children.16/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P393" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.92" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N154" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L154" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P394" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P395" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P396" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N155" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L155" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P398" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.11 //@children.5/@children.2/@children.16/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N156" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L156" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.11 //@children.5/@children.2/@children.16/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P401" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.13 //@children.5/@children.2/@children.16/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N157" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L157" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P402" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P403" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N158" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L158" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P404" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P406" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N159" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L159" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P408" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N160" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L160" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P409" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.16 //@children.5/@children.2/@children.16/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P411" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N161" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L161" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P412" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P413" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.19 //@children.5/@children.2/@children.16/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N162" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L162" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.25 //@children.5/@children.2/@children.16/@containedEdges.29 //@children.5/@children.2/@children.16/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P415" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P416" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N163" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L163" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P418" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N164" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L164" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P420" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.23 //@children.5/@children.2/@children.16/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N165" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L165" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P421" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N166" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L166" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P424" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N167" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L167" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P425" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P426" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N168" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L168" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P427" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P428" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N169" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L169" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P430" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P431" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N170" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L170" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P432" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P433" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N171" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L171" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P436" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.22 //@children.5/@children.2/@children.16/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P437" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P438" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N172" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L172" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P439" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P440" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N173" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L173" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P442" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.26 //@children.5/@children.2/@children.16/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P443" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P444" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N174" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L174" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P445" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.16/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P446" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.16/@containedEdges.32 //@children.5/@children.2/@children.16/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E346" sources="//@children.5/@children.2/@children.16/@ports.0" targets="//@children.5/@children.2/@children.16/@children.0/@ports.1"/>
+        <containedEdges identifier="E347" sources="//@children.5/@children.2/@children.16/@ports.0" targets="//@children.5/@children.2/@children.16/@children.4/@ports.1"/>
+        <containedEdges identifier="E348" sources="//@children.5/@children.2/@children.16/@ports.0" targets="//@children.5/@children.2/@children.16/@children.15/@ports.1"/>
+        <containedEdges identifier="E349" sources="//@children.5/@children.2/@children.16/@ports.0" targets="//@children.5/@children.2/@children.16/@children.16/@ports.1"/>
+        <containedEdges identifier="E350" sources="//@children.5/@children.2/@children.16/@ports.0" targets="//@children.5/@children.2/@children.16/@children.18/@ports.1"/>
+        <containedEdges identifier="E351" sources="//@children.5/@children.2/@children.16/@ports.3" targets="//@children.5/@children.2/@children.16/@children.4/@ports.0"/>
+        <containedEdges identifier="E352" sources="//@children.5/@children.2/@children.16/@ports.3" targets="//@children.5/@children.2/@children.16/@children.18/@ports.2"/>
+        <containedEdges identifier="E353" sources="//@children.5/@children.2/@children.16/@ports.1" targets="//@children.5/@children.2/@children.16/@children.7/@ports.0"/>
+        <containedEdges identifier="E354" sources="//@children.5/@children.2/@children.16/@ports.1" targets="//@children.5/@children.2/@children.16/@children.10/@ports.0"/>
+        <containedEdges identifier="E355" sources="//@children.5/@children.2/@children.16/@ports.1" targets="//@children.5/@children.2/@children.16/@children.14/@ports.0"/>
+        <containedEdges identifier="E356" sources="//@children.5/@children.2/@children.16/@children.0/@ports.2" targets="//@children.5/@children.2/@children.16/@children.9/@ports.0"/>
+        <containedEdges identifier="E357" sources="//@children.5/@children.2/@children.16/@children.1/@ports.1" targets="//@children.5/@children.2/@children.16/@children.2/@ports.0"/>
+        <containedEdges identifier="E358" sources="//@children.5/@children.2/@children.16/@children.1/@ports.1" targets="//@children.5/@children.2/@children.16/@children.12/@ports.0"/>
+        <containedEdges identifier="E359" sources="//@children.5/@children.2/@children.16/@children.2/@ports.2" targets="//@children.5/@children.2/@children.16/@ports.2"/>
+        <containedEdges identifier="E360" sources="//@children.5/@children.2/@children.16/@children.2/@ports.2" targets="//@children.5/@children.2/@children.16/@children.5/@ports.0"/>
+        <containedEdges identifier="E361" sources="//@children.5/@children.2/@children.16/@children.3/@ports.0" targets="//@children.5/@children.2/@children.16/@children.2/@ports.0"/>
+        <containedEdges identifier="E362" sources="//@children.5/@children.2/@children.16/@children.4/@ports.2" targets="//@children.5/@children.2/@children.16/@children.6/@ports.0"/>
+        <containedEdges identifier="E363" sources="//@children.5/@children.2/@children.16/@children.5/@ports.1" targets="//@children.5/@children.2/@children.16/@children.6/@ports.0"/>
+        <containedEdges identifier="E364" sources="//@children.5/@children.2/@children.16/@children.6/@ports.2" targets="//@children.5/@children.2/@children.16/@ports.4"/>
+        <containedEdges identifier="E365" sources="//@children.5/@children.2/@children.16/@children.7/@ports.1" targets="//@children.5/@children.2/@children.16/@children.0/@ports.0"/>
+        <containedEdges identifier="E366" sources="//@children.5/@children.2/@children.16/@children.7/@ports.1" targets="//@children.5/@children.2/@children.16/@children.15/@ports.0"/>
+        <containedEdges identifier="E367" sources="//@children.5/@children.2/@children.16/@children.8/@ports.1" targets="//@children.5/@children.2/@children.16/@children.1/@ports.0"/>
+        <containedEdges identifier="E368" sources="//@children.5/@children.2/@children.16/@children.9/@ports.1" targets="//@children.5/@children.2/@children.16/@children.17/@ports.0"/>
+        <containedEdges identifier="E369" sources="//@children.5/@children.2/@children.16/@children.10/@ports.1" targets="//@children.5/@children.2/@children.16/@children.16/@ports.2"/>
+        <containedEdges identifier="E370" sources="//@children.5/@children.2/@children.16/@children.10/@ports.1" targets="//@children.5/@children.2/@children.16/@children.16/@ports.3"/>
+        <containedEdges identifier="E371" sources="//@children.5/@children.2/@children.16/@children.11/@ports.0" targets="//@children.5/@children.2/@children.16/@children.8/@ports.0"/>
+        <containedEdges identifier="E372" sources="//@children.5/@children.2/@children.16/@children.13/@ports.1" targets="//@children.5/@children.2/@children.16/@children.19/@ports.0"/>
+        <containedEdges identifier="E373" sources="//@children.5/@children.2/@children.16/@children.15/@ports.2" targets="//@children.5/@children.2/@children.16/@children.13/@ports.0"/>
+        <containedEdges identifier="E374" sources="//@children.5/@children.2/@children.16/@children.16/@ports.0" targets="//@children.5/@children.2/@children.16/@children.8/@ports.2"/>
+        <containedEdges identifier="E375" sources="//@children.5/@children.2/@children.16/@children.17/@ports.2" targets="//@children.5/@children.2/@children.16/@children.8/@ports.0"/>
+        <containedEdges identifier="E376" sources="//@children.5/@children.2/@children.16/@children.18/@ports.0" targets="//@children.5/@children.2/@children.16/@children.20/@ports.0"/>
+        <containedEdges identifier="E377" sources="//@children.5/@children.2/@children.16/@children.19/@ports.2" targets="//@children.5/@children.2/@children.16/@children.8/@ports.0"/>
+        <containedEdges identifier="E378" sources="//@children.5/@children.2/@children.16/@children.20/@ports.1" targets="//@children.5/@children.2/@children.16/@children.17/@ports.0"/>
+        <containedEdges identifier="E379" sources="//@children.5/@children.2/@children.16/@children.20/@ports.1" targets="//@children.5/@children.2/@children.16/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N175">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L175" height="15.0" width="56.0" text="VAVPeri7"/>
+        <ports identifier="P447" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.0 //@children.5/@children.2/@children.17/@containedEdges.1 //@children.5/@children.2/@children.17/@containedEdges.2 //@children.5/@children.2/@children.17/@containedEdges.3 //@children.5/@children.2/@children.17/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.50">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P448" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.7 //@children.5/@children.2/@children.17/@containedEdges.8 //@children.5/@children.2/@children.17/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P449" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.93" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P450" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.5 //@children.5/@children.2/@children.17/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P451" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.94" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N176" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L176" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P453" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P454" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N177" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L177" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P455" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P456" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.11 //@children.5/@children.2/@children.17/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N178" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L178" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P457" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.11 //@children.5/@children.2/@children.17/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P459" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.13 //@children.5/@children.2/@children.17/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N179" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L179" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P460" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P461" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N180" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L180" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P462" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P463" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P464" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N181" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L181" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P465" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P466" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N182" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L182" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P467" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.16 //@children.5/@children.2/@children.17/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P468" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P469" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N183" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L183" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P471" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.19 //@children.5/@children.2/@children.17/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N184" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L184" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P472" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.25 //@children.5/@children.2/@children.17/@containedEdges.29 //@children.5/@children.2/@children.17/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P473" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P474" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N185" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L185" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P475" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P476" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N186" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L186" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P478" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.23 //@children.5/@children.2/@children.17/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N187" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L187" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P479" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P480" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N188" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L188" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P482" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N189" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L189" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P483" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P484" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N190" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L190" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P486" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N191" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L191" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P487" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P489" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N192" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L192" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P490" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P491" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P493" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N193" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L193" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P494" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.22 //@children.5/@children.2/@children.17/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P496" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N194" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L194" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P497" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P498" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N195" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L195" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.26 //@children.5/@children.2/@children.17/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P501" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P502" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N196" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L196" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P503" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.17/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P504" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.17/@containedEdges.32 //@children.5/@children.2/@children.17/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E380" sources="//@children.5/@children.2/@children.17/@ports.0" targets="//@children.5/@children.2/@children.17/@children.0/@ports.1"/>
+        <containedEdges identifier="E381" sources="//@children.5/@children.2/@children.17/@ports.0" targets="//@children.5/@children.2/@children.17/@children.4/@ports.1"/>
+        <containedEdges identifier="E382" sources="//@children.5/@children.2/@children.17/@ports.0" targets="//@children.5/@children.2/@children.17/@children.15/@ports.1"/>
+        <containedEdges identifier="E383" sources="//@children.5/@children.2/@children.17/@ports.0" targets="//@children.5/@children.2/@children.17/@children.16/@ports.1"/>
+        <containedEdges identifier="E384" sources="//@children.5/@children.2/@children.17/@ports.0" targets="//@children.5/@children.2/@children.17/@children.18/@ports.1"/>
+        <containedEdges identifier="E385" sources="//@children.5/@children.2/@children.17/@ports.3" targets="//@children.5/@children.2/@children.17/@children.4/@ports.0"/>
+        <containedEdges identifier="E386" sources="//@children.5/@children.2/@children.17/@ports.3" targets="//@children.5/@children.2/@children.17/@children.18/@ports.2"/>
+        <containedEdges identifier="E387" sources="//@children.5/@children.2/@children.17/@ports.1" targets="//@children.5/@children.2/@children.17/@children.7/@ports.0"/>
+        <containedEdges identifier="E388" sources="//@children.5/@children.2/@children.17/@ports.1" targets="//@children.5/@children.2/@children.17/@children.10/@ports.0"/>
+        <containedEdges identifier="E389" sources="//@children.5/@children.2/@children.17/@ports.1" targets="//@children.5/@children.2/@children.17/@children.14/@ports.0"/>
+        <containedEdges identifier="E390" sources="//@children.5/@children.2/@children.17/@children.0/@ports.2" targets="//@children.5/@children.2/@children.17/@children.9/@ports.0"/>
+        <containedEdges identifier="E391" sources="//@children.5/@children.2/@children.17/@children.1/@ports.1" targets="//@children.5/@children.2/@children.17/@children.2/@ports.0"/>
+        <containedEdges identifier="E392" sources="//@children.5/@children.2/@children.17/@children.1/@ports.1" targets="//@children.5/@children.2/@children.17/@children.12/@ports.0"/>
+        <containedEdges identifier="E393" sources="//@children.5/@children.2/@children.17/@children.2/@ports.2" targets="//@children.5/@children.2/@children.17/@ports.2"/>
+        <containedEdges identifier="E394" sources="//@children.5/@children.2/@children.17/@children.2/@ports.2" targets="//@children.5/@children.2/@children.17/@children.5/@ports.0"/>
+        <containedEdges identifier="E395" sources="//@children.5/@children.2/@children.17/@children.3/@ports.0" targets="//@children.5/@children.2/@children.17/@children.2/@ports.0"/>
+        <containedEdges identifier="E396" sources="//@children.5/@children.2/@children.17/@children.4/@ports.2" targets="//@children.5/@children.2/@children.17/@children.6/@ports.0"/>
+        <containedEdges identifier="E397" sources="//@children.5/@children.2/@children.17/@children.5/@ports.1" targets="//@children.5/@children.2/@children.17/@children.6/@ports.0"/>
+        <containedEdges identifier="E398" sources="//@children.5/@children.2/@children.17/@children.6/@ports.2" targets="//@children.5/@children.2/@children.17/@ports.4"/>
+        <containedEdges identifier="E399" sources="//@children.5/@children.2/@children.17/@children.7/@ports.1" targets="//@children.5/@children.2/@children.17/@children.0/@ports.0"/>
+        <containedEdges identifier="E400" sources="//@children.5/@children.2/@children.17/@children.7/@ports.1" targets="//@children.5/@children.2/@children.17/@children.15/@ports.0"/>
+        <containedEdges identifier="E401" sources="//@children.5/@children.2/@children.17/@children.8/@ports.1" targets="//@children.5/@children.2/@children.17/@children.1/@ports.0"/>
+        <containedEdges identifier="E402" sources="//@children.5/@children.2/@children.17/@children.9/@ports.1" targets="//@children.5/@children.2/@children.17/@children.17/@ports.0"/>
+        <containedEdges identifier="E403" sources="//@children.5/@children.2/@children.17/@children.10/@ports.1" targets="//@children.5/@children.2/@children.17/@children.16/@ports.2"/>
+        <containedEdges identifier="E404" sources="//@children.5/@children.2/@children.17/@children.10/@ports.1" targets="//@children.5/@children.2/@children.17/@children.16/@ports.3"/>
+        <containedEdges identifier="E405" sources="//@children.5/@children.2/@children.17/@children.11/@ports.0" targets="//@children.5/@children.2/@children.17/@children.8/@ports.0"/>
+        <containedEdges identifier="E406" sources="//@children.5/@children.2/@children.17/@children.13/@ports.1" targets="//@children.5/@children.2/@children.17/@children.19/@ports.0"/>
+        <containedEdges identifier="E407" sources="//@children.5/@children.2/@children.17/@children.15/@ports.2" targets="//@children.5/@children.2/@children.17/@children.13/@ports.0"/>
+        <containedEdges identifier="E408" sources="//@children.5/@children.2/@children.17/@children.16/@ports.0" targets="//@children.5/@children.2/@children.17/@children.8/@ports.2"/>
+        <containedEdges identifier="E409" sources="//@children.5/@children.2/@children.17/@children.17/@ports.2" targets="//@children.5/@children.2/@children.17/@children.8/@ports.0"/>
+        <containedEdges identifier="E410" sources="//@children.5/@children.2/@children.17/@children.18/@ports.0" targets="//@children.5/@children.2/@children.17/@children.20/@ports.0"/>
+        <containedEdges identifier="E411" sources="//@children.5/@children.2/@children.17/@children.19/@ports.2" targets="//@children.5/@children.2/@children.17/@children.8/@ports.0"/>
+        <containedEdges identifier="E412" sources="//@children.5/@children.2/@children.17/@children.20/@ports.1" targets="//@children.5/@children.2/@children.17/@children.17/@ports.0"/>
+        <containedEdges identifier="E413" sources="//@children.5/@children.2/@children.17/@children.20/@ports.1" targets="//@children.5/@children.2/@children.17/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N197">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L197" height="15.0" width="56.0" text="VAVPeri8"/>
+        <ports identifier="P505" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.0 //@children.5/@children.2/@children.18/@containedEdges.1 //@children.5/@children.2/@children.18/@containedEdges.2 //@children.5/@children.2/@children.18/@containedEdges.3 //@children.5/@children.2/@children.18/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.51">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P506" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.7 //@children.5/@children.2/@children.18/@containedEdges.8 //@children.5/@children.2/@children.18/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P507" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.95" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P508" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.5 //@children.5/@children.2/@children.18/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P509" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.96" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N198" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L198" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P511" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P512" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N199" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L199" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P513" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P514" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.11 //@children.5/@children.2/@children.18/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N200" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L200" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.11 //@children.5/@children.2/@children.18/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P516" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P517" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.13 //@children.5/@children.2/@children.18/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N201" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L201" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P518" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N202" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L202" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P520" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P521" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P522" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N203" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L203" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P523" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P524" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N204" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L204" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P525" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.16 //@children.5/@children.2/@children.18/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P526" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P527" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N205" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L205" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P528" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P529" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.19 //@children.5/@children.2/@children.18/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N206" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L206" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.25 //@children.5/@children.2/@children.18/@containedEdges.29 //@children.5/@children.2/@children.18/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P531" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P532" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N207" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L207" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P533" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P534" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N208" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L208" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P536" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.23 //@children.5/@children.2/@children.18/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N209" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L209" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P537" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P538" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N210" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L210" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P540" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N211" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L211" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P541" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P542" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N212" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L212" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P544" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N213" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L213" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P547" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N214" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L214" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P548" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N215" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L215" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.22 //@children.5/@children.2/@children.18/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P553" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P554" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N216" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L216" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P555" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P556" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P557" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N217" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L217" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P558" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.26 //@children.5/@children.2/@children.18/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P559" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P560" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N218" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L218" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.18/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P562" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.18/@containedEdges.32 //@children.5/@children.2/@children.18/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E414" sources="//@children.5/@children.2/@children.18/@ports.0" targets="//@children.5/@children.2/@children.18/@children.0/@ports.1"/>
+        <containedEdges identifier="E415" sources="//@children.5/@children.2/@children.18/@ports.0" targets="//@children.5/@children.2/@children.18/@children.4/@ports.1"/>
+        <containedEdges identifier="E416" sources="//@children.5/@children.2/@children.18/@ports.0" targets="//@children.5/@children.2/@children.18/@children.15/@ports.1"/>
+        <containedEdges identifier="E417" sources="//@children.5/@children.2/@children.18/@ports.0" targets="//@children.5/@children.2/@children.18/@children.16/@ports.1"/>
+        <containedEdges identifier="E418" sources="//@children.5/@children.2/@children.18/@ports.0" targets="//@children.5/@children.2/@children.18/@children.18/@ports.1"/>
+        <containedEdges identifier="E419" sources="//@children.5/@children.2/@children.18/@ports.3" targets="//@children.5/@children.2/@children.18/@children.4/@ports.0"/>
+        <containedEdges identifier="E420" sources="//@children.5/@children.2/@children.18/@ports.3" targets="//@children.5/@children.2/@children.18/@children.18/@ports.2"/>
+        <containedEdges identifier="E421" sources="//@children.5/@children.2/@children.18/@ports.1" targets="//@children.5/@children.2/@children.18/@children.7/@ports.0"/>
+        <containedEdges identifier="E422" sources="//@children.5/@children.2/@children.18/@ports.1" targets="//@children.5/@children.2/@children.18/@children.10/@ports.0"/>
+        <containedEdges identifier="E423" sources="//@children.5/@children.2/@children.18/@ports.1" targets="//@children.5/@children.2/@children.18/@children.14/@ports.0"/>
+        <containedEdges identifier="E424" sources="//@children.5/@children.2/@children.18/@children.0/@ports.2" targets="//@children.5/@children.2/@children.18/@children.9/@ports.0"/>
+        <containedEdges identifier="E425" sources="//@children.5/@children.2/@children.18/@children.1/@ports.1" targets="//@children.5/@children.2/@children.18/@children.2/@ports.0"/>
+        <containedEdges identifier="E426" sources="//@children.5/@children.2/@children.18/@children.1/@ports.1" targets="//@children.5/@children.2/@children.18/@children.12/@ports.0"/>
+        <containedEdges identifier="E427" sources="//@children.5/@children.2/@children.18/@children.2/@ports.2" targets="//@children.5/@children.2/@children.18/@ports.2"/>
+        <containedEdges identifier="E428" sources="//@children.5/@children.2/@children.18/@children.2/@ports.2" targets="//@children.5/@children.2/@children.18/@children.5/@ports.0"/>
+        <containedEdges identifier="E429" sources="//@children.5/@children.2/@children.18/@children.3/@ports.0" targets="//@children.5/@children.2/@children.18/@children.2/@ports.0"/>
+        <containedEdges identifier="E430" sources="//@children.5/@children.2/@children.18/@children.4/@ports.2" targets="//@children.5/@children.2/@children.18/@children.6/@ports.0"/>
+        <containedEdges identifier="E431" sources="//@children.5/@children.2/@children.18/@children.5/@ports.1" targets="//@children.5/@children.2/@children.18/@children.6/@ports.0"/>
+        <containedEdges identifier="E432" sources="//@children.5/@children.2/@children.18/@children.6/@ports.2" targets="//@children.5/@children.2/@children.18/@ports.4"/>
+        <containedEdges identifier="E433" sources="//@children.5/@children.2/@children.18/@children.7/@ports.1" targets="//@children.5/@children.2/@children.18/@children.0/@ports.0"/>
+        <containedEdges identifier="E434" sources="//@children.5/@children.2/@children.18/@children.7/@ports.1" targets="//@children.5/@children.2/@children.18/@children.15/@ports.0"/>
+        <containedEdges identifier="E435" sources="//@children.5/@children.2/@children.18/@children.8/@ports.1" targets="//@children.5/@children.2/@children.18/@children.1/@ports.0"/>
+        <containedEdges identifier="E436" sources="//@children.5/@children.2/@children.18/@children.9/@ports.1" targets="//@children.5/@children.2/@children.18/@children.17/@ports.0"/>
+        <containedEdges identifier="E437" sources="//@children.5/@children.2/@children.18/@children.10/@ports.1" targets="//@children.5/@children.2/@children.18/@children.16/@ports.2"/>
+        <containedEdges identifier="E438" sources="//@children.5/@children.2/@children.18/@children.10/@ports.1" targets="//@children.5/@children.2/@children.18/@children.16/@ports.3"/>
+        <containedEdges identifier="E439" sources="//@children.5/@children.2/@children.18/@children.11/@ports.0" targets="//@children.5/@children.2/@children.18/@children.8/@ports.0"/>
+        <containedEdges identifier="E440" sources="//@children.5/@children.2/@children.18/@children.13/@ports.1" targets="//@children.5/@children.2/@children.18/@children.19/@ports.0"/>
+        <containedEdges identifier="E441" sources="//@children.5/@children.2/@children.18/@children.15/@ports.2" targets="//@children.5/@children.2/@children.18/@children.13/@ports.0"/>
+        <containedEdges identifier="E442" sources="//@children.5/@children.2/@children.18/@children.16/@ports.0" targets="//@children.5/@children.2/@children.18/@children.8/@ports.2"/>
+        <containedEdges identifier="E443" sources="//@children.5/@children.2/@children.18/@children.17/@ports.2" targets="//@children.5/@children.2/@children.18/@children.8/@ports.0"/>
+        <containedEdges identifier="E444" sources="//@children.5/@children.2/@children.18/@children.18/@ports.0" targets="//@children.5/@children.2/@children.18/@children.20/@ports.0"/>
+        <containedEdges identifier="E445" sources="//@children.5/@children.2/@children.18/@children.19/@ports.2" targets="//@children.5/@children.2/@children.18/@children.8/@ports.0"/>
+        <containedEdges identifier="E446" sources="//@children.5/@children.2/@children.18/@children.20/@ports.1" targets="//@children.5/@children.2/@children.18/@children.17/@ports.0"/>
+        <containedEdges identifier="E447" sources="//@children.5/@children.2/@children.18/@children.20/@ports.1" targets="//@children.5/@children.2/@children.18/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N219">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L219" height="15.0" width="56.0" text="VAVPeri9"/>
+        <ports identifier="P563" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.0 //@children.5/@children.2/@children.19/@containedEdges.1 //@children.5/@children.2/@children.19/@containedEdges.2 //@children.5/@children.2/@children.19/@containedEdges.3 //@children.5/@children.2/@children.19/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.52">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P564" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.7 //@children.5/@children.2/@children.19/@containedEdges.8 //@children.5/@children.2/@children.19/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P565" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.98" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P566" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.5 //@children.5/@children.2/@children.19/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P567" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.97" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N220" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L220" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P568" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P570" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N221" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L221" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P571" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P572" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.11 //@children.5/@children.2/@children.19/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N222" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L222" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.11 //@children.5/@children.2/@children.19/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P574" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P575" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.13 //@children.5/@children.2/@children.19/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N223" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L223" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P576" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N224" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L224" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P578" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P579" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P580" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N225" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L225" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P581" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P582" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N226" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L226" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P583" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.16 //@children.5/@children.2/@children.19/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P584" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P585" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N227" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L227" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P587" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.19 //@children.5/@children.2/@children.19/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N228" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L228" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P588" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.25 //@children.5/@children.2/@children.19/@containedEdges.29 //@children.5/@children.2/@children.19/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P589" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P590" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N229" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L229" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P592" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N230" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L230" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P593" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P594" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.23 //@children.5/@children.2/@children.19/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N231" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L231" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P595" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N232" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L232" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P597" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P598" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N233" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L233" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P600" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N234" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L234" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P601" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P602" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N235" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L235" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P604" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P605" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N236" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L236" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P606" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P607" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P609" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N237" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L237" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P610" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.22 //@children.5/@children.2/@children.19/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P612" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N238" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L238" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P613" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P614" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N239" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L239" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P616" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.26 //@children.5/@children.2/@children.19/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P618" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N240" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L240" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P619" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.19/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P620" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.19/@containedEdges.32 //@children.5/@children.2/@children.19/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E448" sources="//@children.5/@children.2/@children.19/@ports.0" targets="//@children.5/@children.2/@children.19/@children.0/@ports.1"/>
+        <containedEdges identifier="E449" sources="//@children.5/@children.2/@children.19/@ports.0" targets="//@children.5/@children.2/@children.19/@children.4/@ports.1"/>
+        <containedEdges identifier="E450" sources="//@children.5/@children.2/@children.19/@ports.0" targets="//@children.5/@children.2/@children.19/@children.15/@ports.1"/>
+        <containedEdges identifier="E451" sources="//@children.5/@children.2/@children.19/@ports.0" targets="//@children.5/@children.2/@children.19/@children.16/@ports.1"/>
+        <containedEdges identifier="E452" sources="//@children.5/@children.2/@children.19/@ports.0" targets="//@children.5/@children.2/@children.19/@children.18/@ports.1"/>
+        <containedEdges identifier="E453" sources="//@children.5/@children.2/@children.19/@ports.3" targets="//@children.5/@children.2/@children.19/@children.4/@ports.0"/>
+        <containedEdges identifier="E454" sources="//@children.5/@children.2/@children.19/@ports.3" targets="//@children.5/@children.2/@children.19/@children.18/@ports.2"/>
+        <containedEdges identifier="E455" sources="//@children.5/@children.2/@children.19/@ports.1" targets="//@children.5/@children.2/@children.19/@children.7/@ports.0"/>
+        <containedEdges identifier="E456" sources="//@children.5/@children.2/@children.19/@ports.1" targets="//@children.5/@children.2/@children.19/@children.10/@ports.0"/>
+        <containedEdges identifier="E457" sources="//@children.5/@children.2/@children.19/@ports.1" targets="//@children.5/@children.2/@children.19/@children.14/@ports.0"/>
+        <containedEdges identifier="E458" sources="//@children.5/@children.2/@children.19/@children.0/@ports.2" targets="//@children.5/@children.2/@children.19/@children.9/@ports.0"/>
+        <containedEdges identifier="E459" sources="//@children.5/@children.2/@children.19/@children.1/@ports.1" targets="//@children.5/@children.2/@children.19/@children.2/@ports.0"/>
+        <containedEdges identifier="E460" sources="//@children.5/@children.2/@children.19/@children.1/@ports.1" targets="//@children.5/@children.2/@children.19/@children.12/@ports.0"/>
+        <containedEdges identifier="E461" sources="//@children.5/@children.2/@children.19/@children.2/@ports.2" targets="//@children.5/@children.2/@children.19/@ports.2"/>
+        <containedEdges identifier="E462" sources="//@children.5/@children.2/@children.19/@children.2/@ports.2" targets="//@children.5/@children.2/@children.19/@children.5/@ports.0"/>
+        <containedEdges identifier="E463" sources="//@children.5/@children.2/@children.19/@children.3/@ports.0" targets="//@children.5/@children.2/@children.19/@children.2/@ports.0"/>
+        <containedEdges identifier="E464" sources="//@children.5/@children.2/@children.19/@children.4/@ports.2" targets="//@children.5/@children.2/@children.19/@children.6/@ports.0"/>
+        <containedEdges identifier="E465" sources="//@children.5/@children.2/@children.19/@children.5/@ports.1" targets="//@children.5/@children.2/@children.19/@children.6/@ports.0"/>
+        <containedEdges identifier="E466" sources="//@children.5/@children.2/@children.19/@children.6/@ports.2" targets="//@children.5/@children.2/@children.19/@ports.4"/>
+        <containedEdges identifier="E467" sources="//@children.5/@children.2/@children.19/@children.7/@ports.1" targets="//@children.5/@children.2/@children.19/@children.0/@ports.0"/>
+        <containedEdges identifier="E468" sources="//@children.5/@children.2/@children.19/@children.7/@ports.1" targets="//@children.5/@children.2/@children.19/@children.15/@ports.0"/>
+        <containedEdges identifier="E469" sources="//@children.5/@children.2/@children.19/@children.8/@ports.1" targets="//@children.5/@children.2/@children.19/@children.1/@ports.0"/>
+        <containedEdges identifier="E470" sources="//@children.5/@children.2/@children.19/@children.9/@ports.1" targets="//@children.5/@children.2/@children.19/@children.17/@ports.0"/>
+        <containedEdges identifier="E471" sources="//@children.5/@children.2/@children.19/@children.10/@ports.1" targets="//@children.5/@children.2/@children.19/@children.16/@ports.2"/>
+        <containedEdges identifier="E472" sources="//@children.5/@children.2/@children.19/@children.10/@ports.1" targets="//@children.5/@children.2/@children.19/@children.16/@ports.3"/>
+        <containedEdges identifier="E473" sources="//@children.5/@children.2/@children.19/@children.11/@ports.0" targets="//@children.5/@children.2/@children.19/@children.8/@ports.0"/>
+        <containedEdges identifier="E474" sources="//@children.5/@children.2/@children.19/@children.13/@ports.1" targets="//@children.5/@children.2/@children.19/@children.19/@ports.0"/>
+        <containedEdges identifier="E475" sources="//@children.5/@children.2/@children.19/@children.15/@ports.2" targets="//@children.5/@children.2/@children.19/@children.13/@ports.0"/>
+        <containedEdges identifier="E476" sources="//@children.5/@children.2/@children.19/@children.16/@ports.0" targets="//@children.5/@children.2/@children.19/@children.8/@ports.2"/>
+        <containedEdges identifier="E477" sources="//@children.5/@children.2/@children.19/@children.17/@ports.2" targets="//@children.5/@children.2/@children.19/@children.8/@ports.0"/>
+        <containedEdges identifier="E478" sources="//@children.5/@children.2/@children.19/@children.18/@ports.0" targets="//@children.5/@children.2/@children.19/@children.20/@ports.0"/>
+        <containedEdges identifier="E479" sources="//@children.5/@children.2/@children.19/@children.19/@ports.2" targets="//@children.5/@children.2/@children.19/@children.8/@ports.0"/>
+        <containedEdges identifier="E480" sources="//@children.5/@children.2/@children.19/@children.20/@ports.1" targets="//@children.5/@children.2/@children.19/@children.17/@ports.0"/>
+        <containedEdges identifier="E481" sources="//@children.5/@children.2/@children.19/@children.20/@ports.1" targets="//@children.5/@children.2/@children.19/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N241">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L241" height="15.0" width="63.0" text="VAVPeri10"/>
+        <ports identifier="P621" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.0 //@children.5/@children.2/@children.20/@containedEdges.1 //@children.5/@children.2/@children.20/@containedEdges.2 //@children.5/@children.2/@children.20/@containedEdges.3 //@children.5/@children.2/@children.20/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.53">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P622" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.7 //@children.5/@children.2/@children.20/@containedEdges.8 //@children.5/@children.2/@children.20/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P623" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.99" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P624" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.5 //@children.5/@children.2/@children.20/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.23">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P625" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.100" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N242" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L242" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P626" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P628" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N243" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L243" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P629" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P630" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.11 //@children.5/@children.2/@children.20/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N244" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L244" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P631" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.11 //@children.5/@children.2/@children.20/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P633" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.13 //@children.5/@children.2/@children.20/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N245" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L245" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P634" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N246" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L246" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P636" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P637" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P638" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N247" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L247" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P639" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P640" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N248" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L248" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P641" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.16 //@children.5/@children.2/@children.20/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P642" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P643" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N249" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L249" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P645" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.19 //@children.5/@children.2/@children.20/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N250" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L250" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P646" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.25 //@children.5/@children.2/@children.20/@containedEdges.29 //@children.5/@children.2/@children.20/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P647" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P648" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N251" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L251" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P649" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P650" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N252" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L252" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P651" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P652" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.23 //@children.5/@children.2/@children.20/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N253" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L253" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P653" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P654" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N254" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L254" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P655" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P656" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N255" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L255" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P657" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P658" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N256" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L256" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P659" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P660" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N257" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L257" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P661" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P662" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P663" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N258" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L258" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P664" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P665" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P666" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P667" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N259" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L259" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.22 //@children.5/@children.2/@children.20/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P670" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N260" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L260" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P671" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P672" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P673" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N261" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L261" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P674" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.26 //@children.5/@children.2/@children.20/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P676" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N262" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L262" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P677" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.20/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P678" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.20/@containedEdges.32 //@children.5/@children.2/@children.20/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E482" sources="//@children.5/@children.2/@children.20/@ports.0" targets="//@children.5/@children.2/@children.20/@children.0/@ports.1"/>
+        <containedEdges identifier="E483" sources="//@children.5/@children.2/@children.20/@ports.0" targets="//@children.5/@children.2/@children.20/@children.4/@ports.1"/>
+        <containedEdges identifier="E484" sources="//@children.5/@children.2/@children.20/@ports.0" targets="//@children.5/@children.2/@children.20/@children.15/@ports.1"/>
+        <containedEdges identifier="E485" sources="//@children.5/@children.2/@children.20/@ports.0" targets="//@children.5/@children.2/@children.20/@children.16/@ports.1"/>
+        <containedEdges identifier="E486" sources="//@children.5/@children.2/@children.20/@ports.0" targets="//@children.5/@children.2/@children.20/@children.18/@ports.1"/>
+        <containedEdges identifier="E487" sources="//@children.5/@children.2/@children.20/@ports.3" targets="//@children.5/@children.2/@children.20/@children.4/@ports.0"/>
+        <containedEdges identifier="E488" sources="//@children.5/@children.2/@children.20/@ports.3" targets="//@children.5/@children.2/@children.20/@children.18/@ports.2"/>
+        <containedEdges identifier="E489" sources="//@children.5/@children.2/@children.20/@ports.1" targets="//@children.5/@children.2/@children.20/@children.7/@ports.0"/>
+        <containedEdges identifier="E490" sources="//@children.5/@children.2/@children.20/@ports.1" targets="//@children.5/@children.2/@children.20/@children.10/@ports.0"/>
+        <containedEdges identifier="E491" sources="//@children.5/@children.2/@children.20/@ports.1" targets="//@children.5/@children.2/@children.20/@children.14/@ports.0"/>
+        <containedEdges identifier="E492" sources="//@children.5/@children.2/@children.20/@children.0/@ports.2" targets="//@children.5/@children.2/@children.20/@children.9/@ports.0"/>
+        <containedEdges identifier="E493" sources="//@children.5/@children.2/@children.20/@children.1/@ports.1" targets="//@children.5/@children.2/@children.20/@children.2/@ports.0"/>
+        <containedEdges identifier="E494" sources="//@children.5/@children.2/@children.20/@children.1/@ports.1" targets="//@children.5/@children.2/@children.20/@children.12/@ports.0"/>
+        <containedEdges identifier="E495" sources="//@children.5/@children.2/@children.20/@children.2/@ports.2" targets="//@children.5/@children.2/@children.20/@ports.2"/>
+        <containedEdges identifier="E496" sources="//@children.5/@children.2/@children.20/@children.2/@ports.2" targets="//@children.5/@children.2/@children.20/@children.5/@ports.0"/>
+        <containedEdges identifier="E497" sources="//@children.5/@children.2/@children.20/@children.3/@ports.0" targets="//@children.5/@children.2/@children.20/@children.2/@ports.0"/>
+        <containedEdges identifier="E498" sources="//@children.5/@children.2/@children.20/@children.4/@ports.2" targets="//@children.5/@children.2/@children.20/@children.6/@ports.0"/>
+        <containedEdges identifier="E499" sources="//@children.5/@children.2/@children.20/@children.5/@ports.1" targets="//@children.5/@children.2/@children.20/@children.6/@ports.0"/>
+        <containedEdges identifier="E500" sources="//@children.5/@children.2/@children.20/@children.6/@ports.2" targets="//@children.5/@children.2/@children.20/@ports.4"/>
+        <containedEdges identifier="E501" sources="//@children.5/@children.2/@children.20/@children.7/@ports.1" targets="//@children.5/@children.2/@children.20/@children.0/@ports.0"/>
+        <containedEdges identifier="E502" sources="//@children.5/@children.2/@children.20/@children.7/@ports.1" targets="//@children.5/@children.2/@children.20/@children.15/@ports.0"/>
+        <containedEdges identifier="E503" sources="//@children.5/@children.2/@children.20/@children.8/@ports.1" targets="//@children.5/@children.2/@children.20/@children.1/@ports.0"/>
+        <containedEdges identifier="E504" sources="//@children.5/@children.2/@children.20/@children.9/@ports.1" targets="//@children.5/@children.2/@children.20/@children.17/@ports.0"/>
+        <containedEdges identifier="E505" sources="//@children.5/@children.2/@children.20/@children.10/@ports.1" targets="//@children.5/@children.2/@children.20/@children.16/@ports.2"/>
+        <containedEdges identifier="E506" sources="//@children.5/@children.2/@children.20/@children.10/@ports.1" targets="//@children.5/@children.2/@children.20/@children.16/@ports.3"/>
+        <containedEdges identifier="E507" sources="//@children.5/@children.2/@children.20/@children.11/@ports.0" targets="//@children.5/@children.2/@children.20/@children.8/@ports.0"/>
+        <containedEdges identifier="E508" sources="//@children.5/@children.2/@children.20/@children.13/@ports.1" targets="//@children.5/@children.2/@children.20/@children.19/@ports.0"/>
+        <containedEdges identifier="E509" sources="//@children.5/@children.2/@children.20/@children.15/@ports.2" targets="//@children.5/@children.2/@children.20/@children.13/@ports.0"/>
+        <containedEdges identifier="E510" sources="//@children.5/@children.2/@children.20/@children.16/@ports.0" targets="//@children.5/@children.2/@children.20/@children.8/@ports.2"/>
+        <containedEdges identifier="E511" sources="//@children.5/@children.2/@children.20/@children.17/@ports.2" targets="//@children.5/@children.2/@children.20/@children.8/@ports.0"/>
+        <containedEdges identifier="E512" sources="//@children.5/@children.2/@children.20/@children.18/@ports.0" targets="//@children.5/@children.2/@children.20/@children.20/@ports.0"/>
+        <containedEdges identifier="E513" sources="//@children.5/@children.2/@children.20/@children.19/@ports.2" targets="//@children.5/@children.2/@children.20/@children.8/@ports.0"/>
+        <containedEdges identifier="E514" sources="//@children.5/@children.2/@children.20/@children.20/@ports.1" targets="//@children.5/@children.2/@children.20/@children.17/@ports.0"/>
+        <containedEdges identifier="E515" sources="//@children.5/@children.2/@children.20/@children.20/@ports.1" targets="//@children.5/@children.2/@children.20/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N263">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L263" height="15.0" width="62.0" text="VAVPeri11"/>
+        <ports identifier="P679" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.0 //@children.5/@children.2/@children.21/@containedEdges.1 //@children.5/@children.2/@children.21/@containedEdges.2 //@children.5/@children.2/@children.21/@containedEdges.3 //@children.5/@children.2/@children.21/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.54">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P680" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.7 //@children.5/@children.2/@children.21/@containedEdges.8 //@children.5/@children.2/@children.21/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P681" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.102" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P682" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.5 //@children.5/@children.2/@children.21/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.24">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P683" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.101" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N264" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L264" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P684" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P685" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P686" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N265" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L265" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P687" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P688" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.11 //@children.5/@children.2/@children.21/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N266" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L266" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P689" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.11 //@children.5/@children.2/@children.21/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P690" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P691" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.13 //@children.5/@children.2/@children.21/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N267" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L267" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P692" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P693" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N268" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L268" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P695" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P696" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N269" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L269" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P698" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N270" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L270" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P699" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.16 //@children.5/@children.2/@children.21/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P700" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P701" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N271" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L271" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P702" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P703" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.19 //@children.5/@children.2/@children.21/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N272" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L272" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P704" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.25 //@children.5/@children.2/@children.21/@containedEdges.29 //@children.5/@children.2/@children.21/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P705" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P706" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N273" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L273" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P707" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P708" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N274" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L274" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P709" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P710" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.23 //@children.5/@children.2/@children.21/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N275" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L275" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P711" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P712" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N276" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L276" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P713" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P714" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N277" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L277" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P715" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P716" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N278" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L278" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P717" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P718" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N279" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L279" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P719" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P720" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P721" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N280" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L280" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P722" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P723" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P724" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P725" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N281" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L281" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P726" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.22 //@children.5/@children.2/@children.21/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P727" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P728" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N282" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L282" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P729" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P730" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P731" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N283" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L283" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P732" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.26 //@children.5/@children.2/@children.21/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P733" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P734" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N284" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L284" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P735" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.21/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P736" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.21/@containedEdges.32 //@children.5/@children.2/@children.21/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E516" sources="//@children.5/@children.2/@children.21/@ports.0" targets="//@children.5/@children.2/@children.21/@children.0/@ports.1"/>
+        <containedEdges identifier="E517" sources="//@children.5/@children.2/@children.21/@ports.0" targets="//@children.5/@children.2/@children.21/@children.4/@ports.1"/>
+        <containedEdges identifier="E518" sources="//@children.5/@children.2/@children.21/@ports.0" targets="//@children.5/@children.2/@children.21/@children.15/@ports.1"/>
+        <containedEdges identifier="E519" sources="//@children.5/@children.2/@children.21/@ports.0" targets="//@children.5/@children.2/@children.21/@children.16/@ports.1"/>
+        <containedEdges identifier="E520" sources="//@children.5/@children.2/@children.21/@ports.0" targets="//@children.5/@children.2/@children.21/@children.18/@ports.1"/>
+        <containedEdges identifier="E521" sources="//@children.5/@children.2/@children.21/@ports.3" targets="//@children.5/@children.2/@children.21/@children.4/@ports.0"/>
+        <containedEdges identifier="E522" sources="//@children.5/@children.2/@children.21/@ports.3" targets="//@children.5/@children.2/@children.21/@children.18/@ports.2"/>
+        <containedEdges identifier="E523" sources="//@children.5/@children.2/@children.21/@ports.1" targets="//@children.5/@children.2/@children.21/@children.7/@ports.0"/>
+        <containedEdges identifier="E524" sources="//@children.5/@children.2/@children.21/@ports.1" targets="//@children.5/@children.2/@children.21/@children.10/@ports.0"/>
+        <containedEdges identifier="E525" sources="//@children.5/@children.2/@children.21/@ports.1" targets="//@children.5/@children.2/@children.21/@children.14/@ports.0"/>
+        <containedEdges identifier="E526" sources="//@children.5/@children.2/@children.21/@children.0/@ports.2" targets="//@children.5/@children.2/@children.21/@children.9/@ports.0"/>
+        <containedEdges identifier="E527" sources="//@children.5/@children.2/@children.21/@children.1/@ports.1" targets="//@children.5/@children.2/@children.21/@children.2/@ports.0"/>
+        <containedEdges identifier="E528" sources="//@children.5/@children.2/@children.21/@children.1/@ports.1" targets="//@children.5/@children.2/@children.21/@children.12/@ports.0"/>
+        <containedEdges identifier="E529" sources="//@children.5/@children.2/@children.21/@children.2/@ports.2" targets="//@children.5/@children.2/@children.21/@ports.2"/>
+        <containedEdges identifier="E530" sources="//@children.5/@children.2/@children.21/@children.2/@ports.2" targets="//@children.5/@children.2/@children.21/@children.5/@ports.0"/>
+        <containedEdges identifier="E531" sources="//@children.5/@children.2/@children.21/@children.3/@ports.0" targets="//@children.5/@children.2/@children.21/@children.2/@ports.0"/>
+        <containedEdges identifier="E532" sources="//@children.5/@children.2/@children.21/@children.4/@ports.2" targets="//@children.5/@children.2/@children.21/@children.6/@ports.0"/>
+        <containedEdges identifier="E533" sources="//@children.5/@children.2/@children.21/@children.5/@ports.1" targets="//@children.5/@children.2/@children.21/@children.6/@ports.0"/>
+        <containedEdges identifier="E534" sources="//@children.5/@children.2/@children.21/@children.6/@ports.2" targets="//@children.5/@children.2/@children.21/@ports.4"/>
+        <containedEdges identifier="E535" sources="//@children.5/@children.2/@children.21/@children.7/@ports.1" targets="//@children.5/@children.2/@children.21/@children.0/@ports.0"/>
+        <containedEdges identifier="E536" sources="//@children.5/@children.2/@children.21/@children.7/@ports.1" targets="//@children.5/@children.2/@children.21/@children.15/@ports.0"/>
+        <containedEdges identifier="E537" sources="//@children.5/@children.2/@children.21/@children.8/@ports.1" targets="//@children.5/@children.2/@children.21/@children.1/@ports.0"/>
+        <containedEdges identifier="E538" sources="//@children.5/@children.2/@children.21/@children.9/@ports.1" targets="//@children.5/@children.2/@children.21/@children.17/@ports.0"/>
+        <containedEdges identifier="E539" sources="//@children.5/@children.2/@children.21/@children.10/@ports.1" targets="//@children.5/@children.2/@children.21/@children.16/@ports.2"/>
+        <containedEdges identifier="E540" sources="//@children.5/@children.2/@children.21/@children.10/@ports.1" targets="//@children.5/@children.2/@children.21/@children.16/@ports.3"/>
+        <containedEdges identifier="E541" sources="//@children.5/@children.2/@children.21/@children.11/@ports.0" targets="//@children.5/@children.2/@children.21/@children.8/@ports.0"/>
+        <containedEdges identifier="E542" sources="//@children.5/@children.2/@children.21/@children.13/@ports.1" targets="//@children.5/@children.2/@children.21/@children.19/@ports.0"/>
+        <containedEdges identifier="E543" sources="//@children.5/@children.2/@children.21/@children.15/@ports.2" targets="//@children.5/@children.2/@children.21/@children.13/@ports.0"/>
+        <containedEdges identifier="E544" sources="//@children.5/@children.2/@children.21/@children.16/@ports.0" targets="//@children.5/@children.2/@children.21/@children.8/@ports.2"/>
+        <containedEdges identifier="E545" sources="//@children.5/@children.2/@children.21/@children.17/@ports.2" targets="//@children.5/@children.2/@children.21/@children.8/@ports.0"/>
+        <containedEdges identifier="E546" sources="//@children.5/@children.2/@children.21/@children.18/@ports.0" targets="//@children.5/@children.2/@children.21/@children.20/@ports.0"/>
+        <containedEdges identifier="E547" sources="//@children.5/@children.2/@children.21/@children.19/@ports.2" targets="//@children.5/@children.2/@children.21/@children.8/@ports.0"/>
+        <containedEdges identifier="E548" sources="//@children.5/@children.2/@children.21/@children.20/@ports.1" targets="//@children.5/@children.2/@children.21/@children.17/@ports.0"/>
+        <containedEdges identifier="E549" sources="//@children.5/@children.2/@children.21/@children.20/@ports.1" targets="//@children.5/@children.2/@children.21/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N285">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L285" height="15.0" width="63.0" text="VAVPeri12"/>
+        <ports identifier="P737" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.0 //@children.5/@children.2/@children.22/@containedEdges.1 //@children.5/@children.2/@children.22/@containedEdges.2 //@children.5/@children.2/@children.22/@containedEdges.3 //@children.5/@children.2/@children.22/@containedEdges.4" incomingEdges="//@children.5/@children.2/@containedEdges.55">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P738" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.7 //@children.5/@children.2/@children.22/@containedEdges.8 //@children.5/@children.2/@children.22/@containedEdges.9" incomingEdges="//@children.5/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P739" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.104" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P740" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.5 //@children.5/@children.2/@children.22/@containedEdges.6" incomingEdges="//@children.5/@children.2/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P741" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.103" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N286" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L286" height="15.0" width="59.0" text="ErrorTRoo"/>
+          <ports identifier="P742" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P743" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P744" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N287" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L287" height="15.0" width="40.0" text="Limiter"/>
+          <ports identifier="P745" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P746" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.11 //@children.5/@children.2/@children.22/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N288" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L288" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P747" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.11 //@children.5/@children.2/@children.22/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P748" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P749" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.13 //@children.5/@children.2/@children.22/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N289" height="25.0" width="166.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L289" height="15.0" width="72.0" text="m_flow_max"/>
+          <ports identifier="P750" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P751" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N290" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L290" height="15.0" width="38.0" text="dTSup"/>
+          <ports identifier="P752" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P753" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P754" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N291" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L291" height="15.0" width="39.0" text="C_flow"/>
+          <ports identifier="P755" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P756" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N292" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L292" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.16 //@children.5/@children.2/@children.22/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P758" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P759" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N293" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L293" height="15.0" width="117.0" text="VectorDisassembler"/>
+          <ports identifier="P760" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P761" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.19 //@children.5/@children.2/@children.22/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N294" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L294" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P762" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.25 //@children.5/@children.2/@children.22/@containedEdges.29 //@children.5/@children.2/@children.22/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P763" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P764" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N295" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L295" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P765" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P766" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N296" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L296" height="15.0" width="124.0" text="VectorDisassembler2"/>
+          <ports identifier="P767" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P768" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.23 //@children.5/@children.2/@children.22/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N297" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L297" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P769" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P770" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N298" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L298" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P771" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P772" height="8.0" width="8.0" x="66.0" y="19.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N299" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L299" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P773" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P774" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N300" height="41.0" width="10.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L300" height="15.0" width="124.0" text="VectorDisassembler3"/>
+          <ports identifier="P775" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P776" height="8.0" width="8.0" x="10.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N301" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L301" height="15.0" width="66.0" text="ErrorTRoo2"/>
+          <ports identifier="P777" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P778" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P779" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N302" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L302" height="15.0" width="70.0" text="ModalModel"/>
+          <ports identifier="P780" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P781" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P782" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P783" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N303" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L303" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P784" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.22 //@children.5/@children.2/@children.22/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P785" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P786" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N304" height="25.0" width="132.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L304" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P787" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P788" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P789" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N305" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L305" height="15.0" width="87.0" text="MultiplyDivide4"/>
+          <ports identifier="P790" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.26 //@children.5/@children.2/@children.22/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P791" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P792" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N306" height="25.0" width="26.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L306" height="15.0" width="77.0" text="SampleDelay"/>
+          <ports identifier="P793" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@children.22/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P794" height="8.0" width="8.0" x="26.0" y="8.5" outgoingEdges="//@children.5/@children.2/@children.22/@containedEdges.32 //@children.5/@children.2/@children.22/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E550" sources="//@children.5/@children.2/@children.22/@ports.0" targets="//@children.5/@children.2/@children.22/@children.0/@ports.1"/>
+        <containedEdges identifier="E551" sources="//@children.5/@children.2/@children.22/@ports.0" targets="//@children.5/@children.2/@children.22/@children.4/@ports.1"/>
+        <containedEdges identifier="E552" sources="//@children.5/@children.2/@children.22/@ports.0" targets="//@children.5/@children.2/@children.22/@children.15/@ports.1"/>
+        <containedEdges identifier="E553" sources="//@children.5/@children.2/@children.22/@ports.0" targets="//@children.5/@children.2/@children.22/@children.16/@ports.1"/>
+        <containedEdges identifier="E554" sources="//@children.5/@children.2/@children.22/@ports.0" targets="//@children.5/@children.2/@children.22/@children.18/@ports.1"/>
+        <containedEdges identifier="E555" sources="//@children.5/@children.2/@children.22/@ports.3" targets="//@children.5/@children.2/@children.22/@children.4/@ports.0"/>
+        <containedEdges identifier="E556" sources="//@children.5/@children.2/@children.22/@ports.3" targets="//@children.5/@children.2/@children.22/@children.18/@ports.2"/>
+        <containedEdges identifier="E557" sources="//@children.5/@children.2/@children.22/@ports.1" targets="//@children.5/@children.2/@children.22/@children.7/@ports.0"/>
+        <containedEdges identifier="E558" sources="//@children.5/@children.2/@children.22/@ports.1" targets="//@children.5/@children.2/@children.22/@children.10/@ports.0"/>
+        <containedEdges identifier="E559" sources="//@children.5/@children.2/@children.22/@ports.1" targets="//@children.5/@children.2/@children.22/@children.14/@ports.0"/>
+        <containedEdges identifier="E560" sources="//@children.5/@children.2/@children.22/@children.0/@ports.2" targets="//@children.5/@children.2/@children.22/@children.9/@ports.0"/>
+        <containedEdges identifier="E561" sources="//@children.5/@children.2/@children.22/@children.1/@ports.1" targets="//@children.5/@children.2/@children.22/@children.2/@ports.0"/>
+        <containedEdges identifier="E562" sources="//@children.5/@children.2/@children.22/@children.1/@ports.1" targets="//@children.5/@children.2/@children.22/@children.12/@ports.0"/>
+        <containedEdges identifier="E563" sources="//@children.5/@children.2/@children.22/@children.2/@ports.2" targets="//@children.5/@children.2/@children.22/@ports.2"/>
+        <containedEdges identifier="E564" sources="//@children.5/@children.2/@children.22/@children.2/@ports.2" targets="//@children.5/@children.2/@children.22/@children.5/@ports.0"/>
+        <containedEdges identifier="E565" sources="//@children.5/@children.2/@children.22/@children.3/@ports.0" targets="//@children.5/@children.2/@children.22/@children.2/@ports.0"/>
+        <containedEdges identifier="E566" sources="//@children.5/@children.2/@children.22/@children.4/@ports.2" targets="//@children.5/@children.2/@children.22/@children.6/@ports.0"/>
+        <containedEdges identifier="E567" sources="//@children.5/@children.2/@children.22/@children.5/@ports.1" targets="//@children.5/@children.2/@children.22/@children.6/@ports.0"/>
+        <containedEdges identifier="E568" sources="//@children.5/@children.2/@children.22/@children.6/@ports.2" targets="//@children.5/@children.2/@children.22/@ports.4"/>
+        <containedEdges identifier="E569" sources="//@children.5/@children.2/@children.22/@children.7/@ports.1" targets="//@children.5/@children.2/@children.22/@children.0/@ports.0"/>
+        <containedEdges identifier="E570" sources="//@children.5/@children.2/@children.22/@children.7/@ports.1" targets="//@children.5/@children.2/@children.22/@children.15/@ports.0"/>
+        <containedEdges identifier="E571" sources="//@children.5/@children.2/@children.22/@children.8/@ports.1" targets="//@children.5/@children.2/@children.22/@children.1/@ports.0"/>
+        <containedEdges identifier="E572" sources="//@children.5/@children.2/@children.22/@children.9/@ports.1" targets="//@children.5/@children.2/@children.22/@children.17/@ports.0"/>
+        <containedEdges identifier="E573" sources="//@children.5/@children.2/@children.22/@children.10/@ports.1" targets="//@children.5/@children.2/@children.22/@children.16/@ports.2"/>
+        <containedEdges identifier="E574" sources="//@children.5/@children.2/@children.22/@children.10/@ports.1" targets="//@children.5/@children.2/@children.22/@children.16/@ports.3"/>
+        <containedEdges identifier="E575" sources="//@children.5/@children.2/@children.22/@children.11/@ports.0" targets="//@children.5/@children.2/@children.22/@children.8/@ports.0"/>
+        <containedEdges identifier="E576" sources="//@children.5/@children.2/@children.22/@children.13/@ports.1" targets="//@children.5/@children.2/@children.22/@children.19/@ports.0"/>
+        <containedEdges identifier="E577" sources="//@children.5/@children.2/@children.22/@children.15/@ports.2" targets="//@children.5/@children.2/@children.22/@children.13/@ports.0"/>
+        <containedEdges identifier="E578" sources="//@children.5/@children.2/@children.22/@children.16/@ports.0" targets="//@children.5/@children.2/@children.22/@children.8/@ports.2"/>
+        <containedEdges identifier="E579" sources="//@children.5/@children.2/@children.22/@children.17/@ports.2" targets="//@children.5/@children.2/@children.22/@children.8/@ports.0"/>
+        <containedEdges identifier="E580" sources="//@children.5/@children.2/@children.22/@children.18/@ports.0" targets="//@children.5/@children.2/@children.22/@children.20/@ports.0"/>
+        <containedEdges identifier="E581" sources="//@children.5/@children.2/@children.22/@children.19/@ports.2" targets="//@children.5/@children.2/@children.22/@children.8/@ports.0"/>
+        <containedEdges identifier="E582" sources="//@children.5/@children.2/@children.22/@children.20/@ports.1" targets="//@children.5/@children.2/@children.22/@children.17/@ports.0"/>
+        <containedEdges identifier="E583" sources="//@children.5/@children.2/@children.22/@children.20/@ports.1" targets="//@children.5/@children.2/@children.22/@children.19/@ports.0"/>
+      </children>
+      <children identifier="N307" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L307" height="15.0" width="63.0" text="CSVWriter"/>
+        <ports identifier="P795" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@children.2/@containedEdges.105">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N308" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L308" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P796" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.105">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P797" height="8.0" width="8.0" x="-8.0" y="-4.5" incomingEdges="//@children.5/@children.2/@containedEdges.89">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P798" height="8.0" width="8.0" x="-8.0" y="-1.0" incomingEdges="//@children.5/@children.2/@containedEdges.64">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P799" height="8.0" width="8.0" x="-8.0" y="2.5" incomingEdges="//@children.5/@children.2/@containedEdges.66">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P800" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@children.5/@children.2/@containedEdges.68">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P801" height="8.0" width="8.0" x="-8.0" y="9.5" incomingEdges="//@children.5/@children.2/@containedEdges.70">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P802" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.5/@children.2/@containedEdges.72">
+          <properties key="org.eclipse.elk.port.index" value="-6"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P803" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.74">
+          <properties key="org.eclipse.elk.port.index" value="-7"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P804" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@children.5/@children.2/@containedEdges.76">
+          <properties key="org.eclipse.elk.port.index" value="-8"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P805" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@children.5/@children.2/@containedEdges.78">
+          <properties key="org.eclipse.elk.port.index" value="-9"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P806" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@children.5/@children.2/@containedEdges.80">
+          <properties key="org.eclipse.elk.port.index" value="-10"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P807" height="8.0" width="8.0" x="-8.0" y="30.5" incomingEdges="//@children.5/@children.2/@containedEdges.82">
+          <properties key="org.eclipse.elk.port.index" value="-11"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P808" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.5/@children.2/@containedEdges.84">
+          <properties key="org.eclipse.elk.port.index" value="-12"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P809" height="8.0" width="8.0" x="-8.0" y="37.5" incomingEdges="//@children.5/@children.2/@containedEdges.86">
+          <properties key="org.eclipse.elk.port.index" value="-13"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E70" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E71" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E72" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E74" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E75" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.13/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.16/@ports.1"/>
+      <containedEdges identifier="E77" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.17/@ports.1"/>
+      <containedEdges identifier="E78" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.18/@ports.1"/>
+      <containedEdges identifier="E79" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.19/@ports.1"/>
+      <containedEdges identifier="E80" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.20/@ports.1"/>
+      <containedEdges identifier="E81" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.21/@ports.1"/>
+      <containedEdges identifier="E82" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.2/@children.22/@ports.1"/>
+      <containedEdges identifier="E83" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.0/@ports.3"/>
+      <containedEdges identifier="E84" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.1/@ports.3"/>
+      <containedEdges identifier="E85" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.2/@ports.3"/>
+      <containedEdges identifier="E86" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.3/@ports.3"/>
+      <containedEdges identifier="E87" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.4/@ports.3"/>
+      <containedEdges identifier="E88" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.16/@ports.3"/>
+      <containedEdges identifier="E90" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.17/@ports.3"/>
+      <containedEdges identifier="E91" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.18/@ports.3"/>
+      <containedEdges identifier="E92" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.19/@ports.3"/>
+      <containedEdges identifier="E93" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.20/@ports.3"/>
+      <containedEdges identifier="E94" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.21/@ports.3"/>
+      <containedEdges identifier="E95" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.2/@children.22/@ports.3"/>
+      <containedEdges identifier="E96" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.12/@ports.0"/>
+      <containedEdges identifier="E98" sources="//@children.5/@children.2/@ports.6" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.5/@children.2/@children.0/@ports.2" targets="//@children.5/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.5/@children.2/@children.0/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.5/@children.2/@children.0/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.5/@children.2/@children.1/@ports.2" targets="//@children.5/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.5/@children.2/@children.1/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.5/@children.2/@children.1/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.5/@children.2/@children.2/@ports.2" targets="//@children.5/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E106" sources="//@children.5/@children.2/@children.2/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E107" sources="//@children.5/@children.2/@children.2/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E108" sources="//@children.5/@children.2/@children.3/@ports.2" targets="//@children.5/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E109" sources="//@children.5/@children.2/@children.3/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.5/@children.2/@children.3/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E111" sources="//@children.5/@children.2/@children.4/@ports.2" targets="//@children.5/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E112" sources="//@children.5/@children.2/@children.4/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E113" sources="//@children.5/@children.2/@children.4/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E114" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E115" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E116" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E118" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E119" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.16/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.17/@ports.0"/>
+      <containedEdges identifier="E121" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.18/@ports.0"/>
+      <containedEdges identifier="E122" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.19/@ports.0"/>
+      <containedEdges identifier="E123" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.20/@ports.0"/>
+      <containedEdges identifier="E124" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.21/@ports.0"/>
+      <containedEdges identifier="E125" sources="//@children.5/@children.2/@children.5/@ports.1" targets="//@children.5/@children.2/@children.22/@ports.0"/>
+      <containedEdges identifier="E126" sources="//@children.5/@children.2/@children.6/@ports.2" targets="//@children.5/@children.2/@children.7/@ports.0"/>
+      <containedEdges identifier="E127" sources="//@children.5/@children.2/@children.6/@ports.2" targets="//@children.5/@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E128" sources="//@children.5/@children.2/@children.7/@ports.1" targets="//@children.5/@children.2/@ports.4"/>
+      <containedEdges identifier="E129" sources="//@children.5/@children.2/@children.8/@ports.1" targets="//@children.5/@children.2/@children.9/@ports.0"/>
+      <containedEdges identifier="E130" sources="//@children.5/@children.2/@children.8/@ports.1" targets="//@children.5/@children.2/@children.15/@ports.0"/>
+      <containedEdges identifier="E131" sources="//@children.5/@children.2/@children.9/@ports.2" targets="//@children.5/@children.2/@ports.3"/>
+      <containedEdges identifier="E132" sources="//@children.5/@children.2/@children.10/@ports.1" targets="//@children.5/@children.2/@ports.5"/>
+      <containedEdges identifier="E133" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E134" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.2"/>
+      <containedEdges identifier="E135" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.3"/>
+      <containedEdges identifier="E137" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E138" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.4"/>
+      <containedEdges identifier="E139" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E140" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.5"/>
+      <containedEdges identifier="E141" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E142" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.6"/>
+      <containedEdges identifier="E143" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E144" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.7"/>
+      <containedEdges identifier="E145" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E146" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.8"/>
+      <containedEdges identifier="E147" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E148" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.9"/>
+      <containedEdges identifier="E149" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E150" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.10"/>
+      <containedEdges identifier="E151" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E152" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.11"/>
+      <containedEdges identifier="E153" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E154" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.12"/>
+      <containedEdges identifier="E155" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E156" sources="//@children.5/@children.2/@children.12/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.13"/>
+      <containedEdges identifier="E157" sources="//@children.5/@children.2/@children.13/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E158" sources="//@children.5/@children.2/@children.13/@ports.1" targets="//@children.5/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E159" sources="//@children.5/@children.2/@children.13/@ports.1" targets="//@children.5/@children.2/@children.24/@ports.1"/>
+      <containedEdges identifier="E160" sources="//@children.5/@children.2/@children.15/@ports.1" targets="//@children.5/@children.2/@children.14/@ports.0"/>
+      <containedEdges identifier="E161" sources="//@children.5/@children.2/@children.16/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E162" sources="//@children.5/@children.2/@children.16/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E163" sources="//@children.5/@children.2/@children.17/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E164" sources="//@children.5/@children.2/@children.17/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E165" sources="//@children.5/@children.2/@children.18/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E166" sources="//@children.5/@children.2/@children.18/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E167" sources="//@children.5/@children.2/@children.19/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E168" sources="//@children.5/@children.2/@children.19/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E169" sources="//@children.5/@children.2/@children.20/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E170" sources="//@children.5/@children.2/@children.20/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E171" sources="//@children.5/@children.2/@children.21/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E172" sources="//@children.5/@children.2/@children.21/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E173" sources="//@children.5/@children.2/@children.22/@ports.4" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E174" sources="//@children.5/@children.2/@children.22/@ports.2" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E175" sources="//@children.5/@children.2/@children.24/@ports.0" targets="//@children.5/@children.2/@children.23/@ports.0"/>
+    </children>
+    <children identifier="N309" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L309" height="15.0" width="28.0" text="TOut"/>
+      <ports identifier="P810" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P811" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.9 //@children.5/@containedEdges.10 //@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N310" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L310" height="15.0" width="41.0" text="TRoom"/>
+      <ports identifier="P812" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P813" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.12 //@children.5/@containedEdges.13 //@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P814" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P815" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P816" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P817" height="8.0" width="8.0" x="-8.0" y="32.83333206176758">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N311">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L311" height="15.0" width="77.0" text="CentralHVAC"/>
+      <ports identifier="P818" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@containedEdges.0 //@children.5/@children.5/@containedEdges.1 //@children.5/@children.5/@containedEdges.2" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P819" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@containedEdges.7" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P820" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@containedEdges.4 //@children.5/@children.5/@containedEdges.5 //@children.5/@children.5/@containedEdges.6" incomingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P821" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.15" incomingEdges="//@children.5/@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P822" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@containedEdges.3" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N312">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L312" height="15.0" width="81.0" text="ThermalModel"/>
+        <ports identifier="P823" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.2 //@children.5/@children.5/@children.0/@containedEdges.3 //@children.5/@children.5/@children.0/@containedEdges.4" incomingEdges="//@children.5/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P824" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.5 //@children.5/@children.5/@children.0/@containedEdges.6 //@children.5/@children.5/@children.0/@containedEdges.7" incomingEdges="//@children.5/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P825" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.8 //@children.5/@children.5/@children.0/@containedEdges.9 //@children.5/@children.5/@children.0/@containedEdges.10" incomingEdges="//@children.5/@children.5/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P826" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@containedEdges.8" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P827" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.0 //@children.5/@children.5/@children.0/@containedEdges.1" incomingEdges="//@children.5/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P828" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.11 //@children.5/@children.5/@children.0/@containedEdges.12" incomingEdges="//@children.5/@children.5/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N313" height="25.0" width="224.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L313" height="15.0" width="97.0" text="TEconomizerOut"/>
+          <ports identifier="P829" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.13 //@children.5/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P830" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P831" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P832" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N314" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L314" height="15.0" width="74.0" text="TimedPlotter"/>
+          <ports identifier="P833" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.3 //@children.5/@children.5/@children.0/@containedEdges.6 //@children.5/@children.5/@children.0/@containedEdges.13 //@children.5/@children.5/@children.0/@containedEdges.18 //@children.5/@children.5/@children.0/@containedEdges.19 //@children.5/@children.5/@children.0/@containedEdges.20 //@children.5/@children.5/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N315" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L315" height="15.0" width="115.0" text="EconomizerDamper"/>
+          <ports identifier="P834" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.15 //@children.5/@children.5/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P835" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P836" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P837" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P838" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="4"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N316" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L316" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P839" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P840" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N317" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L317" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P841" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P842" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N318">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L318" height="15.0" width="66.0" text="HeatingCoil"/>
+          <ports identifier="P843" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.3" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P844" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.5 //@children.5/@children.5/@children.0/@children.5/@containedEdges.6" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P845" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.4" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P846" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.0 //@children.5/@children.5/@children.0/@children.5/@containedEdges.1 //@children.5/@children.5/@children.0/@children.5/@containedEdges.2" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P847" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.20 //@children.5/@children.5/@children.0/@containedEdges.21" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="4"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P848" height="8.0" width="8.0" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="5"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N319" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L319" height="15.0" width="56.0" text="dTCoilSet"/>
+            <ports identifier="P849" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.13">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P850" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P851" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N320" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L320" height="15.0" width="63.0" text="Q_unconst"/>
+            <ports identifier="P852" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.5 //@children.5/@children.5/@children.0/@children.5/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P853" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P854" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N321" height="41.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L321" height="15.0" width="40.0" text="Limiter"/>
+            <ports identifier="P855" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P856" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.9 //@children.5/@children.5/@children.0/@children.5/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N322" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L322" height="15.0" width="50.0" text="TOutCoil"/>
+            <ports identifier="P857" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.1 //@children.5/@children.5/@children.0/@children.5/@containedEdges.12">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P858" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P859" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.11">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N323" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L323" height="15.0" width="63.0" text="dTEffective"/>
+            <ports identifier="P860" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P861" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P862" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.12">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N324" height="25.0" width="211.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L324" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P863" height="8.0" width="8.0" x="211.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.13">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P864" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P865" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P866" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.5/@children.5/@children.0/@children.5/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E624" sources="//@children.5/@children.5/@children.0/@children.5/@ports.3" targets="//@children.5/@children.5/@children.0/@children.5/@children.0/@ports.1"/>
+          <containedEdges identifier="E625" sources="//@children.5/@children.5/@children.0/@children.5/@ports.3" targets="//@children.5/@children.5/@children.0/@children.5/@children.3/@ports.0"/>
+          <containedEdges identifier="E626" sources="//@children.5/@children.5/@children.0/@children.5/@ports.3" targets="//@children.5/@children.5/@children.0/@children.5/@children.5/@ports.2"/>
+          <containedEdges identifier="E627" sources="//@children.5/@children.5/@children.0/@children.5/@ports.0" targets="//@children.5/@children.5/@children.0/@children.5/@children.5/@ports.1"/>
+          <containedEdges identifier="E628" sources="//@children.5/@children.5/@children.0/@children.5/@ports.2" targets="//@children.5/@children.5/@children.0/@children.5/@children.5/@ports.3"/>
+          <containedEdges identifier="E629" sources="//@children.5/@children.5/@children.0/@children.5/@ports.1" targets="//@children.5/@children.5/@children.0/@children.5/@children.1/@ports.0"/>
+          <containedEdges identifier="E630" sources="//@children.5/@children.5/@children.0/@children.5/@ports.1" targets="//@children.5/@children.5/@children.0/@children.5/@children.4/@ports.1"/>
+          <containedEdges identifier="E631" sources="//@children.5/@children.5/@children.0/@children.5/@children.0/@ports.2" targets="//@children.5/@children.5/@children.0/@children.5/@children.1/@ports.0"/>
+          <containedEdges identifier="E632" sources="//@children.5/@children.5/@children.0/@children.5/@children.1/@ports.2" targets="//@children.5/@children.5/@children.0/@children.5/@children.2/@ports.0"/>
+          <containedEdges identifier="E633" sources="//@children.5/@children.5/@children.0/@children.5/@children.2/@ports.1" targets="//@children.5/@children.5/@children.0/@children.5/@ports.5"/>
+          <containedEdges identifier="E634" sources="//@children.5/@children.5/@children.0/@children.5/@children.2/@ports.1" targets="//@children.5/@children.5/@children.0/@children.5/@children.4/@ports.0"/>
+          <containedEdges identifier="E635" sources="//@children.5/@children.5/@children.0/@children.5/@children.3/@ports.2" targets="//@children.5/@children.5/@children.0/@children.5/@ports.4"/>
+          <containedEdges identifier="E636" sources="//@children.5/@children.5/@children.0/@children.5/@children.4/@ports.2" targets="//@children.5/@children.5/@children.0/@children.5/@children.3/@ports.0"/>
+          <containedEdges identifier="E637" sources="//@children.5/@children.5/@children.0/@children.5/@children.5/@ports.0" targets="//@children.5/@children.5/@children.0/@children.5/@children.0/@ports.0"/>
+        </children>
+        <children identifier="N325">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L325" height="15.0" width="65.0" text="CoolingCoil"/>
+          <ports identifier="P867" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.3" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P868" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.5 //@children.5/@children.5/@children.0/@children.6/@containedEdges.6" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P869" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.4" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P870" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.0 //@children.5/@children.5/@children.0/@children.6/@containedEdges.1 //@children.5/@children.5/@children.0/@children.6/@containedEdges.2" incomingEdges="//@children.5/@children.5/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P871" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.0/@containedEdges.22 //@children.5/@children.5/@children.0/@containedEdges.23" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="4"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P872" height="8.0" width="8.0" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="5"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N326" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L326" height="15.0" width="56.0" text="dTCoilSet"/>
+            <ports identifier="P873" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.13">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P874" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P875" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N327" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L327" height="15.0" width="63.0" text="Q_unconst"/>
+            <ports identifier="P876" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.5 //@children.5/@children.5/@children.0/@children.6/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P877" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P878" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N328" height="41.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L328" height="15.0" width="40.0" text="Limiter"/>
+            <ports identifier="P879" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P880" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.9 //@children.5/@children.5/@children.0/@children.6/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N329" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L329" height="15.0" width="50.0" text="TOutCoil"/>
+            <ports identifier="P881" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.1 //@children.5/@children.5/@children.0/@children.6/@containedEdges.12">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P882" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P883" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.11">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N330" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L330" height="15.0" width="63.0" text="dTEffective"/>
+            <ports identifier="P884" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P885" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P886" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.12">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N331" height="25.0" width="211.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L331" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P887" height="8.0" width="8.0" x="211.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.13">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P888" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P889" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P890" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.5/@children.5/@children.0/@children.6/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E638" sources="//@children.5/@children.5/@children.0/@children.6/@ports.3" targets="//@children.5/@children.5/@children.0/@children.6/@children.0/@ports.1"/>
+          <containedEdges identifier="E639" sources="//@children.5/@children.5/@children.0/@children.6/@ports.3" targets="//@children.5/@children.5/@children.0/@children.6/@children.3/@ports.0"/>
+          <containedEdges identifier="E640" sources="//@children.5/@children.5/@children.0/@children.6/@ports.3" targets="//@children.5/@children.5/@children.0/@children.6/@children.5/@ports.2"/>
+          <containedEdges identifier="E641" sources="//@children.5/@children.5/@children.0/@children.6/@ports.0" targets="//@children.5/@children.5/@children.0/@children.6/@children.5/@ports.1"/>
+          <containedEdges identifier="E642" sources="//@children.5/@children.5/@children.0/@children.6/@ports.2" targets="//@children.5/@children.5/@children.0/@children.6/@children.5/@ports.3"/>
+          <containedEdges identifier="E643" sources="//@children.5/@children.5/@children.0/@children.6/@ports.1" targets="//@children.5/@children.5/@children.0/@children.6/@children.1/@ports.0"/>
+          <containedEdges identifier="E644" sources="//@children.5/@children.5/@children.0/@children.6/@ports.1" targets="//@children.5/@children.5/@children.0/@children.6/@children.4/@ports.1"/>
+          <containedEdges identifier="E645" sources="//@children.5/@children.5/@children.0/@children.6/@children.0/@ports.2" targets="//@children.5/@children.5/@children.0/@children.6/@children.1/@ports.0"/>
+          <containedEdges identifier="E646" sources="//@children.5/@children.5/@children.0/@children.6/@children.1/@ports.2" targets="//@children.5/@children.5/@children.0/@children.6/@children.2/@ports.0"/>
+          <containedEdges identifier="E647" sources="//@children.5/@children.5/@children.0/@children.6/@children.2/@ports.1" targets="//@children.5/@children.5/@children.0/@children.6/@ports.5"/>
+          <containedEdges identifier="E648" sources="//@children.5/@children.5/@children.0/@children.6/@children.2/@ports.1" targets="//@children.5/@children.5/@children.0/@children.6/@children.4/@ports.0"/>
+          <containedEdges identifier="E649" sources="//@children.5/@children.5/@children.0/@children.6/@children.3/@ports.2" targets="//@children.5/@children.5/@children.0/@children.6/@ports.4"/>
+          <containedEdges identifier="E650" sources="//@children.5/@children.5/@children.0/@children.6/@children.4/@ports.2" targets="//@children.5/@children.5/@children.0/@children.6/@children.3/@ports.0"/>
+          <containedEdges identifier="E651" sources="//@children.5/@children.5/@children.0/@children.6/@children.5/@ports.0" targets="//@children.5/@children.5/@children.0/@children.6/@children.0/@ports.0"/>
+        </children>
+        <containedEdges identifier="E600" sources="//@children.5/@children.5/@children.0/@ports.4" targets="//@children.5/@children.5/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E601" sources="//@children.5/@children.5/@children.0/@ports.4" targets="//@children.5/@children.5/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E602" sources="//@children.5/@children.5/@children.0/@ports.0" targets="//@children.5/@children.5/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E603" sources="//@children.5/@children.5/@children.0/@ports.0" targets="//@children.5/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E604" sources="//@children.5/@children.5/@children.0/@ports.0" targets="//@children.5/@children.5/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E605" sources="//@children.5/@children.5/@children.0/@ports.1" targets="//@children.5/@children.5/@children.0/@children.0/@ports.2"/>
+        <containedEdges identifier="E606" sources="//@children.5/@children.5/@children.0/@ports.1" targets="//@children.5/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E607" sources="//@children.5/@children.5/@children.0/@ports.1" targets="//@children.5/@children.5/@children.0/@children.2/@ports.3"/>
+        <containedEdges identifier="E608" sources="//@children.5/@children.5/@children.0/@ports.2" targets="//@children.5/@children.5/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E609" sources="//@children.5/@children.5/@children.0/@ports.2" targets="//@children.5/@children.5/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E610" sources="//@children.5/@children.5/@children.0/@ports.2" targets="//@children.5/@children.5/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E611" sources="//@children.5/@children.5/@children.0/@ports.5" targets="//@children.5/@children.5/@children.0/@children.5/@ports.2"/>
+        <containedEdges identifier="E612" sources="//@children.5/@children.5/@children.0/@ports.5" targets="//@children.5/@children.5/@children.0/@children.6/@ports.2"/>
+        <containedEdges identifier="E613" sources="//@children.5/@children.5/@children.0/@children.0/@ports.0" targets="//@children.5/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E614" sources="//@children.5/@children.5/@children.0/@children.0/@ports.0" targets="//@children.5/@children.5/@children.0/@children.5/@ports.3"/>
+        <containedEdges identifier="E615" sources="//@children.5/@children.5/@children.0/@children.2/@ports.0" targets="//@children.5/@children.5/@children.0/@children.0/@ports.3"/>
+        <containedEdges identifier="E616" sources="//@children.5/@children.5/@children.0/@children.2/@ports.0" targets="//@children.5/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E617" sources="//@children.5/@children.5/@children.0/@children.2/@ports.4" targets="//@children.5/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E618" sources="//@children.5/@children.5/@children.0/@children.3/@ports.1" targets="//@children.5/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E619" sources="//@children.5/@children.5/@children.0/@children.4/@ports.1" targets="//@children.5/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E620" sources="//@children.5/@children.5/@children.0/@children.5/@ports.4" targets="//@children.5/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E621" sources="//@children.5/@children.5/@children.0/@children.5/@ports.4" targets="//@children.5/@children.5/@children.0/@children.6/@ports.3"/>
+        <containedEdges identifier="E622" sources="//@children.5/@children.5/@children.0/@children.6/@ports.4" targets="//@children.5/@children.5/@children.0/@ports.3"/>
+        <containedEdges identifier="E623" sources="//@children.5/@children.5/@children.0/@children.6/@ports.4" targets="//@children.5/@children.5/@children.0/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N332">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L332" height="15.0" width="50.0" text="TSupSet"/>
+        <ports identifier="P891" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.0 //@children.5/@children.5/@children.1/@containedEdges.1 //@children.5/@children.5/@children.1/@containedEdges.2" incomingEdges="//@children.5/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P892" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.4" incomingEdges="//@children.5/@children.5/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P893" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.3" incomingEdges="//@children.5/@children.5/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P894" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@containedEdges.9" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P895" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.5" incomingEdges="//@children.5/@children.5/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P896" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.6" incomingEdges="//@children.5/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N333" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L333" height="15.0" width="71.0" text="TRooErrHea"/>
+          <ports identifier="P897" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P898" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P899" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N334" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L334" height="15.0" width="71.0" text="TRooErrCoo"/>
+          <ports identifier="P900" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P901" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P902" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N335">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L335" height="15.0" width="24.0" text="Hea"/>
+          <ports identifier="P903" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.0" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P904" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.9" incomingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N336" height="46.0" width="66.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L336" height="15.0" width="34.0" text="Scale"/>
+            <ports identifier="P905" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P906" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N337" height="41.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L337" height="15.0" width="40.0" text="Limiter"/>
+            <ports identifier="P907" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P908" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N338" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L338" height="15.0" width="72.0" text="AddSubtract"/>
+            <ports identifier="P909" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P910" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P911" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N339" height="25.0" width="42.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L339" height="15.0" width="34.0" text="Const"/>
+            <ports identifier="P912" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P913" height="8.0" width="8.0" x="-8.0" y="8.5">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N340" height="25.0" width="109.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L340" height="15.0" width="42.0" text="Const3"/>
+            <ports identifier="P914" height="8.0" width="8.0" x="109.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P915" height="8.0" width="8.0" x="-8.0" y="8.5">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N341" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L341" height="15.0" width="80.0" text="MultiplyDivide"/>
+            <ports identifier="P916" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.2 //@children.5/@children.5/@children.1/@children.2/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P917" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P918" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N342" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L342" height="15.0" width="80.0" text="AddSubtract2"/>
+            <ports identifier="P919" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.5 //@children.5/@children.5/@children.1/@children.2/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P920" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P921" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N343" height="25.0" width="39.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L343" height="15.0" width="42.0" text="Const2"/>
+            <ports identifier="P922" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.2/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P923" height="8.0" width="8.0" x="-8.0" y="8.5">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E667" sources="//@children.5/@children.5/@children.1/@children.2/@ports.0" targets="//@children.5/@children.5/@children.1/@children.2/@children.0/@ports.0"/>
+          <containedEdges identifier="E668" sources="//@children.5/@children.5/@children.1/@children.2/@children.0/@ports.1" targets="//@children.5/@children.5/@children.1/@children.2/@children.1/@ports.0"/>
+          <containedEdges identifier="E669" sources="//@children.5/@children.5/@children.1/@children.2/@children.1/@ports.1" targets="//@children.5/@children.5/@children.1/@children.2/@children.5/@ports.0"/>
+          <containedEdges identifier="E670" sources="//@children.5/@children.5/@children.1/@children.2/@children.2/@ports.2" targets="//@children.5/@children.5/@children.1/@children.2/@children.5/@ports.0"/>
+          <containedEdges identifier="E671" sources="//@children.5/@children.5/@children.1/@children.2/@children.3/@ports.0" targets="//@children.5/@children.5/@children.1/@children.2/@children.2/@ports.0"/>
+          <containedEdges identifier="E672" sources="//@children.5/@children.5/@children.1/@children.2/@children.4/@ports.0" targets="//@children.5/@children.5/@children.1/@children.2/@children.6/@ports.0"/>
+          <containedEdges identifier="E673" sources="//@children.5/@children.5/@children.1/@children.2/@children.5/@ports.2" targets="//@children.5/@children.5/@children.1/@children.2/@children.6/@ports.0"/>
+          <containedEdges identifier="E674" sources="//@children.5/@children.5/@children.1/@children.2/@children.6/@ports.2" targets="//@children.5/@children.5/@children.1/@children.2/@ports.1"/>
+          <containedEdges identifier="E675" sources="//@children.5/@children.5/@children.1/@children.2/@children.7/@ports.0" targets="//@children.5/@children.5/@children.1/@children.2/@children.2/@ports.1"/>
+        </children>
+        <children identifier="N344">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L344" height="15.0" width="24.0" text="Coo"/>
+          <ports identifier="P924" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.0" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P925" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.10" incomingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N345" height="46.0" width="66.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L345" height="15.0" width="34.0" text="Scale"/>
+            <ports identifier="P926" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P927" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N346" height="41.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L346" height="15.0" width="40.0" text="Limiter"/>
+            <ports identifier="P928" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P929" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N347" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L347" height="15.0" width="72.0" text="AddSubtract"/>
+            <ports identifier="P930" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P931" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P932" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N348" height="25.0" width="42.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L348" height="15.0" width="34.0" text="Const"/>
+            <ports identifier="P933" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P934" height="8.0" width="8.0" x="-8.0" y="8.5">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N349" height="25.0" width="109.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L349" height="15.0" width="42.0" text="Const3"/>
+            <ports identifier="P935" height="8.0" width="8.0" x="109.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P936" height="8.0" width="8.0" x="-8.0" y="8.5">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N350" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L350" height="15.0" width="80.0" text="MultiplyDivide"/>
+            <ports identifier="P937" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.2 //@children.5/@children.5/@children.1/@children.3/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P938" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P939" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N351" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L351" height="15.0" width="80.0" text="AddSubtract2"/>
+            <ports identifier="P940" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.5 //@children.5/@children.5/@children.1/@children.3/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P941" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P942" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="2"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N352" height="25.0" width="39.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L352" height="15.0" width="42.0" text="Const2"/>
+            <ports identifier="P943" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.1/@children.3/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P944" height="8.0" width="8.0" x="-8.0" y="8.5">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E676" sources="//@children.5/@children.5/@children.1/@children.3/@ports.0" targets="//@children.5/@children.5/@children.1/@children.3/@children.0/@ports.0"/>
+          <containedEdges identifier="E677" sources="//@children.5/@children.5/@children.1/@children.3/@children.0/@ports.1" targets="//@children.5/@children.5/@children.1/@children.3/@children.1/@ports.0"/>
+          <containedEdges identifier="E678" sources="//@children.5/@children.5/@children.1/@children.3/@children.1/@ports.1" targets="//@children.5/@children.5/@children.1/@children.3/@children.5/@ports.0"/>
+          <containedEdges identifier="E679" sources="//@children.5/@children.5/@children.1/@children.3/@children.2/@ports.2" targets="//@children.5/@children.5/@children.1/@children.3/@children.5/@ports.0"/>
+          <containedEdges identifier="E680" sources="//@children.5/@children.5/@children.1/@children.3/@children.3/@ports.0" targets="//@children.5/@children.5/@children.1/@children.3/@children.2/@ports.0"/>
+          <containedEdges identifier="E681" sources="//@children.5/@children.5/@children.1/@children.3/@children.4/@ports.0" targets="//@children.5/@children.5/@children.1/@children.3/@children.6/@ports.0"/>
+          <containedEdges identifier="E682" sources="//@children.5/@children.5/@children.1/@children.3/@children.5/@ports.2" targets="//@children.5/@children.5/@children.1/@children.3/@children.6/@ports.0"/>
+          <containedEdges identifier="E683" sources="//@children.5/@children.5/@children.1/@children.3/@children.6/@ports.2" targets="//@children.5/@children.5/@children.1/@children.3/@ports.1"/>
+          <containedEdges identifier="E684" sources="//@children.5/@children.5/@children.1/@children.3/@children.7/@ports.0" targets="//@children.5/@children.5/@children.1/@children.3/@children.2/@ports.1"/>
+        </children>
+        <children identifier="N353" height="47.0" width="49.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L353" height="15.0" width="64.0" text="Multiplexor"/>
+          <ports identifier="P945" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.9 //@children.5/@children.5/@children.1/@containedEdges.10 //@children.5/@children.5/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P946" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P947" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N354" height="25.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L354" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P948" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P949" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N355" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L355" height="15.0" width="53.0" text="Minimum"/>
+          <ports identifier="P950" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.2 //@children.5/@children.5/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P951" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P952" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N356" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L356" height="15.0" width="57.0" text="Maximum"/>
+          <ports identifier="P953" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@children.1/@containedEdges.12 //@children.5/@children.5/@children.1/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P954" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.5/@children.5/@children.1/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P955" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E652" sources="//@children.5/@children.5/@children.1/@ports.0" targets="//@children.5/@children.5/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E653" sources="//@children.5/@children.5/@children.1/@ports.0" targets="//@children.5/@children.5/@children.1/@children.1/@ports.1"/>
+        <containedEdges identifier="E654" sources="//@children.5/@children.5/@children.1/@ports.0" targets="//@children.5/@children.5/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E655" sources="//@children.5/@children.5/@children.1/@ports.2" targets="//@children.5/@children.5/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E656" sources="//@children.5/@children.5/@children.1/@ports.1" targets="//@children.5/@children.5/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E657" sources="//@children.5/@children.5/@children.1/@ports.4" targets="//@children.5/@children.5/@children.1/@children.4/@ports.2"/>
+        <containedEdges identifier="E658" sources="//@children.5/@children.5/@children.1/@ports.5" targets="//@children.5/@children.5/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E659" sources="//@children.5/@children.5/@children.1/@children.0/@ports.2" targets="//@children.5/@children.5/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E660" sources="//@children.5/@children.5/@children.1/@children.1/@ports.2" targets="//@children.5/@children.5/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E661" sources="//@children.5/@children.5/@children.1/@children.2/@ports.1" targets="//@children.5/@children.5/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E662" sources="//@children.5/@children.5/@children.1/@children.3/@ports.1" targets="//@children.5/@children.5/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E663" sources="//@children.5/@children.5/@children.1/@children.4/@ports.1" targets="//@children.5/@children.5/@children.1/@ports.3"/>
+        <containedEdges identifier="E664" sources="//@children.5/@children.5/@children.1/@children.5/@ports.0" targets="//@children.5/@children.5/@children.1/@children.7/@ports.0"/>
+        <containedEdges identifier="E665" sources="//@children.5/@children.5/@children.1/@children.6/@ports.1" targets="//@children.5/@children.5/@children.1/@children.7/@ports.0"/>
+        <containedEdges identifier="E666" sources="//@children.5/@children.5/@children.1/@children.7/@ports.1" targets="//@children.5/@children.5/@children.1/@children.4/@ports.0"/>
+      </children>
+      <children identifier="N357" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L357" height="15.0" width="89.0" text="OperatingMode"/>
+        <ports identifier="P956" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.5/@containedEdges.10 //@children.5/@children.5/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P957" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.5/@children.5/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P958" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.5/@children.5/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P959" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.5/@children.5/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P960" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.5/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N358" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L358" height="15.0" width="117.0" text="VectorDisassembler"/>
+        <ports identifier="P961" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.5/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P962" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@children.5/@containedEdges.12 //@children.5/@children.5/@containedEdges.13 //@children.5/@children.5/@containedEdges.14 //@children.5/@children.5/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E584" sources="//@children.5/@children.5/@ports.0" targets="//@children.5/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E585" sources="//@children.5/@children.5/@ports.0" targets="//@children.5/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E586" sources="//@children.5/@children.5/@ports.0" targets="//@children.5/@children.5/@children.2/@ports.4"/>
+      <containedEdges identifier="E587" sources="//@children.5/@children.5/@ports.4" targets="//@children.5/@children.5/@children.0/@ports.4"/>
+      <containedEdges identifier="E588" sources="//@children.5/@children.5/@ports.2" targets="//@children.5/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E589" sources="//@children.5/@children.5/@ports.2" targets="//@children.5/@children.5/@children.1/@ports.5"/>
+      <containedEdges identifier="E590" sources="//@children.5/@children.5/@ports.2" targets="//@children.5/@children.5/@children.2/@ports.3"/>
+      <containedEdges identifier="E591" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.5/@children.3/@ports.0"/>
+      <containedEdges identifier="E592" sources="//@children.5/@children.5/@children.0/@ports.3" targets="//@children.5/@children.5/@ports.3"/>
+      <containedEdges identifier="E593" sources="//@children.5/@children.5/@children.1/@ports.3" targets="//@children.5/@children.5/@children.0/@ports.2"/>
+      <containedEdges identifier="E594" sources="//@children.5/@children.5/@children.2/@ports.0" targets="//@children.5/@children.5/@children.0/@ports.5"/>
+      <containedEdges identifier="E595" sources="//@children.5/@children.5/@children.2/@ports.0" targets="//@children.5/@children.5/@children.1/@ports.4"/>
+      <containedEdges identifier="E596" sources="//@children.5/@children.5/@children.3/@ports.1" targets="//@children.5/@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E597" sources="//@children.5/@children.5/@children.3/@ports.1" targets="//@children.5/@children.5/@children.2/@ports.1"/>
+      <containedEdges identifier="E598" sources="//@children.5/@children.5/@children.3/@ports.1" targets="//@children.5/@children.5/@children.1/@ports.2"/>
+      <containedEdges identifier="E599" sources="//@children.5/@children.5/@children.3/@ports.1" targets="//@children.5/@children.5/@children.2/@ports.2"/>
+    </children>
+    <children identifier="N359" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L359" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P963" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P964" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P965" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P966" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N360" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L360" height="15.0" width="50.0" text="TRooExt"/>
+      <ports identifier="P967" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P968" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.17 //@children.5/@containedEdges.18 //@children.5/@containedEdges.19 //@children.5/@containedEdges.20 //@children.5/@containedEdges.21 //@children.5/@containedEdges.22 //@children.5/@containedEdges.23 //@children.5/@containedEdges.24 //@children.5/@containedEdges.25 //@children.5/@containedEdges.26 //@children.5/@containedEdges.27 //@children.5/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N361" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L361" height="15.0" width="129.0" text="DayTimeTemperatures"/>
+      <ports identifier="P969" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.17 //@children.5/@containedEdges.18 //@children.5/@containedEdges.19 //@children.5/@containedEdges.20 //@children.5/@containedEdges.21 //@children.5/@containedEdges.22 //@children.5/@containedEdges.23 //@children.5/@containedEdges.24 //@children.5/@containedEdges.25 //@children.5/@containedEdges.26 //@children.5/@containedEdges.27 //@children.5/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.5/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.5/@ports.1" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.5/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.5/@children.1/@ports.2" targets="//@children.5/@children.6/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.5/@children.2/@ports.3" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.5/@children.2/@ports.5" targets="//@children.5/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.5/@children.2/@ports.4" targets="//@children.5/@children.5/@ports.4"/>
+    <containedEdges identifier="E21" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.2/@ports.6"/>
+    <containedEdges identifier="E23" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.5/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.6/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.5/@children.5/@ports.3" targets="//@children.5/@children.2/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.5/@children.6/@ports.2" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.8/@ports.0"/>
+  </children>
+  <children identifier="N362" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L362" height="15.0" width="67.0" text="EnergyPlus"/>
+    <ports identifier="P970" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P971" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N363" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L363" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P972" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P973" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P974" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N364" height="25.0" width="63.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L364" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P975" height="8.0" width="8.0" x="63.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P976" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N365" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L365" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P977" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P978" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P979" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N366" height="25.0" width="42.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L366" height="15.0" width="76.0" text="StringConst2"/>
+    <ports identifier="P980" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P981" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N367" height="34.0" width="34.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L367" height="15.0" width="38.0" text="Round"/>
+    <ports identifier="P982" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P983" height="8.0" width="8.0" x="34.0" y="13.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_ucbpower_DataReadingExample.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_ucbpower_DataReadingExample.elkg
@@ -1,0 +1,528 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="93.0" text="IterateOverArray"/>
+    <ports identifier="P12" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N8" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.5/@children.0/@children.1/@ports.1" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="101.0" text="PteraModalModel"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="26.0" text="data"/>
+      <ports identifier="P19" incomingEdges="//@children.6/@containedEdges.1 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="28.0" text="Start"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="95.0" text="ReadOnlineData"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="102.0" text="ReadOnlineData2"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E24" sources="//@children.6/@children.0/@children.0/@ports.0" targets="//@children.6/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.6/@children.0/@children.0/@ports.0" targets="//@children.6/@children.0/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="26.0" text="data"/>
+      <ports identifier="P23" x="61.0" y="20.5" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="26.0" text="data"/>
+      <ports identifier="P24" x="61.0" y="20.5" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="134.0" text="OnlineDataFileReader2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="128.0" text="LocalDataFileReader2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="25.0" width="183.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="183.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.15/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="121.0" text="LocalDataFileReader"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.15/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.15/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.15/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.5 //@children.15/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.15/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.15/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.15/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E26" sources="//@children.15/@ports.0" targets="//@children.15/@children.2/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.15/@children.0/@ports.0" targets="//@children.15/@children.4/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.15/@children.1/@ports.0" targets="//@children.15/@children.4/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.15/@children.2/@ports.2" targets="//@children.15/@children.1/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.15/@children.2/@ports.3" targets="//@children.15/@children.0/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.15/@children.3/@ports.0" targets="//@children.15/@children.2/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.15/@children.3/@ports.0" targets="//@children.15/@children.4/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.15/@children.4/@ports.3" targets="//@children.15/@ports.1"/>
+  </children>
+  <children identifier="N31" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="89.0" text="JSONToToken2"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="110.0" text="ArrayToSequence2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="128.0" text="RecordDisassembler2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L34" height="15.0" width="101.0" text="IterateOverArray2"/>
+    <ports identifier="P65" height="8.0" width="8.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N35">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L35" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.19/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N36" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.19/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="79.0" text="ArrayElement"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.19/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.19/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.19/@children.0/@ports.0" targets="//@children.19/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.19/@children.0/@children.1/@ports.1" targets="//@children.19/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.8/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.13/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.15/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.16/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.1" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_ucbpower_UCBPowerForServer.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_ucbpower_UCBPowerForServer.elkg
@@ -1,0 +1,1194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="53.0" text="Cory Hall"/>
+    <children identifier="N2" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P1" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L3" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N4" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="121.0" text="LocalDataFileReader"/>
+        <ports identifier="P6" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="112.0" text="ConfigurationSelect"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.1/@children.1/@ports.2"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.1/@children.0/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.1/@children.1/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.1/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.1/@children.3/@ports.1" targets="//@children.0/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.1/@children.3/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="82.0" text="JSONToToken"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="93.0" text="IterateOverArray"/>
+      <ports identifier="P25" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N12">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L12" height="15.0" width="99.0" text="IterateComposite"/>
+        <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N13" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L13" height="15.0" width="79.0" text="ArrayElement"/>
+          <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.5/@children.0/@containedEdges.1 //@children.0/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N14" height="25.0" width="256.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P30" height="8.0" width="8.0" x="256.0" y="8.5" outgoingEdges="//@children.0/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N15" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="67.0" text="SetVariable"/>
+          <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="25.0" width="425.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P34" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@children.0/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N17">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L17" height="15.0" width="108.0" text="SelectDisplayType"/>
+          <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.0" incomingEdges="//@children.0/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.1" incomingEdges="//@children.0/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <children identifier="N18" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L18" height="15.0" width="97.0" text="SequencePlotter"/>
+            <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N19" height="31.0" width="31.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L19" height="15.0" width="113.0" text="ExpressionToToken"/>
+            <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P40" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N20" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L20" height="15.0" width="67.0" text="DisplayText"/>
+            <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N21" height="46.0" width="39.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L21" height="15.0" width="40.0" text="Switch"/>
+            <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P43" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.3 //@children.0/@children.5/@children.0/@children.4/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P44" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.5/@children.0/@children.4/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E24" sources="//@children.0/@children.5/@children.0/@children.4/@ports.0" targets="//@children.0/@children.5/@children.0/@children.4/@children.3/@ports.0"/>
+          <containedEdges identifier="E25" sources="//@children.0/@children.5/@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E26" sources="//@children.0/@children.5/@children.0/@children.4/@children.1/@ports.1" targets="//@children.0/@children.5/@children.0/@children.4/@children.3/@ports.2"/>
+          <containedEdges identifier="E27" sources="//@children.0/@children.5/@children.0/@children.4/@children.3/@ports.1" targets="//@children.0/@children.5/@children.0/@children.4/@children.2/@ports.0"/>
+          <containedEdges identifier="E28" sources="//@children.0/@children.5/@children.0/@children.4/@children.3/@ports.1" targets="//@children.0/@children.5/@children.0/@children.4/@children.0/@ports.0"/>
+        </children>
+        <children identifier="N22" height="25.0" width="46.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P45" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.0/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E18" sources="//@children.0/@children.5/@children.0/@ports.0" targets="//@children.0/@children.5/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E19" sources="//@children.0/@children.5/@children.0/@children.0/@ports.1" targets="//@children.0/@children.5/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E20" sources="//@children.0/@children.5/@children.0/@children.0/@ports.1" targets="//@children.0/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E21" sources="//@children.0/@children.5/@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E22" sources="//@children.0/@children.5/@children.0/@children.3/@ports.0" targets="//@children.0/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E23" sources="//@children.0/@children.5/@children.0/@children.5/@ports.0" targets="//@children.0/@children.5/@children.0/@children.4/@ports.1"/>
+      </children>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="82.0" text="StringReplace"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="25.0" width="27.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="67.0" text="Donner Lab"/>
+    <children identifier="N28" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N29">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L29" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P59" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N30" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="121.0" text="LocalDataFileReader"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="112.0" text="ConfigurationSelect"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E38" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.1/@children.1/@ports.2"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.1/@children.3/@ports.2" targets="//@children.1/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N34" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="82.0" text="JSONToToken"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L37" height="15.0" width="93.0" text="IterateOverArray"/>
+      <ports identifier="P81" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N38">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L38" height="15.0" width="99.0" text="IterateComposite"/>
+        <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N39" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L39" height="15.0" width="79.0" text="ArrayElement"/>
+          <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.5/@children.0/@containedEdges.1 //@children.1/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N40" height="25.0" width="256.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L40" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P86" height="8.0" width="8.0" x="256.0" y="8.5" outgoingEdges="//@children.1/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N41" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L41" height="15.0" width="67.0" text="SetVariable"/>
+          <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P89" height="8.0" width="8.0" x="61.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N42" height="25.0" width="425.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L42" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P90" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@children.1/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N43">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L43" height="15.0" width="108.0" text="SelectDisplayType"/>
+          <ports identifier="P92" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.0" incomingEdges="//@children.1/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P93" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.1" incomingEdges="//@children.1/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <children identifier="N44" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L44" height="15.0" width="97.0" text="SequencePlotter"/>
+            <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N45" height="31.0" width="31.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L45" height="15.0" width="113.0" text="ExpressionToToken"/>
+            <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P96" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N46" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L46" height="15.0" width="67.0" text="DisplayText"/>
+            <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N47" height="46.0" width="39.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L47" height="15.0" width="40.0" text="Switch"/>
+            <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P99" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.3 //@children.1/@children.5/@children.0/@children.4/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P100" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.5/@children.0/@children.4/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E51" sources="//@children.1/@children.5/@children.0/@children.4/@ports.0" targets="//@children.1/@children.5/@children.0/@children.4/@children.3/@ports.0"/>
+          <containedEdges identifier="E52" sources="//@children.1/@children.5/@children.0/@children.4/@ports.1" targets="//@children.1/@children.5/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E53" sources="//@children.1/@children.5/@children.0/@children.4/@children.1/@ports.1" targets="//@children.1/@children.5/@children.0/@children.4/@children.3/@ports.2"/>
+          <containedEdges identifier="E54" sources="//@children.1/@children.5/@children.0/@children.4/@children.3/@ports.1" targets="//@children.1/@children.5/@children.0/@children.4/@children.2/@ports.0"/>
+          <containedEdges identifier="E55" sources="//@children.1/@children.5/@children.0/@children.4/@children.3/@ports.1" targets="//@children.1/@children.5/@children.0/@children.4/@children.0/@ports.0"/>
+        </children>
+        <children identifier="N48" height="25.0" width="46.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L48" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P101" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.1/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E45" sources="//@children.1/@children.5/@children.0/@ports.0" targets="//@children.1/@children.5/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E46" sources="//@children.1/@children.5/@children.0/@children.0/@ports.1" targets="//@children.1/@children.5/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E47" sources="//@children.1/@children.5/@children.0/@children.0/@ports.1" targets="//@children.1/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E48" sources="//@children.1/@children.5/@children.0/@children.1/@ports.0" targets="//@children.1/@children.5/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E49" sources="//@children.1/@children.5/@children.0/@children.3/@ports.0" targets="//@children.1/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E50" sources="//@children.1/@children.5/@children.0/@children.5/@ports.0" targets="//@children.1/@children.5/@children.0/@children.4/@ports.1"/>
+      </children>
+    </children>
+    <children identifier="N49" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="82.0" text="StringReplace"/>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="25.0" width="27.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E29" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.1/@children.6/@ports.3" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E35" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N53">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L53" height="15.0" width="56.0" text="Birge Hall"/>
+    <children identifier="N54" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N55">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L55" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P115" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@children.2/@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N56" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L56" height="15.0" width="121.0" text="LocalDataFileReader"/>
+        <ports identifier="P118" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N57" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="127.0" text="OnlineDataFileReader"/>
+        <ports identifier="P121" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="112.0" text="ConfigurationSelect"/>
+        <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.2/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P126" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.2/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+        <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P129" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.2/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E65" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.1/@children.1/@ports.2"/>
+      <containedEdges identifier="E67" sources="//@children.2/@children.1/@children.0/@ports.0" targets="//@children.2/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E68" sources="//@children.2/@children.1/@children.1/@ports.0" targets="//@children.2/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E69" sources="//@children.2/@children.1/@children.2/@ports.2" targets="//@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E70" sources="//@children.2/@children.1/@children.3/@ports.1" targets="//@children.2/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E71" sources="//@children.2/@children.1/@children.3/@ports.2" targets="//@children.2/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N60" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="82.0" text="JSONToToken"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P136" height="8.0" width="8.0" x="10.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N63">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L63" height="15.0" width="93.0" text="IterateOverArray"/>
+      <ports identifier="P137" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N64">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L64" height="15.0" width="99.0" text="IterateComposite"/>
+        <ports identifier="P138" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N65" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L65" height="15.0" width="79.0" text="ArrayElement"/>
+          <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.5/@children.0/@containedEdges.1 //@children.2/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N66" height="25.0" width="256.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L66" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P142" height="8.0" width="8.0" x="256.0" y="8.5" outgoingEdges="//@children.2/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N67" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L67" height="15.0" width="67.0" text="SetVariable"/>
+          <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N68" height="25.0" width="425.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="73.0" text="Expression2"/>
+          <ports identifier="P146" height="8.0" width="8.0" x="425.0" y="8.5" outgoingEdges="//@children.2/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N69">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L69" height="15.0" width="108.0" text="SelectDisplayType"/>
+          <ports identifier="P148" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.0" incomingEdges="//@children.2/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P149" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.1" incomingEdges="//@children.2/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <children identifier="N70" height="41.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L70" height="15.0" width="97.0" text="SequencePlotter"/>
+            <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N71" height="31.0" width="31.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L71" height="15.0" width="113.0" text="ExpressionToToken"/>
+            <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P152" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N72" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L72" height="15.0" width="67.0" text="DisplayText"/>
+            <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N73" height="46.0" width="39.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L73" height="15.0" width="40.0" text="Switch"/>
+            <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P155" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.3 //@children.2/@children.5/@children.0/@children.4/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P156" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.5/@children.0/@children.4/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E78" sources="//@children.2/@children.5/@children.0/@children.4/@ports.0" targets="//@children.2/@children.5/@children.0/@children.4/@children.3/@ports.0"/>
+          <containedEdges identifier="E79" sources="//@children.2/@children.5/@children.0/@children.4/@ports.1" targets="//@children.2/@children.5/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E80" sources="//@children.2/@children.5/@children.0/@children.4/@children.1/@ports.1" targets="//@children.2/@children.5/@children.0/@children.4/@children.3/@ports.2"/>
+          <containedEdges identifier="E81" sources="//@children.2/@children.5/@children.0/@children.4/@children.3/@ports.1" targets="//@children.2/@children.5/@children.0/@children.4/@children.2/@ports.0"/>
+          <containedEdges identifier="E82" sources="//@children.2/@children.5/@children.0/@children.4/@children.3/@ports.1" targets="//@children.2/@children.5/@children.0/@children.4/@children.0/@ports.0"/>
+        </children>
+        <children identifier="N74" height="25.0" width="46.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P157" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.2/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E72" sources="//@children.2/@children.5/@children.0/@ports.0" targets="//@children.2/@children.5/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E73" sources="//@children.2/@children.5/@children.0/@children.0/@ports.1" targets="//@children.2/@children.5/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E74" sources="//@children.2/@children.5/@children.0/@children.0/@ports.1" targets="//@children.2/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E75" sources="//@children.2/@children.5/@children.0/@children.1/@ports.0" targets="//@children.2/@children.5/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E76" sources="//@children.2/@children.5/@children.0/@children.3/@ports.0" targets="//@children.2/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E77" sources="//@children.2/@children.5/@children.0/@children.5/@ports.0" targets="//@children.2/@children.5/@children.0/@children.4/@ports.1"/>
+      </children>
+    </children>
+    <children identifier="N75" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="82.0" text="StringReplace"/>
+      <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P162" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="25.0" width="27.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P163" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P165" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N78" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L78" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P167" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E56" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.2/@children.6/@ports.3" targets="//@children.2/@children.1/@ports.2"/>
+    <containedEdges identifier="E62" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E64" sources="//@children.2/@children.9/@ports.0" targets="//@children.2/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N79" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="25.0" width="419.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P171" height="8.0" width="8.0" x="419.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptango_ucbpowerptera_UCBPowerPtera.elkg
+++ b/realworld/ptolemy/hierarchical/ptango_ucbpowerptera_UCBPowerPtera.elkg
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="172.0" text="InstanceOfSingleReaderClass"/>
+    <children identifier="N2" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P1" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="55.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="130.0" text="VisualModelReference"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="-1.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="131.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="27.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.4/@ports.4"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.4/@ports.5"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.4/@ports.6"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="180.0" text="InstanceOfSingleReaderClass2"/>
+    <children identifier="N11" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="55.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="130.0" text="VisualModelReference"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="-1.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="131.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="27.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.4/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.4/@ports.3" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.4/@ports.4"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.4/@ports.5"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.4/@ports.6"/>
+  </children>
+  <children identifier="N19">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L19" height="15.0" width="180.0" text="InstanceOfSingleReaderClass3"/>
+    <children identifier="N20" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.2 //@children.2/@containedEdges.3 //@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="55.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="130.0" text="VisualModelReference"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="-1.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="131.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="25.0" width="27.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="27.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.7/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.4/@ports.3" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.4/@ports.4"/>
+    <containedEdges identifier="E32" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.4/@ports.5"/>
+    <containedEdges identifier="E33" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.4/@ports.6"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptera_adaptivecarwash_AdaptiveCarWash.elkg
+++ b/realworld/ptolemy/hierarchical/ptera_adaptivecarwash_AdaptiveCarWash.elkg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="InitQueue"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="60.0" text="InitServers"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="101.0" text="PteraModalModel"/>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="74.0" text="queueOutput"/>
+      <ports identifier="P10" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N6" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="24.0" text="Run"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="32.0" text="Enter"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.1 //@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="28.0" text="Start"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.1 //@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="34.0" text="Leave"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="58.0" text="ReadInput"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.3/@children.0/@children.3/@ports.1" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.3/@children.0/@children.4/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.3/@children.0/@ports.2" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@ports.3"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="81.0" text="ModelUpdater"/>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="63.0" text="_Controller"/>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="135.0" text="InitModelWithContainer"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="113.0" text="SwitchToSlowMode"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@children.0/@containedEdges.0 //@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="56.0" text="TooSlow?"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@children.0/@containedEdges.1 //@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@children.0/@containedEdges.2 //@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="111.0" text="SwitchToFastMode"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="54.0" text="TooFast?"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@children.0/@containedEdges.4 //@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@children.0/@containedEdges.5 //@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.5/@children.0/@children.0/@ports.0" targets="//@children.5/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.5/@children.0/@children.1/@ports.1" targets="//@children.5/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E20" sources="//@children.5/@children.0/@children.2/@ports.1" targets="//@children.5/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.5/@children.0/@children.2/@ports.1" targets="//@children.5/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.5/@children.0/@children.3/@ports.1" targets="//@children.5/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.5/@children.0/@children.4/@ports.1" targets="//@children.5/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.5/@children.0/@children.4/@ports.1" targets="//@children.5/@children.0/@children.4/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="85.0" text="SetQueueSize"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptera_adaptivecarwash_AdaptiveCarWashFSM.elkg
+++ b/realworld/ptolemy/hierarchical/ptera_adaptivecarwash_AdaptiveCarWashFSM.elkg
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="InitQueue"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="60.0" text="InitServers"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="89.0" text="PteraSubmodel"/>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.3/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="56.0" text="queueOut"/>
+      <ports identifier="P10" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N6" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="32.0" text="Enter"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.1 //@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="28.0" text="Start"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="34.0" text="Leave"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="17.0" text="Init"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="24.0" text="Run"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="69.0" text="UpdateMST"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E18" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E20" sources="//@children.3/@children.0/@children.3/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.3/@children.0/@children.4/@ports.0" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="56.0" text="queueOut"/>
+      <ports identifier="P24" y="13.666666984558105" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" y="27.33333396911621" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" x="61.0" y="13.666666984558105" outgoingEdges="//@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" x="61.0" y="27.33333396911621" outgoingEdges="//@children.3/@containedEdges.6 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.3/@children.1/@ports.2" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.3/@children.1/@ports.2" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.3/@children.1/@ports.3" targets="//@children.3/@ports.3"/>
+    <containedEdges identifier="E14" sources="//@children.3/@children.1/@ports.3" targets="//@children.3/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.3" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptera_carwash_CarWashDE.elkg
+++ b/realworld/ptolemy/hierarchical/ptera_carwash_CarWashDE.elkg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="InitQueue"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="60.0" text="InitServers"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="101.0" text="PteraModalModel"/>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="74.0" text="queueOutput"/>
+      <ports identifier="P10" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N6" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="24.0" text="Run"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="32.0" text="Enter"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.1 //@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="28.0" text="Start"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.1 //@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="34.0" text="Leave"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="58.0" text="ReadInput"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E11" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.3/@children.0/@children.3/@ports.1" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.3/@children.0/@children.4/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.3/@children.0/@ports.2" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@ports.3"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.3" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptera_simultaneouscarwash_SimultaneousCarWash.elkg
+++ b/realworld/ptolemy/hierarchical/ptera_simultaneouscarwash_SimultaneousCarWash.elkg
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="63.0" text="InitQueue1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="InitServers1"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="101.0" text="PteraModalModel"/>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1" incomingEdges="//@containedEdges.1 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.3" incomingEdges="//@containedEdges.0 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.2/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L4" height="15.0" width="74.0" text="queueOutput"/>
+      <ports identifier="P9" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N5" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="24.0" text="Run"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="52.0" text="Simulate"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.1 //@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="74.0" text="WaitForInput"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1 //@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E19" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E20" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="74.0" text="queueOutput"/>
+      <ports identifier="P17" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" outgoingEdges="//@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" outgoingEdges="//@children.2/@containedEdges.6 //@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="32.0" text="Enter"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.1/@containedEdges.1 //@children.2/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.1/@containedEdges.0 //@children.2/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="28.0" text="Start"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.1/@containedEdges.0 //@children.2/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="34.0" text="Leave"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="17.0" text="Init"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E22" sources="//@children.2/@children.1/@children.0/@ports.1" targets="//@children.2/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.2/@children.1/@children.0/@ports.1" targets="//@children.2/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.2/@children.1/@children.1/@ports.1" targets="//@children.2/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.2/@children.1/@children.2/@ports.1" targets="//@children.2/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.2/@children.1/@children.3/@ports.0" targets="//@children.2/@children.1/@children.0/@ports.0"/>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.2/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.0/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N13" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="68.0" text="InitServers2"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="63.0" text="InitQueue2"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.4/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptera_trafficlight_TrafficLight.elkg
+++ b/realworld/ptolemy/hierarchical/ptera_trafficlight_TrafficLight.elkg
@@ -1,0 +1,508 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="62.0" text="TrafficLight"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.0/@containedEdges.14 //@children.0/@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="29.0" text="Error"/>
+      <ports identifier="P8" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" incomingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P10" incomingEdges="//@children.0/@containedEdges.11 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P11" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" incomingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="41.0" text="Normal"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.1 //@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="17.0" text="Init"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="76.0" text="ReactToError"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1 //@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="29.0" text="Error"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.4 //@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="66.0" text="ReactToOK"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="69.0" text="StartNormal"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.5 //@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="57.0" text="StartError"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@containedEdges.7 //@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+    </children>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="29.0" text="Error"/>
+      <ports identifier="P26" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" outgoingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" outgoingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" outgoingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" outgoingEdges="//@children.0/@containedEdges.14 //@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="33.0" text="CRed"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.1/@containedEdges.4 //@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.1/@containedEdges.0 //@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="45.0" text="CGreen"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.1/@containedEdges.2 //@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="47.0" text="CYellow"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="17.0" text="Init"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="33.0" text="PRed"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="45.0" text="PGreen"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E43" sources="//@children.0/@children.1/@children.0/@ports.1" targets="//@children.0/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.1/@children.0/@ports.1" targets="//@children.0/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.1/@children.1/@ports.1" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.0/@children.1/@children.1/@ports.1" targets="//@children.0/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.0/@children.1/@children.2/@ports.1" targets="//@children.0/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.1/@children.3/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N17">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L17" height="15.0" width="29.0" text="Error"/>
+      <ports identifier="P42" outgoingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" outgoingEdges="//@children.0/@containedEdges.18 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" outgoingEdges="//@children.0/@containedEdges.20 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" outgoingEdges="//@children.0/@containedEdges.22 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" outgoingEdges="//@children.0/@containedEdges.24 //@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N18" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="90.0" text="TurnYellowLight"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.2/@containedEdges.0 //@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="17.0" text="Init"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E49" sources="//@children.0/@children.2/@children.0/@ports.1" targets="//@children.0/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.2/@children.1/@ports.0" targets="//@children.0/@children.2/@children.0/@ports.0"/>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.5" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.5" targets="//@children.0/@children.1/@ports.5"/>
+    <containedEdges identifier="E10" sources="//@children.0/@ports.5" targets="//@children.0/@children.2/@ports.5"/>
+    <containedEdges identifier="E11" sources="//@children.0/@ports.6" targets="//@children.0/@children.0/@ports.6"/>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.6" targets="//@children.0/@children.1/@ports.6"/>
+    <containedEdges identifier="E13" sources="//@children.0/@ports.6" targets="//@children.0/@children.2/@ports.6"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="74.0" text="SetVariable1"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="86.0" text="ErrorGenerator"/>
+    <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.6/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L26" height="15.0" width="29.0" text="Error"/>
+      <ports identifier="P64" outgoingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P65" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N27" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="17.0" text="Init"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="29.0" text="Error"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="19.0" text="OK"/>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E53" sources="//@children.6/@children.0/@children.0/@ports.0" targets="//@children.6/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.6/@children.0/@children.1/@ports.1" targets="//@children.6/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.6/@children.0/@children.2/@ports.1" targets="//@children.6/@children.0/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E51" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.4" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.0/@ports.6"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pthales_dynamic_ThalesDynamicModalModelPN.elkg
+++ b/realworld/ptolemy/hierarchical/pthales_dynamic_ThalesDynamicModalModelPN.elkg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="187.0" text="PthalesWrapperCompositeActor"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.1/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.1/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L3" height="15.0" width="189.0" text="PthalesDynamicCompositeActor"/>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0 //@children.1/@children.0/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@children.1/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N4" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E13" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.1/@children.0/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.20830154418945" width="60.70830154418945">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="163.0" text="PthalesRemoveHeaderActor"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.20830154418945" width="60.70830154418945">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="170.0" text="PthalesRemoveHeaderActor2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.104150772094727" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.70830154418945" y="16.104150772094727" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="196.0" text="PthalesDynamicCompositeActor2"/>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.4/@containedEdges.0 //@children.1/@children.4/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7" incomingEdges="//@children.1/@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E16" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.4/@children.0/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E18" sources="//@children.1/@children.4/@children.1/@ports.1" targets="//@children.1/@children.4/@ports.1"/>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.3" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pthales_fft_FFT.elkg
+++ b/realworld/ptolemy/hierarchical/pthales_fft_FFT.elkg
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="99.0" text="SquareGenerator"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="266.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="266.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="77.0" text="DownSample"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="232.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="232.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="85.0" width="196.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="196.0" y="38.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="23.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="54.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="40.0" text="Viewer"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="107.0" text="SequenceToMatrix"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="84.0" text="AbsoluteValue"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="108.0" text="DoubleMatrixToJAI"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="110.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="110.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N16">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L16" height="15.0" width="64.0" text="FFTofRows"/>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N17" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="24.0" text="FFT"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N18">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L18" height="15.0" width="83.0" text="FFTofColumns"/>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N19" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="24.0" text="FFT"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.1"/>
+  </children>
+  <children identifier="N20">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L20" height="15.0" width="47.0" text="Viewer2"/>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N21" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="107.0" text="SequenceToMatrix"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="84.0" text="AbsoluteValue"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="108.0" text="DoubleMatrixToJAI"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="121.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="121.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.4 //@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.5/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/pthales_illustrative_Illustrative.elkg
+++ b/realworld/ptolemy/hierarchical/pthales_illustrative_Illustrative.elkg
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="Source"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="26.0" text="Sink"/>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N4" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="107.0" text="SequenceToMatrix"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="24.0" text="Test"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="34.0" text="Sink2"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="107.0" text="SequenceToMatrix"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="51.0" text="Display2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="24.0" text="Test"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPattern.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPattern.elkg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="30.0" text="Plant"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E5" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.3/@ports.3" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P19" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E13" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.1/@children.0/@children.0/@ports.1" targets="//@children.1/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N11" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPattern1.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPattern1.elkg
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="30.0" text="Plant"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="132.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P25" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.2 //@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E16" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E18" sources="//@children.1/@children.0/@children.0/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.1/@children.0/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E20" sources="//@children.1/@children.0/@children.2/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPattern2.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPattern2.elkg
@@ -1,0 +1,337 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="30.0" text="Plant"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="132.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="132.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E6" sources="//@children.0/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P32" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.2 //@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="44.0" text="Merge2"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.7 //@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="68.0" text="SingleEvent"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="76.0" text="SingleEvent2"/>
+        <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="76.0" text="SingleEvent3"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E19" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.1/@children.0/@children.0/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.1/@children.0/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.1/@children.0/@children.2/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.1/@children.0/@children.3/@ports.1" targets="//@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E24" sources="//@children.1/@children.0/@children.4/@ports.0" targets="//@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E25" sources="//@children.1/@children.0/@children.5/@ports.0" targets="//@children.1/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.1/@children.0/@children.6/@ports.0" targets="//@children.1/@children.0/@children.3/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.4" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.4" targets="//@children.0/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPatternComplex1.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_actuatorpattern_ActuatorPatternComplex1.elkg
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="30.0" text="Plant"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="120.0" text="ContinuousSinewave"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="127.0" text="ContinuousSinewave2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="56.0" text="Sampler2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.1" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@ports.3"/>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P18" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N9" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="68.0" text="SingleEvent"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.2/@children.0/@children.0/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@ports.2"/>
+    </children>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="93.0" text="PtidesPlatform2"/>
+    <ports identifier="P28" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P32" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E22" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@ports.3"/>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.0/@ports.2"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="93.0" text="PtidesPlatform3"/>
+    <ports identifier="P41" height="8.0" width="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E23" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.4/@children.0/@children.0/@ports.0" targets="//@children.4/@children.0/@ports.2"/>
+      <containedEdges identifier="E25" sources="//@children.4/@children.0/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N18" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="98.0" text="MicrostepDelay3"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_controller_Controller.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_controller_Controller.elkg
@@ -1,0 +1,1636 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="56.0" text="Controller"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="63.0" text="Controller2"/>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E18" sources="//@children.0/@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@ports.2"/>
+    </children>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="30.0" text="Plant"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="56.0" text="Sampler2"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L17" height="15.0" width="38.0" text="Plant2"/>
+      <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.9/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.11" incomingEdges="//@children.1/@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N18" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="63.0" text="InputAdder"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.9/@containedEdges.0 //@children.1/@children.9/@containedEdges.6 //@children.1/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="74.0" text="OutputAdder"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.9/@containedEdges.7 //@children.1/@children.9/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="62.0" text="Integrator0"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.9/@containedEdges.3 //@children.1/@children.9/@containedEdges.4 //@children.1/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="65.0" text="Feedback0"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="78.0" text="Feedforward0"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="62.0" text="Integrator1"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.9/@containedEdges.8 //@children.1/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="65.0" text="Feedback1"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.9/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="78.0" text="Feedforward1"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.9/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E33" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.9/@children.0/@ports.2" targets="//@children.1/@children.9/@children.2/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.9/@children.1/@ports.2" targets="//@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.9/@children.2/@ports.2" targets="//@children.1/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.9/@children.2/@ports.2" targets="//@children.1/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.1/@children.9/@children.2/@ports.2" targets="//@children.1/@children.9/@children.5/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.9/@children.3/@ports.1" targets="//@children.1/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.9/@children.4/@ports.1" targets="//@children.1/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.9/@children.5/@ports.2" targets="//@children.1/@children.9/@children.6/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.9/@children.5/@ports.2" targets="//@children.1/@children.9/@children.7/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.9/@children.6/@ports.1" targets="//@children.1/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.9/@children.7/@ports.1" targets="//@children.1/@children.9/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N26">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L26" height="15.0" width="30.0" text="Plant"/>
+      <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.10/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.12 //@children.1/@containedEdges.13" incomingEdges="//@children.1/@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N27" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="63.0" text="InputAdder"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.10/@containedEdges.0 //@children.1/@children.10/@containedEdges.6 //@children.1/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="74.0" text="OutputAdder"/>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.10/@containedEdges.7 //@children.1/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="62.0" text="Integrator0"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.3 //@children.1/@children.10/@containedEdges.4 //@children.1/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="65.0" text="Feedback0"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="78.0" text="Feedforward0"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="62.0" text="Integrator1"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.8 //@children.1/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="65.0" text="Feedback1"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="78.0" text="Feedforward1"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E45" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.1/@children.10/@children.0/@ports.2" targets="//@children.1/@children.10/@children.2/@ports.1"/>
+      <containedEdges identifier="E47" sources="//@children.1/@children.10/@children.1/@ports.2" targets="//@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.1/@children.10/@children.2/@ports.2" targets="//@children.1/@children.10/@children.3/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.1/@children.10/@children.2/@ports.2" targets="//@children.1/@children.10/@children.4/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.1/@children.10/@children.2/@ports.2" targets="//@children.1/@children.10/@children.5/@ports.1"/>
+      <containedEdges identifier="E51" sources="//@children.1/@children.10/@children.3/@ports.1" targets="//@children.1/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.1/@children.10/@children.4/@ports.1" targets="//@children.1/@children.10/@children.1/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.1/@children.10/@children.5/@ports.2" targets="//@children.1/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.1/@children.10/@children.5/@ports.2" targets="//@children.1/@children.10/@children.7/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.1/@children.10/@children.6/@ports.1" targets="//@children.1/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.1/@children.10/@children.7/@ports.1" targets="//@children.1/@children.10/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.9/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.9/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N35">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L35" height="15.0" width="38.0" text="Plant2"/>
+    <ports identifier="P90" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P91" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.2/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N36" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="56.0" text="Sampler2"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N45">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L45" height="15.0" width="162.0" text="ContinuousTransferFunction"/>
+      <ports identifier="P113" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.9/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.10 //@children.2/@containedEdges.11" incomingEdges="//@children.2/@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N46" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="63.0" text="InputAdder"/>
+        <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.9/@containedEdges.0 //@children.2/@children.9/@containedEdges.6 //@children.2/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="74.0" text="OutputAdder"/>
+        <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.9/@containedEdges.7 //@children.2/@children.9/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P120" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="62.0" text="Integrator0"/>
+        <ports identifier="P121" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P123" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.2/@children.9/@containedEdges.3 //@children.2/@children.9/@containedEdges.4 //@children.2/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="65.0" text="Feedback0"/>
+        <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P126" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="78.0" text="Feedforward0"/>
+        <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="62.0" text="Integrator1"/>
+        <ports identifier="P129" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.2/@children.9/@containedEdges.8 //@children.2/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="65.0" text="Feedback1"/>
+        <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.9/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P134" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="78.0" text="Feedforward1"/>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P136" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.9/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E71" sources="//@children.2/@children.9/@ports.0" targets="//@children.2/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E72" sources="//@children.2/@children.9/@children.0/@ports.2" targets="//@children.2/@children.9/@children.2/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.2/@children.9/@children.1/@ports.2" targets="//@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E74" sources="//@children.2/@children.9/@children.2/@ports.2" targets="//@children.2/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.2/@children.9/@children.2/@ports.2" targets="//@children.2/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.2/@children.9/@children.2/@ports.2" targets="//@children.2/@children.9/@children.5/@ports.1"/>
+      <containedEdges identifier="E77" sources="//@children.2/@children.9/@children.3/@ports.1" targets="//@children.2/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.2/@children.9/@children.4/@ports.1" targets="//@children.2/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.2/@children.9/@children.5/@ports.2" targets="//@children.2/@children.9/@children.6/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.2/@children.9/@children.5/@ports.2" targets="//@children.2/@children.9/@children.7/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.2/@children.9/@children.6/@ports.1" targets="//@children.2/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.2/@children.9/@children.7/@ports.1" targets="//@children.2/@children.9/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N54">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L54" height="15.0" width="169.0" text="ContinuousTransferFunction2"/>
+      <ports identifier="P137" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.10/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.12 //@children.2/@containedEdges.13" incomingEdges="//@children.2/@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N55" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L55" height="15.0" width="63.0" text="InputAdder"/>
+        <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.0 //@children.2/@children.10/@containedEdges.6 //@children.2/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N56" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L56" height="15.0" width="74.0" text="OutputAdder"/>
+        <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.10/@containedEdges.7 //@children.2/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P144" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N57" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="62.0" text="Integrator0"/>
+        <ports identifier="P145" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P147" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.2/@children.10/@containedEdges.3 //@children.2/@children.10/@containedEdges.4 //@children.2/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P148" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="65.0" text="Feedback0"/>
+        <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P150" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="78.0" text="Feedforward0"/>
+        <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P152" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="62.0" text="Integrator1"/>
+        <ports identifier="P153" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P155" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.2/@children.10/@containedEdges.8 //@children.2/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P156" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="65.0" text="Feedback1"/>
+        <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P158" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N62" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L62" height="15.0" width="78.0" text="Feedforward1"/>
+        <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P160" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E83" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.2/@children.10/@children.0/@ports.2" targets="//@children.2/@children.10/@children.2/@ports.1"/>
+      <containedEdges identifier="E85" sources="//@children.2/@children.10/@children.1/@ports.2" targets="//@children.2/@children.10/@ports.1"/>
+      <containedEdges identifier="E86" sources="//@children.2/@children.10/@children.2/@ports.2" targets="//@children.2/@children.10/@children.3/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.2/@children.10/@children.2/@ports.2" targets="//@children.2/@children.10/@children.4/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.2/@children.10/@children.2/@ports.2" targets="//@children.2/@children.10/@children.5/@ports.1"/>
+      <containedEdges identifier="E89" sources="//@children.2/@children.10/@children.3/@ports.1" targets="//@children.2/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E90" sources="//@children.2/@children.10/@children.4/@ports.1" targets="//@children.2/@children.10/@children.1/@ports.0"/>
+      <containedEdges identifier="E91" sources="//@children.2/@children.10/@children.5/@ports.2" targets="//@children.2/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E92" sources="//@children.2/@children.10/@children.5/@ports.2" targets="//@children.2/@children.10/@children.7/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.2/@children.10/@children.6/@ports.1" targets="//@children.2/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E94" sources="//@children.2/@children.10/@children.7/@ports.1" targets="//@children.2/@children.10/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E57" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.2/@ports.1" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E60" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E61" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.2/@children.4/@ports.2" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.2/@children.5/@ports.2" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E65" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E67" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+  </children>
+  <children identifier="N63">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L63" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P161" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N64" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P168" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E95" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E96" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E97" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E98" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@ports.3"/>
+  </children>
+  <children identifier="N66">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L66" height="15.0" width="38.0" text="Plant3"/>
+    <ports identifier="P169" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.4/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N67" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P174" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.11 //@children.4/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P178" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P182" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N72" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L72" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P185" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N73" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+      <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P187" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P188" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="56.0" text="Sampler2"/>
+      <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P191" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N76">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L76" height="15.0" width="162.0" text="ContinuousTransferFunction"/>
+      <ports identifier="P192" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.9/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P193" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.10 //@children.4/@containedEdges.11" incomingEdges="//@children.4/@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N77" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L77" height="15.0" width="63.0" text="InputAdder"/>
+        <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.9/@containedEdges.0 //@children.4/@children.9/@containedEdges.6 //@children.4/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P196" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N78" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L78" height="15.0" width="74.0" text="OutputAdder"/>
+        <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.9/@containedEdges.7 //@children.4/@children.9/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P199" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.9/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N79" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="62.0" text="Integrator0"/>
+        <ports identifier="P200" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.9/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P202" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.9/@containedEdges.3 //@children.4/@children.9/@containedEdges.4 //@children.4/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P203" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="65.0" text="Feedback0"/>
+        <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.9/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P205" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.9/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="78.0" text="Feedforward0"/>
+        <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.9/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P207" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.9/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="62.0" text="Integrator1"/>
+        <ports identifier="P208" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.9/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.9/@containedEdges.8 //@children.4/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P211" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="65.0" text="Feedback1"/>
+        <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.9/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P213" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.9/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="78.0" text="Feedforward1"/>
+        <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.9/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.9/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E113" sources="//@children.4/@children.9/@ports.0" targets="//@children.4/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E114" sources="//@children.4/@children.9/@children.0/@ports.2" targets="//@children.4/@children.9/@children.2/@ports.1"/>
+      <containedEdges identifier="E115" sources="//@children.4/@children.9/@children.1/@ports.2" targets="//@children.4/@children.9/@ports.1"/>
+      <containedEdges identifier="E116" sources="//@children.4/@children.9/@children.2/@ports.2" targets="//@children.4/@children.9/@children.3/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.4/@children.9/@children.2/@ports.2" targets="//@children.4/@children.9/@children.4/@ports.0"/>
+      <containedEdges identifier="E118" sources="//@children.4/@children.9/@children.2/@ports.2" targets="//@children.4/@children.9/@children.5/@ports.1"/>
+      <containedEdges identifier="E119" sources="//@children.4/@children.9/@children.3/@ports.1" targets="//@children.4/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.4/@children.9/@children.4/@ports.1" targets="//@children.4/@children.9/@children.1/@ports.0"/>
+      <containedEdges identifier="E121" sources="//@children.4/@children.9/@children.5/@ports.2" targets="//@children.4/@children.9/@children.6/@ports.0"/>
+      <containedEdges identifier="E122" sources="//@children.4/@children.9/@children.5/@ports.2" targets="//@children.4/@children.9/@children.7/@ports.0"/>
+      <containedEdges identifier="E123" sources="//@children.4/@children.9/@children.6/@ports.1" targets="//@children.4/@children.9/@children.0/@ports.0"/>
+      <containedEdges identifier="E124" sources="//@children.4/@children.9/@children.7/@ports.1" targets="//@children.4/@children.9/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N85">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L85" height="15.0" width="169.0" text="ContinuousTransferFunction2"/>
+      <ports identifier="P216" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.10/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P217" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.12 //@children.4/@containedEdges.13" incomingEdges="//@children.4/@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N86" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L86" height="15.0" width="63.0" text="InputAdder"/>
+        <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.10/@containedEdges.0 //@children.4/@children.10/@containedEdges.6 //@children.4/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P220" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N87" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L87" height="15.0" width="74.0" text="OutputAdder"/>
+        <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.10/@containedEdges.7 //@children.4/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P223" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N88" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L88" height="15.0" width="62.0" text="Integrator0"/>
+        <ports identifier="P224" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P226" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.10/@containedEdges.3 //@children.4/@children.10/@containedEdges.4 //@children.4/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P227" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N89" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L89" height="15.0" width="65.0" text="Feedback0"/>
+        <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P229" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N90" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L90" height="15.0" width="78.0" text="Feedforward0"/>
+        <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P231" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N91" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L91" height="15.0" width="62.0" text="Integrator1"/>
+        <ports identifier="P232" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P234" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.10/@containedEdges.8 //@children.4/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P235" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N92" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L92" height="15.0" width="65.0" text="Feedback1"/>
+        <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P237" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.10/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N93" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L93" height="15.0" width="78.0" text="Feedforward1"/>
+        <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.10/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P239" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.10/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E125" sources="//@children.4/@children.10/@ports.0" targets="//@children.4/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E126" sources="//@children.4/@children.10/@children.0/@ports.2" targets="//@children.4/@children.10/@children.2/@ports.1"/>
+      <containedEdges identifier="E127" sources="//@children.4/@children.10/@children.1/@ports.2" targets="//@children.4/@children.10/@ports.1"/>
+      <containedEdges identifier="E128" sources="//@children.4/@children.10/@children.2/@ports.2" targets="//@children.4/@children.10/@children.3/@ports.0"/>
+      <containedEdges identifier="E129" sources="//@children.4/@children.10/@children.2/@ports.2" targets="//@children.4/@children.10/@children.4/@ports.0"/>
+      <containedEdges identifier="E130" sources="//@children.4/@children.10/@children.2/@ports.2" targets="//@children.4/@children.10/@children.5/@ports.1"/>
+      <containedEdges identifier="E131" sources="//@children.4/@children.10/@children.3/@ports.1" targets="//@children.4/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E132" sources="//@children.4/@children.10/@children.4/@ports.1" targets="//@children.4/@children.10/@children.1/@ports.0"/>
+      <containedEdges identifier="E133" sources="//@children.4/@children.10/@children.5/@ports.2" targets="//@children.4/@children.10/@children.6/@ports.0"/>
+      <containedEdges identifier="E134" sources="//@children.4/@children.10/@children.5/@ports.2" targets="//@children.4/@children.10/@children.7/@ports.0"/>
+      <containedEdges identifier="E135" sources="//@children.4/@children.10/@children.6/@ports.1" targets="//@children.4/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.4/@children.10/@children.7/@ports.1" targets="//@children.4/@children.10/@children.1/@ports.0"/>
+    </children>
+    <containedEdges identifier="E99" sources="//@children.4/@ports.0" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E100" sources="//@children.4/@ports.1" targets="//@children.4/@children.6/@ports.0"/>
+    <containedEdges identifier="E101" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E102" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E103" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E104" sources="//@children.4/@children.4/@ports.2" targets="//@children.4/@children.9/@ports.0"/>
+    <containedEdges identifier="E105" sources="//@children.4/@children.5/@ports.2" targets="//@children.4/@children.10/@ports.0"/>
+    <containedEdges identifier="E106" sources="//@children.4/@children.6/@ports.1" targets="//@children.4/@children.5/@ports.1"/>
+    <containedEdges identifier="E107" sources="//@children.4/@children.7/@ports.0" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E108" sources="//@children.4/@children.8/@ports.1" targets="//@children.4/@ports.3"/>
+    <containedEdges identifier="E109" sources="//@children.4/@children.9/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E110" sources="//@children.4/@children.9/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E111" sources="//@children.4/@children.10/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E112" sources="//@children.4/@children.10/@ports.1" targets="//@children.4/@children.8/@ports.0"/>
+  </children>
+  <children identifier="N94">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L94" height="15.0" width="101.0" text="CompositeActor3"/>
+    <ports identifier="P240" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P241" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P242" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.5/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P243" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.5/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N95" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L95" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P245" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N96" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L96" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P247" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E137" sources="//@children.5/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E138" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E139" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@ports.2"/>
+    <containedEdges identifier="E140" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@ports.3"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.3" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.3" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.3" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_cosimulation_CoSimulation.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_cosimulation_CoSimulation.elkg
@@ -1,0 +1,1332 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <children identifier="N3">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L3" height="15.0" width="154.0" text="ArchitectureMappingModel"/>
+        <children identifier="N4">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L4" height="15.0" width="17.0" text="P1"/>
+          <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N5" height="36.0" width="67.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L5" height="15.0" width="9.0" text="P"/>
+            <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P6" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@children.0/@children.0/@containedEdges.4 //@children.0/@children.0/@children.0/@children.0/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P7" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.9">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+            <ports identifier="P8" height="8.0" width="8.0" x="42.0" y="36.0">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <children identifier="N6" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L6" height="15.0" width="37.0" text="Merge"/>
+            <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.16 //@children.0/@children.0/@children.0/@children.0/@containedEdges.18">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P10" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N7" height="25.0" width="56.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+            <ports identifier="P11" height="8.0" width="8.0" x="56.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.17">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N8" height="25.0" width="54.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+            <ports identifier="P13" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.19">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N9" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L9" height="15.0" width="44.0" text="Merge2"/>
+            <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.7 //@children.0/@children.0/@children.0/@children.0/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P16" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.9">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N10" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L10" height="15.0" width="40.0" text="Equals"/>
+            <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@children.0/@children.0/@containedEdges.12">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N11" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L11" height="15.0" width="54.0" text="TrueGate"/>
+            <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.11">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N12" height="25.0" width="54.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L12" height="15.0" width="74.0" text="TimedPlotter"/>
+            <ports identifier="P21" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.12">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N13" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L13" height="15.0" width="48.0" text="Equals2"/>
+            <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.4 //@children.0/@children.0/@children.0/@children.0/@containedEdges.14">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.13">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N14" height="25.0" width="101.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L14" height="15.0" width="81.0" text="DiscreteClock"/>
+            <ports identifier="P25" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.14">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N15" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L15" height="15.0" width="61.0" text="TrueGate2"/>
+            <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.13">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.15">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N16" height="25.0" width="54.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L16" height="15.0" width="81.0" text="TimedPlotter2"/>
+            <ports identifier="P29" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.16 //@children.0/@children.0/@children.0/@children.0/@containedEdges.17">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N17" height="25.0" width="101.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L17" height="15.0" width="89.0" text="DiscreteClock2"/>
+            <ports identifier="P31" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.18 //@children.0/@children.0/@children.0/@children.0/@containedEdges.19">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.0/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E33" sources="//@children.0/@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.11/@ports.1"/>
+          <containedEdges identifier="E34" sources="//@children.0/@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.12/@ports.1"/>
+          <containedEdges identifier="E35" sources="//@children.0/@children.0/@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.5/@ports.0"/>
+          <containedEdges identifier="E36" sources="//@children.0/@children.0/@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.7/@ports.1"/>
+          <containedEdges identifier="E37" sources="//@children.0/@children.0/@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.8/@ports.0"/>
+          <containedEdges identifier="E38" sources="//@children.0/@children.0/@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.9/@ports.1"/>
+          <containedEdges identifier="E39" sources="//@children.0/@children.0/@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.0/@ports.0"/>
+          <containedEdges identifier="E40" sources="//@children.0/@children.0/@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.4/@ports.0"/>
+          <containedEdges identifier="E41" sources="//@children.0/@children.0/@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.4/@ports.0"/>
+          <containedEdges identifier="E42" sources="//@children.0/@children.0/@children.0/@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.0/@ports.2"/>
+          <containedEdges identifier="E43" sources="//@children.0/@children.0/@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.6/@ports.0"/>
+          <containedEdges identifier="E44" sources="//@children.0/@children.0/@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@ports.3"/>
+          <containedEdges identifier="E45" sources="//@children.0/@children.0/@children.0/@children.0/@children.7/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.5/@ports.0"/>
+          <containedEdges identifier="E46" sources="//@children.0/@children.0/@children.0/@children.0/@children.8/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@children.10/@ports.0"/>
+          <containedEdges identifier="E47" sources="//@children.0/@children.0/@children.0/@children.0/@children.9/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.8/@ports.0"/>
+          <containedEdges identifier="E48" sources="//@children.0/@children.0/@children.0/@children.0/@children.10/@ports.1" targets="//@children.0/@children.0/@children.0/@children.0/@ports.2"/>
+          <containedEdges identifier="E49" sources="//@children.0/@children.0/@children.0/@children.0/@children.11/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.1/@ports.0"/>
+          <containedEdges identifier="E50" sources="//@children.0/@children.0/@children.0/@children.0/@children.11/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.2/@ports.1"/>
+          <containedEdges identifier="E51" sources="//@children.0/@children.0/@children.0/@children.0/@children.12/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.1/@ports.0"/>
+          <containedEdges identifier="E52" sources="//@children.0/@children.0/@children.0/@children.0/@children.12/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@children.3/@ports.1"/>
+        </children>
+        <children identifier="N18">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L18" height="15.0" width="17.0" text="P2"/>
+          <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@children.0/@containedEdges.3" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <children identifier="N19" height="36.0" width="67.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L19" height="15.0" width="9.0" text="P"/>
+            <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P36" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.1 //@children.0/@children.0/@children.0/@children.1/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P37" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+            <ports identifier="P38" height="8.0" width="8.0" x="42.0" y="36.0">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <children identifier="N20" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L20" height="15.0" width="37.0" text="Merge"/>
+            <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.9">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P40" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N21" height="25.0" width="77.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L21" height="15.0" width="34.0" text="Const"/>
+            <ports identifier="P41" height="8.0" width="8.0" x="77.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N22" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L22" height="15.0" width="44.0" text="Merge2"/>
+            <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.4">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P44" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N23" height="25.0" width="76.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L23" height="15.0" width="89.0" text="DiscreteClock2"/>
+            <ports identifier="P45" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N24" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L24" height="15.0" width="48.0" text="Equals2"/>
+            <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.2 //@children.0/@children.0/@children.0/@children.1/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N25" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L25" height="15.0" width="61.0" text="TrueGate2"/>
+            <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N26" height="25.0" width="76.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L26" height="15.0" width="81.0" text="DiscreteClock"/>
+            <ports identifier="P51" height="8.0" width="8.0" x="76.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.9 //@children.0/@children.0/@children.0/@children.1/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.1/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E53" sources="//@children.0/@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.0/@children.1/@children.7/@ports.1"/>
+          <containedEdges identifier="E54" sources="//@children.0/@children.0/@children.0/@children.1/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.1/@children.4/@ports.1"/>
+          <containedEdges identifier="E55" sources="//@children.0/@children.0/@children.0/@children.1/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.1/@children.5/@ports.0"/>
+          <containedEdges identifier="E56" sources="//@children.0/@children.0/@children.0/@children.1/@children.1/@ports.1" targets="//@children.0/@children.0/@children.0/@children.1/@children.0/@ports.0"/>
+          <containedEdges identifier="E57" sources="//@children.0/@children.0/@children.0/@children.1/@children.2/@ports.0" targets="//@children.0/@children.0/@children.0/@children.1/@children.3/@ports.0"/>
+          <containedEdges identifier="E58" sources="//@children.0/@children.0/@children.0/@children.1/@children.3/@ports.1" targets="//@children.0/@children.0/@children.0/@children.1/@children.0/@ports.2"/>
+          <containedEdges identifier="E59" sources="//@children.0/@children.0/@children.0/@children.1/@children.4/@ports.0" targets="//@children.0/@children.0/@children.0/@children.1/@children.5/@ports.0"/>
+          <containedEdges identifier="E60" sources="//@children.0/@children.0/@children.0/@children.1/@children.5/@ports.1" targets="//@children.0/@children.0/@children.0/@children.1/@children.6/@ports.0"/>
+          <containedEdges identifier="E61" sources="//@children.0/@children.0/@children.0/@children.1/@children.6/@ports.1" targets="//@children.0/@children.0/@children.0/@children.1/@ports.1"/>
+          <containedEdges identifier="E62" sources="//@children.0/@children.0/@children.0/@children.1/@children.7/@ports.0" targets="//@children.0/@children.0/@children.0/@children.1/@children.1/@ports.0"/>
+          <containedEdges identifier="E63" sources="//@children.0/@children.0/@children.0/@children.1/@children.7/@ports.0" targets="//@children.0/@children.0/@children.0/@children.1/@children.2/@ports.1"/>
+        </children>
+        <children identifier="N27" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="65.0" text="RampMAG"/>
+          <ports identifier="P56" height="8.0" width="8.0" x="15.0" y="-8.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P57" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P58" height="8.0" width="8.0" x="38.0" y="-8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N29">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L29" height="15.0" width="18.0" text="r2s"/>
+          <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.0 //@children.0/@children.0/@children.0/@children.4/@containedEdges.1 //@children.0/@children.0/@children.0/@children.4/@containedEdges.2" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P61" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.8" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.7" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P63" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.6 //@children.0/@children.0/@children.0/@children.4/@containedEdges.7 //@children.0/@children.0/@children.0/@children.4/@containedEdges.8" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P64" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.9" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.42">
+            <properties key="org.eclipse.elk.port.index" value="4"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.3 //@children.0/@children.0/@children.0/@children.4/@containedEdges.4 //@children.0/@children.0/@children.0/@children.4/@containedEdges.5" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="5"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.9 //@children.0/@children.0/@children.0/@children.4/@containedEdges.10 //@children.0/@children.0/@children.0/@children.4/@containedEdges.11" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="-6"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.10" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.47">
+            <properties key="org.eclipse.elk.port.index" value="7"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.12 //@children.0/@children.0/@children.0/@children.4/@containedEdges.13 //@children.0/@children.0/@children.0/@children.4/@containedEdges.14" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="-8"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.11" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.52">
+            <properties key="org.eclipse.elk.port.index" value="9"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <children identifier="N30" height="36.0" width="67.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L30" height="15.0" width="37.0" text="Server"/>
+            <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.25">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P71" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.15 //@children.0/@children.0/@children.0/@children.4/@containedEdges.16 //@children.0/@children.0/@children.0/@children.4/@containedEdges.17 //@children.0/@children.0/@children.0/@children.4/@containedEdges.18 //@children.0/@children.0/@children.0/@children.4/@containedEdges.19 //@children.0/@children.0/@children.0/@children.4/@containedEdges.20 //@children.0/@children.0/@children.0/@children.4/@containedEdges.21 //@children.0/@children.0/@children.0/@children.4/@containedEdges.22 //@children.0/@children.0/@children.0/@children.4/@containedEdges.23 //@children.0/@children.0/@children.0/@children.4/@containedEdges.24">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P72" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.38">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+            <ports identifier="P73" height="8.0" width="8.0" x="42.0" y="36.0">
+              <properties key="org.eclipse.elk.port.index" value="-3"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <children identifier="N31" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L31" height="15.0" width="37.0" text="Merge"/>
+            <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.26 //@children.0/@children.0/@children.0/@children.4/@containedEdges.27 //@children.0/@children.0/@children.0/@children.4/@containedEdges.30 //@children.0/@children.0/@children.0/@children.4/@containedEdges.43 //@children.0/@children.0/@children.0/@children.4/@containedEdges.48">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P75" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.25">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N32" height="25.0" width="36.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L32" height="15.0" width="34.0" text="Const"/>
+            <ports identifier="P76" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.26">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N33" height="25.0" width="36.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L33" height="15.0" width="42.0" text="Const2"/>
+            <ports identifier="P78" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.27">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N34" height="25.0" width="36.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L34" height="15.0" width="42.0" text="Const3"/>
+            <ports identifier="P80" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.28">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.15">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N35" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L35" height="15.0" width="40.0" text="Equals"/>
+            <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.16 //@children.0/@children.0/@children.0/@children.4/@containedEdges.28">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P83" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.29">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N36" height="25.0" width="64.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L36" height="15.0" width="42.0" text="Const4"/>
+            <ports identifier="P84" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.30">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N37" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L37" height="15.0" width="54.0" text="TrueGate"/>
+            <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.29">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.31">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N38" height="25.0" width="36.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L38" height="15.0" width="42.0" text="Const5"/>
+            <ports identifier="P88" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.32">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.17">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N39" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L39" height="15.0" width="48.0" text="Equals2"/>
+            <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.18 //@children.0/@children.0/@children.0/@children.4/@containedEdges.32">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P91" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.33">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N40" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L40" height="15.0" width="61.0" text="TrueGate2"/>
+            <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.33">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P93" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.34">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N41" height="25.0" width="64.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L41" height="15.0" width="42.0" text="Const6"/>
+            <ports identifier="P94" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.35">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.19">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N42" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L42" height="15.0" width="48.0" text="Equals3"/>
+            <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.20 //@children.0/@children.0/@children.0/@children.4/@containedEdges.35">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P97" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.36">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N43" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L43" height="15.0" width="61.0" text="TrueGate3"/>
+            <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.36">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P99" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.37">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N44" height="25.0" width="75.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L44" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P100" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.38">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.39">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N45" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L45" height="15.0" width="44.0" text="Merge2"/>
+            <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.1 //@children.0/@children.0/@children.0/@children.4/@containedEdges.4 //@children.0/@children.0/@children.0/@children.4/@containedEdges.7 //@children.0/@children.0/@children.0/@children.4/@containedEdges.9 //@children.0/@children.0/@children.0/@children.4/@containedEdges.12">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P103" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.39">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N46" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L46" height="15.0" width="49.0" text="Register"/>
+            <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P105" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.40">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P106" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.31">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <children identifier="N47" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L47" height="15.0" width="56.0" text="Register2"/>
+            <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P108" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.41">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P109" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.34">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <children identifier="N48" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L48" height="15.0" width="56.0" text="Register3"/>
+            <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.8">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P111" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.42">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P112" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.37">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <children identifier="N49" height="25.0" width="38.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L49" height="15.0" width="42.0" text="Const7"/>
+            <ports identifier="P113" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.43">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.10">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N50" height="25.0" width="38.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L50" height="15.0" width="42.0" text="Const8"/>
+            <ports identifier="P115" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.44">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.21">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N51" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L51" height="15.0" width="48.0" text="Equals4"/>
+            <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.22 //@children.0/@children.0/@children.0/@children.4/@containedEdges.44">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P118" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.45">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N52" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L52" height="15.0" width="61.0" text="TrueGate4"/>
+            <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.45">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P120" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.46">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N53" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L53" height="15.0" width="56.0" text="Register4"/>
+            <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.11">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P122" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.47">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P123" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.46">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <children identifier="N54" height="25.0" width="47.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L54" height="15.0" width="42.0" text="Const9"/>
+            <ports identifier="P124" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.48">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.13">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N55" height="25.0" width="47.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L55" height="15.0" width="49.0" text="Const10"/>
+            <ports identifier="P126" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.49">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.23">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N56" height="31.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L56" height="15.0" width="48.0" text="Equals5"/>
+            <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.24 //@children.0/@children.0/@children.0/@children.4/@containedEdges.49">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P129" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.50">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N57" height="31.0" width="41.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L57" height="15.0" width="61.0" text="TrueGate5"/>
+            <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.50">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P131" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.51">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N58" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L58" height="15.0" width="56.0" text="Register5"/>
+            <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.14">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P133" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.52">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P134" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@children.4/@containedEdges.51">
+              <properties key="org.eclipse.elk.port.index" value="-2"/>
+              <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E64" sources="//@children.0/@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.2/@ports.1"/>
+          <containedEdges identifier="E65" sources="//@children.0/@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.15/@ports.0"/>
+          <containedEdges identifier="E66" sources="//@children.0/@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.16/@ports.0"/>
+          <containedEdges identifier="E67" sources="//@children.0/@children.0/@children.0/@children.4/@ports.5" targets="//@children.0/@children.0/@children.0/@children.4/@children.3/@ports.1"/>
+          <containedEdges identifier="E68" sources="//@children.0/@children.0/@children.0/@children.4/@ports.5" targets="//@children.0/@children.0/@children.0/@children.4/@children.15/@ports.0"/>
+          <containedEdges identifier="E69" sources="//@children.0/@children.0/@children.0/@children.4/@ports.5" targets="//@children.0/@children.0/@children.0/@children.4/@children.17/@ports.0"/>
+          <containedEdges identifier="E70" sources="//@children.0/@children.0/@children.0/@children.4/@ports.3" targets="//@children.0/@children.0/@children.0/@children.4/@children.6/@ports.1"/>
+          <containedEdges identifier="E71" sources="//@children.0/@children.0/@children.0/@children.4/@ports.3" targets="//@children.0/@children.0/@children.0/@children.4/@children.15/@ports.0"/>
+          <containedEdges identifier="E72" sources="//@children.0/@children.0/@children.0/@children.4/@ports.3" targets="//@children.0/@children.0/@children.0/@children.4/@children.18/@ports.0"/>
+          <containedEdges identifier="E73" sources="//@children.0/@children.0/@children.0/@children.4/@ports.6" targets="//@children.0/@children.0/@children.0/@children.4/@children.15/@ports.0"/>
+          <containedEdges identifier="E74" sources="//@children.0/@children.0/@children.0/@children.4/@ports.6" targets="//@children.0/@children.0/@children.0/@children.4/@children.19/@ports.1"/>
+          <containedEdges identifier="E75" sources="//@children.0/@children.0/@children.0/@children.4/@ports.6" targets="//@children.0/@children.0/@children.0/@children.4/@children.23/@ports.0"/>
+          <containedEdges identifier="E76" sources="//@children.0/@children.0/@children.0/@children.4/@ports.8" targets="//@children.0/@children.0/@children.0/@children.4/@children.15/@ports.0"/>
+          <containedEdges identifier="E77" sources="//@children.0/@children.0/@children.0/@children.4/@ports.8" targets="//@children.0/@children.0/@children.0/@children.4/@children.24/@ports.1"/>
+          <containedEdges identifier="E78" sources="//@children.0/@children.0/@children.0/@children.4/@ports.8" targets="//@children.0/@children.0/@children.0/@children.4/@children.28/@ports.0"/>
+          <containedEdges identifier="E79" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.4/@ports.1"/>
+          <containedEdges identifier="E80" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.5/@ports.0"/>
+          <containedEdges identifier="E81" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.8/@ports.1"/>
+          <containedEdges identifier="E82" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.9/@ports.0"/>
+          <containedEdges identifier="E83" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.11/@ports.1"/>
+          <containedEdges identifier="E84" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.12/@ports.0"/>
+          <containedEdges identifier="E85" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.20/@ports.1"/>
+          <containedEdges identifier="E86" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.21/@ports.0"/>
+          <containedEdges identifier="E87" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.25/@ports.1"/>
+          <containedEdges identifier="E88" sources="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.26/@ports.0"/>
+          <containedEdges identifier="E89" sources="//@children.0/@children.0/@children.0/@children.4/@children.1/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.0"/>
+          <containedEdges identifier="E90" sources="//@children.0/@children.0/@children.0/@children.4/@children.2/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E91" sources="//@children.0/@children.0/@children.0/@children.4/@children.3/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E92" sources="//@children.0/@children.0/@children.0/@children.4/@children.4/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.5/@ports.0"/>
+          <containedEdges identifier="E93" sources="//@children.0/@children.0/@children.0/@children.4/@children.5/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.7/@ports.0"/>
+          <containedEdges identifier="E94" sources="//@children.0/@children.0/@children.0/@children.4/@children.6/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E95" sources="//@children.0/@children.0/@children.0/@children.4/@children.7/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.16/@ports.2"/>
+          <containedEdges identifier="E96" sources="//@children.0/@children.0/@children.0/@children.4/@children.8/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.9/@ports.0"/>
+          <containedEdges identifier="E97" sources="//@children.0/@children.0/@children.0/@children.4/@children.9/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.10/@ports.0"/>
+          <containedEdges identifier="E98" sources="//@children.0/@children.0/@children.0/@children.4/@children.10/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.17/@ports.2"/>
+          <containedEdges identifier="E99" sources="//@children.0/@children.0/@children.0/@children.4/@children.11/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.12/@ports.0"/>
+          <containedEdges identifier="E100" sources="//@children.0/@children.0/@children.0/@children.4/@children.12/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.13/@ports.0"/>
+          <containedEdges identifier="E101" sources="//@children.0/@children.0/@children.0/@children.4/@children.13/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.18/@ports.2"/>
+          <containedEdges identifier="E102" sources="//@children.0/@children.0/@children.0/@children.4/@children.14/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.0/@ports.2"/>
+          <containedEdges identifier="E103" sources="//@children.0/@children.0/@children.0/@children.4/@children.15/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.14/@ports.1"/>
+          <containedEdges identifier="E104" sources="//@children.0/@children.0/@children.0/@children.4/@children.16/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@ports.1"/>
+          <containedEdges identifier="E105" sources="//@children.0/@children.0/@children.0/@children.4/@children.17/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@ports.2"/>
+          <containedEdges identifier="E106" sources="//@children.0/@children.0/@children.0/@children.4/@children.18/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@ports.4"/>
+          <containedEdges identifier="E107" sources="//@children.0/@children.0/@children.0/@children.4/@children.19/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E108" sources="//@children.0/@children.0/@children.0/@children.4/@children.20/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.21/@ports.0"/>
+          <containedEdges identifier="E109" sources="//@children.0/@children.0/@children.0/@children.4/@children.21/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.22/@ports.0"/>
+          <containedEdges identifier="E110" sources="//@children.0/@children.0/@children.0/@children.4/@children.22/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.23/@ports.2"/>
+          <containedEdges identifier="E111" sources="//@children.0/@children.0/@children.0/@children.4/@children.23/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@ports.7"/>
+          <containedEdges identifier="E112" sources="//@children.0/@children.0/@children.0/@children.4/@children.24/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.1/@ports.0"/>
+          <containedEdges identifier="E113" sources="//@children.0/@children.0/@children.0/@children.4/@children.25/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@children.26/@ports.0"/>
+          <containedEdges identifier="E114" sources="//@children.0/@children.0/@children.0/@children.4/@children.26/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.27/@ports.0"/>
+          <containedEdges identifier="E115" sources="//@children.0/@children.0/@children.0/@children.4/@children.27/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@children.28/@ports.2"/>
+          <containedEdges identifier="E116" sources="//@children.0/@children.0/@children.0/@children.4/@children.28/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@ports.9"/>
+        </children>
+        <children identifier="N59" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="87.0" text="SpectrumMAG"/>
+          <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P136" height="8.0" width="8.0" x="61.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P138" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P139" height="8.0" width="8.0" x="15.0" y="-8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="4"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P140" height="8.0" width="8.0" x="38.0" y="-8.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="5"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+        </children>
+        <children identifier="N60" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L60" height="15.0" width="46.0" text="getData"/>
+          <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P142" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P143" height="8.0" width="8.0" x="61.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P144" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N61" height="28.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L61" height="15.0" width="174.0" text="avoidZeroDelayLoopException"/>
+          <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P146" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N62">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+          <labels identifier="L62" height="15.0" width="11.0" text="M"/>
+          <ports identifier="P147" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.2" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P148" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.18" incomingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P149" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.0 //@children.0/@children.0/@children.0/@children.8/@containedEdges.1" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <ports identifier="P150" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.19" incomingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+          </ports>
+          <children identifier="N63" height="41.0" width="61.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L63" height="15.0" width="67.0" text="SetVariable"/>
+            <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P152" height="8.0" width="8.0" x="61.0" y="16.5">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N64" height="41.0" width="21.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L64" height="15.0" width="37.0" text="Merge"/>
+            <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.5 //@children.0/@children.0/@children.0/@children.8/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+            <ports identifier="P154" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.3">
+              <properties key="org.eclipse.elk.port.index" value="1"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+          </children>
+          <children identifier="N65" height="25.0" width="192.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L65" height="15.0" width="66.0" text="Expression"/>
+            <ports identifier="P155" height="8.0" width="8.0" x="192.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.4 //@children.0/@children.0/@children.0/@children.8/@containedEdges.5">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.2">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N66" height="25.0" width="380.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L66" height="15.0" width="73.0" text="Expression2"/>
+            <ports identifier="P157" height="8.0" width="8.0" x="380.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.6">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.0">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <children identifier="N67" height="25.0" width="213.0">
+            <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+            <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+            <labels identifier="L67" height="15.0" width="73.0" text="Expression3"/>
+            <ports identifier="P159" height="8.0" width="8.0" x="213.0" y="8.5" outgoingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.7">
+              <properties key="org.eclipse.elk.port.index" value="0"/>
+              <properties key="org.eclipse.elk.port.side" value="EAST"/>
+            </ports>
+            <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@children.0/@children.8/@containedEdges.1">
+              <properties key="org.eclipse.elk.port.index" value="-1"/>
+              <properties key="org.eclipse.elk.port.side" value="WEST"/>
+            </ports>
+          </children>
+          <containedEdges identifier="E117" sources="//@children.0/@children.0/@children.0/@children.8/@ports.2" targets="//@children.0/@children.0/@children.0/@children.8/@children.3/@ports.1"/>
+          <containedEdges identifier="E118" sources="//@children.0/@children.0/@children.0/@children.8/@ports.2" targets="//@children.0/@children.0/@children.0/@children.8/@children.4/@ports.1"/>
+          <containedEdges identifier="E119" sources="//@children.0/@children.0/@children.0/@children.8/@ports.0" targets="//@children.0/@children.0/@children.0/@children.8/@children.2/@ports.1"/>
+          <containedEdges identifier="E120" sources="//@children.0/@children.0/@children.0/@children.8/@children.1/@ports.1" targets="//@children.0/@children.0/@children.0/@children.8/@children.0/@ports.0"/>
+          <containedEdges identifier="E121" sources="//@children.0/@children.0/@children.0/@children.8/@children.2/@ports.0" targets="//@children.0/@children.0/@children.0/@children.8/@ports.3"/>
+          <containedEdges identifier="E122" sources="//@children.0/@children.0/@children.0/@children.8/@children.2/@ports.0" targets="//@children.0/@children.0/@children.0/@children.8/@children.1/@ports.0"/>
+          <containedEdges identifier="E123" sources="//@children.0/@children.0/@children.0/@children.8/@children.3/@ports.0" targets="//@children.0/@children.0/@children.0/@children.8/@children.1/@ports.0"/>
+          <containedEdges identifier="E124" sources="//@children.0/@children.0/@children.0/@children.8/@children.4/@ports.0" targets="//@children.0/@children.0/@children.0/@children.8/@ports.1"/>
+        </children>
+        <children identifier="N68" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="56.0" text="sendData"/>
+          <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P162" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P163" height="8.0" width="8.0" x="61.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P165" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.22 //@children.0/@children.0/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="35.0" text="Ramp"/>
+          <ports identifier="P166" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.24 //@children.0/@children.0/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N71" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="124.0" text="resumeDiscreteClock"/>
+          <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="78.0" text="resumeRamp"/>
+          <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N73" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="99.0" text="resumeSpectrum"/>
+          <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N74" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P171" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P172" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N75" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L75" height="15.0" width="56.0" text="Register2"/>
+          <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P174" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P175" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N76" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L76" height="15.0" width="56.0" text="Spectrum"/>
+          <ports identifier="P176" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N77" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L77" height="15.0" width="56.0" text="Register3"/>
+          <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P178" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P179" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E3" sources="//@children.0/@children.0/@children.0/@children.0/@ports.3" targets="//@children.0/@children.0/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E4" sources="//@children.0/@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.0/@children.15/@ports.2"/>
+        <containedEdges identifier="E5" sources="//@children.0/@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.0/@children.5/@ports.5"/>
+        <containedEdges identifier="E6" sources="//@children.0/@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.0/@children.18/@ports.2"/>
+        <containedEdges identifier="E7" sources="//@children.0/@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@ports.5"/>
+        <containedEdges identifier="E8" sources="//@children.0/@children.0/@children.0/@children.3/@ports.3" targets="//@children.0/@children.0/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E9" sources="//@children.0/@children.0/@children.0/@children.3/@ports.2" targets="//@children.0/@children.0/@children.0/@children.16/@ports.2"/>
+        <containedEdges identifier="E10" sources="//@children.0/@children.0/@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@children.0/@children.8/@ports.2"/>
+        <containedEdges identifier="E11" sources="//@children.0/@children.0/@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.0/@children.4/@ports.4" targets="//@children.0/@children.0/@children.0/@children.9/@ports.3"/>
+        <containedEdges identifier="E13" sources="//@children.0/@children.0/@children.0/@children.4/@ports.7" targets="//@children.0/@children.0/@children.0/@children.6/@ports.3"/>
+        <containedEdges identifier="E14" sources="//@children.0/@children.0/@children.0/@children.4/@ports.9" targets="//@children.0/@children.0/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E15" sources="//@children.0/@children.0/@children.0/@children.5/@ports.2" targets="//@children.0/@children.0/@children.0/@children.6/@ports.2"/>
+        <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.0/@children.5/@ports.3" targets="//@children.0/@children.0/@children.0/@children.9/@ports.2"/>
+        <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.0/@children.5/@ports.4" targets="//@children.0/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E18" sources="//@children.0/@children.0/@children.0/@children.6/@ports.0" targets="//@children.0/@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E19" sources="//@children.0/@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E20" sources="//@children.0/@children.0/@children.0/@children.7/@ports.1" targets="//@children.0/@children.0/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E21" sources="//@children.0/@children.0/@children.0/@children.8/@ports.1" targets="//@children.0/@children.0/@children.0/@children.4/@ports.6"/>
+        <containedEdges identifier="E22" sources="//@children.0/@children.0/@children.0/@children.8/@ports.3" targets="//@children.0/@children.0/@children.0/@children.4/@ports.8"/>
+        <containedEdges identifier="E23" sources="//@children.0/@children.0/@children.0/@children.9/@ports.1" targets="//@children.0/@children.0/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E24" sources="//@children.0/@children.0/@children.0/@children.9/@ports.0" targets="//@children.0/@children.0/@children.0/@children.4/@ports.3"/>
+        <containedEdges identifier="E25" sources="//@children.0/@children.0/@children.0/@children.10/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E26" sources="//@children.0/@children.0/@children.0/@children.10/@ports.0" targets="//@children.0/@children.0/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E27" sources="//@children.0/@children.0/@children.0/@children.11/@ports.0" targets="//@children.0/@children.0/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E28" sources="//@children.0/@children.0/@children.0/@children.11/@ports.0" targets="//@children.0/@children.0/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E29" sources="//@children.0/@children.0/@children.0/@children.15/@ports.1" targets="//@children.0/@children.0/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E30" sources="//@children.0/@children.0/@children.0/@children.16/@ports.1" targets="//@children.0/@children.0/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E31" sources="//@children.0/@children.0/@children.0/@children.17/@ports.0" targets="//@children.0/@children.0/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E32" sources="//@children.0/@children.0/@children.0/@children.18/@ports.1" targets="//@children.0/@children.0/@children.0/@children.14/@ports.0"/>
+      </children>
+      <children identifier="N78" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L78" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P180" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P184" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N79">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L79" height="15.0" width="24.0" text="App"/>
+        <ports identifier="P185" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P186" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N80" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L80" height="15.0" width="56.0" text="Spectrum"/>
+          <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P188" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N81" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L81" height="15.0" width="35.0" text="Ramp"/>
+          <ports identifier="P189" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E125" sources="//@children.0/@children.0/@children.2/@children.0/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E126" sources="//@children.0/@children.0/@children.2/@children.1/@ports.0" targets="//@children.0/@children.0/@children.2/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N82" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="74.0" text="TimedPlotter"/>
+        <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E1" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E2" sources="//@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+    </children>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_distributedpowerplant_DistributedPowerPlant.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_distributedpowerplant_DistributedPowerPlant.elkg
@@ -1,0 +1,639 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="100.0" text="GeneratorTurbine"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="75.0" text="sensorSignal"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@ports.2"/>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P24" height="8.0" width="8.0" x="9.25" y="-8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="9.25" y="41.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="26.5" y="-8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="26.5" y="41.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="43.75" y="41.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="43.75" y="-8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="TimedDelay"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="TimedDelay2"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P34" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.3 //@children.4/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0 //@children.4/@children.0/@containedEdges.1 //@children.4/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N14" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="39.0" text="Plotter"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.0 //@children.4/@children.0/@containedEdges.8 //@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="46.0" text="Plotter2"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.3 //@children.4/@children.0/@containedEdges.13 //@children.4/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L16" height="15.0" width="104.0" text="heartbeatDetector"/>
+        <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.7 //@children.4/@children.0/@containedEdges.8" incomingEdges="//@children.4/@children.0/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.2/@containedEdges.1" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.9 //@children.4/@children.0/@containedEdges.10 //@children.4/@children.0/@containedEdges.11" incomingEdges="//@children.4/@children.0/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.2/@containedEdges.0" incomingEdges="//@children.4/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N17" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="78.0" text="MissDetector"/>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.4/@children.0/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.4/@children.0/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="92.0" text="StatusClassifier"/>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.4/@children.0/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.4/@children.0/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E44" sources="//@children.4/@children.0/@children.2/@ports.3" targets="//@children.4/@children.0/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E45" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E46" sources="//@children.4/@children.0/@children.2/@children.0/@ports.2" targets="//@children.4/@children.0/@children.2/@children.1/@ports.0"/>
+        <containedEdges identifier="E47" sources="//@children.4/@children.0/@children.2/@children.0/@ports.3" targets="//@children.4/@children.0/@children.2/@children.1/@ports.1"/>
+        <containedEdges identifier="E48" sources="//@children.4/@children.0/@children.2/@children.1/@ports.2" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E49" sources="//@children.4/@children.0/@children.2/@children.1/@ports.3" targets="//@children.4/@children.0/@children.2/@ports.2"/>
+      </children>
+      <children identifier="N19" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="71.0" text="PlantControl"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@children.4/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="-1.0" incomingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.4/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@children.4/@children.0/@containedEdges.12 //@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@children.4/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-6"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.4/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-7"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@children.4/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="8"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+          <properties key="org.eclipse.elk.port.index" value="9"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="46.0" text="Plotter3"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.15 //@children.4/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="64.0" text="LocalClock"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.16 //@children.4/@children.0/@containedEdges.17 //@children.4/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E25" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@children.0/@children.3/@ports.4"/>
+      <containedEdges identifier="E28" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E31" sources="//@children.4/@children.0/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.3"/>
+      <containedEdges identifier="E32" sources="//@children.4/@children.0/@children.2/@ports.0" targets="//@children.4/@children.0/@ports.5"/>
+      <containedEdges identifier="E33" sources="//@children.4/@children.0/@children.2/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.4/@children.0/@children.2/@ports.2" targets="//@children.4/@children.0/@ports.6"/>
+      <containedEdges identifier="E35" sources="//@children.4/@children.0/@children.2/@ports.2" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.4/@children.0/@children.2/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.6"/>
+      <containedEdges identifier="E37" sources="//@children.4/@children.0/@children.3/@ports.5" targets="//@children.4/@children.0/@ports.4"/>
+      <containedEdges identifier="E38" sources="//@children.4/@children.0/@children.3/@ports.5" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.4/@children.0/@children.3/@ports.8" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.4/@children.0/@children.5/@ports.0" targets="//@children.4/@children.0/@children.2/@ports.3"/>
+      <containedEdges identifier="E42" sources="//@children.4/@children.0/@children.5/@ports.0" targets="//@children.4/@children.0/@children.3/@ports.7"/>
+      <containedEdges identifier="E43" sources="//@children.4/@children.0/@children.5/@ports.0" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N22">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L22" height="15.0" width="108.0" text="SupervisoryControl"/>
+    <ports identifier="P78" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N23">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L23" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0 //@children.5/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" incomingEdges="//@children.5/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" incomingEdges="//@children.5/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N24" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="68.0" text="SingleEvent"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="76.0" text="SingleEvent2"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.4 //@children.5/@children.0/@containedEdges.6 //@children.5/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="68.0" text="TimedDelay"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="95.0" text="ResettableTimer"/>
+        <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="44.0" text="Merge2"/>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.1 //@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E50" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.5/@children.0/@children.0/@ports.0" targets="//@children.5/@children.0/@ports.3"/>
+      <containedEdges identifier="E54" sources="//@children.5/@children.0/@children.1/@ports.0" targets="//@children.5/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.5/@children.0/@children.2/@ports.1" targets="//@children.5/@children.0/@ports.2"/>
+      <containedEdges identifier="E56" sources="//@children.5/@children.0/@children.3/@ports.0" targets="//@children.5/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.5/@children.0/@children.4/@ports.1" targets="//@children.5/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E58" sources="//@children.5/@children.0/@children.5/@ports.1" targets="//@children.5/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E59" sources="//@children.5/@children.0/@children.6/@ports.1" targets="//@children.5/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E60" sources="//@children.5/@children.0/@children.7/@ports.0" targets="//@children.5/@children.0/@children.5/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.5" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.2" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.4" targets="//@children.1/@ports.5"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.4" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E13" sources="//@children.4/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.5/@ports.3" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E15" sources="//@children.5/@ports.2" targets="//@children.4/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_errorhandling_ErrorHandling.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_errorhandling_ErrorHandling.elkg
@@ -1,0 +1,455 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E8" sources="//@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="93.0" text="PtidesPlatform3"/>
+    <ports identifier="P8" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N7">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L7" height="15.0" width="73.0" text="ErrorHandler"/>
+        <children identifier="N8" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L8" height="15.0" width="59.0" text="missedN2"/>
+          <ports identifier="P15" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.0 //@children.1/@children.0/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N9" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L9" height="15.0" width="116.0" text="ErrorHandlingAction"/>
+          <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N10" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L10" height="15.0" width="46.0" text="Counter"/>
+          <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.2 //@children.1/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N11" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L11" height="15.0" width="68.0" text="Comparator"/>
+          <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N12" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N13" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L13" height="15.0" width="54.0" text="TrueGate"/>
+          <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.6 //@children.1/@children.0/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N14" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+          <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N15" height="25.0" width="135.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="66.0" text="Expression"/>
+          <ports identifier="P30" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="41.0" text="Repeat"/>
+          <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="28.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="90.0" text="MicrostepDelay"/>
+          <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.0/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.1/@children.0/@children.1/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E11" sources="//@children.1/@children.0/@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E12" sources="//@children.1/@children.0/@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E13" sources="//@children.1/@children.0/@children.1/@children.2/@ports.2" targets="//@children.1/@children.0/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E14" sources="//@children.1/@children.0/@children.1/@children.2/@ports.2" targets="//@children.1/@children.0/@children.1/@children.4/@ports.1"/>
+        <containedEdges identifier="E15" sources="//@children.1/@children.0/@children.1/@children.3/@ports.2" targets="//@children.1/@children.0/@children.1/@children.5/@ports.0"/>
+        <containedEdges identifier="E16" sources="//@children.1/@children.0/@children.1/@children.4/@ports.0" targets="//@children.1/@children.0/@children.1/@children.3/@ports.1"/>
+        <containedEdges identifier="E17" sources="//@children.1/@children.0/@children.1/@children.5/@ports.1" targets="//@children.1/@children.0/@children.1/@children.7/@ports.1"/>
+        <containedEdges identifier="E18" sources="//@children.1/@children.0/@children.1/@children.5/@ports.1" targets="//@children.1/@children.0/@children.1/@children.8/@ports.0"/>
+        <containedEdges identifier="E19" sources="//@children.1/@children.0/@children.1/@children.7/@ports.0" targets="//@children.1/@children.0/@children.1/@children.6/@ports.0"/>
+        <containedEdges identifier="E20" sources="//@children.1/@children.0/@children.1/@children.8/@ports.1" targets="//@children.1/@children.0/@children.1/@children.9/@ports.0"/>
+        <containedEdges identifier="E21" sources="//@children.1/@children.0/@children.1/@children.9/@ports.1" targets="//@children.1/@children.0/@children.1/@children.2/@ports.1"/>
+      </children>
+      <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E10" sources="//@children.1/@children.0/@children.0/@ports.1" targets="//@children.1/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N18">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L18" height="15.0" width="93.0" text="PtidesPlatform4"/>
+    <ports identifier="P36" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N19">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L19" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N20" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L21" height="15.0" width="73.0" text="ErrorHandler"/>
+        <children identifier="N22" height="25.0" width="33.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L22" height="15.0" width="59.0" text="missedN2"/>
+          <ports identifier="P45" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N23" height="40.0" width="60.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L23" height="15.0" width="123.0" text="ErrorHandlingAction2"/>
+          <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E26" sources="//@children.2/@children.0/@children.1/@children.0/@ports.0" targets="//@children.2/@children.0/@children.1/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N24" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E22" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.2/@children.0/@children.0/@ports.2" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.2"/>
+    </children>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="80.0" text="InitializeDelay"/>
+    <ports identifier="P63" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_mixedsimulator_MixedSimulator.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_mixedsimulator_MixedSimulator.elkg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="69.0" text="Plant Model"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="103.0" text="PeriodicSampler2"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="86.0" text="Network Model"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P19" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N11" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E13" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.4/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E16" sources="//@children.4/@children.0/@children.1/@ports.2" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@ports.2"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_multiplatformtdma_MultiPlatformTDMA.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_multiplatformtdma_MultiPlatformTDMA.elkg
@@ -1,0 +1,852 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="86.0" text="Network Model"/>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.1/@containedEdges.45">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.47">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="63.0" text="Remainder"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.14 //@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="84.0" text="BooleanSelect"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="84.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="78.0" text="CurrentTime2"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.20 //@children.1/@containedEdges.21 //@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="70.0" text="Remainder2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.23 //@children.1/@containedEdges.24 //@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.27 //@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="92.0" text="BooleanSelect2"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="80.0" text="AddSubtract4"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.21 //@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="84.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="78.0" text="CurrentTime3"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="80.0" text="AddSubtract5"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.33 //@children.1/@containedEdges.34 //@children.1/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="70.0" text="Remainder3"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.36 //@children.1/@containedEdges.37 //@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="75.0" text="Comparator3"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.40 //@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="47.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="92.0" text="BooleanSelect3"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.1/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.1/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="80.0" text="AddSubtract6"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.34 //@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="84.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="84.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="76.0" text="TimedDelay2"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="76.0" text="TimedDelay3"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="69.0" text="TimeDelay2"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="69.0" text="TimeDelay3"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.0" targets="//@children.1/@children.27/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.2" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.1/@ports.2" targets="//@children.1/@children.28/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@ports.4" targets="//@children.1/@children.16/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.1/@ports.4" targets="//@children.1/@children.29/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.5/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.1/@children.5/@ports.3" targets="//@children.1/@children.27/@ports.2"/>
+    <containedEdges identifier="E36" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.13/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.15/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E43" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E44" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.12/@ports.1"/>
+    <containedEdges identifier="E45" sources="//@children.1/@children.11/@ports.2" targets="//@children.1/@children.13/@ports.2"/>
+    <containedEdges identifier="E46" sources="//@children.1/@children.12/@ports.0" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.1/@children.12/@ports.0" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.1/@children.13/@ports.3" targets="//@children.1/@children.28/@ports.2"/>
+    <containedEdges identifier="E49" sources="//@children.1/@children.14/@ports.2" targets="//@children.1/@children.13/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.1/@children.15/@ports.0" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.1/@children.16/@ports.0" targets="//@children.1/@children.18/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.1/@children.17/@ports.2" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.1/@children.17/@ports.2" targets="//@children.1/@children.22/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.1/@children.17/@ports.2" targets="//@children.1/@children.23/@ports.1"/>
+    <containedEdges identifier="E55" sources="//@children.1/@children.18/@ports.1" targets="//@children.1/@children.17/@ports.1"/>
+    <containedEdges identifier="E56" sources="//@children.1/@children.18/@ports.1" targets="//@children.1/@children.19/@ports.1"/>
+    <containedEdges identifier="E57" sources="//@children.1/@children.18/@ports.1" targets="//@children.1/@children.20/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.1/@children.19/@ports.2" targets="//@children.1/@children.21/@ports.2"/>
+    <containedEdges identifier="E59" sources="//@children.1/@children.20/@ports.0" targets="//@children.1/@children.17/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.1/@children.20/@ports.0" targets="//@children.1/@children.19/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.1/@children.21/@ports.3" targets="//@children.1/@children.29/@ports.2"/>
+    <containedEdges identifier="E62" sources="//@children.1/@children.22/@ports.2" targets="//@children.1/@children.21/@ports.1"/>
+    <containedEdges identifier="E63" sources="//@children.1/@children.23/@ports.0" targets="//@children.1/@children.22/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.1/@children.24/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E65" sources="//@children.1/@children.25/@ports.1" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E66" sources="//@children.1/@children.26/@ports.1" targets="//@children.1/@ports.5"/>
+    <containedEdges identifier="E67" sources="//@children.1/@children.27/@ports.1" targets="//@children.1/@children.24/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.1/@children.28/@ports.1" targets="//@children.1/@children.25/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.1/@children.29/@ports.1" targets="//@children.1/@children.26/@ports.0"/>
+  </children>
+  <children identifier="N33" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="41.0" text="Clock3"/>
+    <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="41.0" text="Clock2"/>
+    <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N35" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L35" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P94" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N36" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L36" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P96" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N37" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P98" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="78.0" text="CurrentTime4"/>
+    <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="51.0" text="Display4"/>
+    <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="78.0" text="CurrentTime5"/>
+    <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="51.0" text="Display5"/>
+    <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="78.0" text="CurrentTime6"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="51.0" text="Display6"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L47" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P112" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N48" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@children.16/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@children.16/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E70" sources="//@children.16/@children.0/@ports.0" targets="//@children.16/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N49">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L49" height="15.0" width="93.0" text="PtidesPlatform2"/>
+    <ports identifier="P116" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N50" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@children.17/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@children.17/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E71" sources="//@children.17/@children.0/@ports.0" targets="//@children.17/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N51">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L51" height="15.0" width="93.0" text="PtidesPlatform3"/>
+    <ports identifier="P120" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N52" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@children.18/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@children.18/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E72" sources="//@children.18/@children.0/@ports.0" targets="//@children.18/@children.0/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.5" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.3" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.12/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.14/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.16/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.16/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.17/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E16" sources="//@children.17/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.18/@ports.1" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E18" sources="//@children.18/@ports.1" targets="//@children.6/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_multiplecores_MultipleCores.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_multiplecores_MultipleCores.elkg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="49.0" text="Register"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="25.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="25.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.5 //@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.9 //@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E8" sources="//@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E9" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E10" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@children.6/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@children.6/@ports.2" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="76.0" text="SingleEvent4"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.0/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithCurrentLocalTime.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithCurrentLocalTime.elkg
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="49.0" text="Resume"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="111.0" text="SingleEventStartup"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="38.0" text="Pause"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="eventMonitor"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7 //@children.1/@containedEdges.8 //@children.1/@containedEdges.10 //@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="55.0" text="IsPresent"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="124.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="124.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.11" incomingEdges="//@children.1/@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="96.0" text="incrementOutput"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E29" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.6/@children.0/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E31" sources="//@children.1/@children.6/@children.1/@ports.1" targets="//@children.1/@children.6/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.7/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.12" incomingEdges="//@children.1/@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N16" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="96.0" text="incrementOutput"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E32" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.7/@children.1/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.7/@children.0/@ports.1" targets="//@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.7/@children.1/@ports.1" targets="//@children.1/@children.7/@children.0/@ports.0"/>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.5" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.3" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.4" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="80.0" text="samplePeriod"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="90.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L21" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P44" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N22">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L22" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" incomingEdges="//@children.5/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" incomingEdges="//@children.5/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N23" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-6"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E35" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E37" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E38" sources="//@children.5/@children.0/@ports.3" targets="//@children.5/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E39" sources="//@children.5/@children.0/@children.0/@ports.1" targets="//@children.5/@children.0/@ports.4"/>
+      <containedEdges identifier="E40" sources="//@children.5/@children.0/@children.0/@ports.5" targets="//@children.5/@children.0/@ports.5"/>
+      <containedEdges identifier="E41" sources="//@children.5/@children.0/@children.1/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.6"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.1/@ports.5"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.0" targets="//@children.5/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.4" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.5" targets="//@children.1/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithoutCurrentLocalTime.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_powermanagementunitsamplingwithoutcurrentlocaltime_PowerManagementUnitSamplingWithoutCurrentLocalTime.elkg
@@ -1,0 +1,413 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="49.0" text="Resume"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="111.0" text="SingleEventStartup"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="38.0" text="Pause"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="eventMonitor"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7 //@children.1/@containedEdges.8 //@children.1/@containedEdges.10 //@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="55.0" text="IsPresent"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="124.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="124.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.11" incomingEdges="//@children.1/@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="96.0" text="incrementOutput"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E28" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.1/@children.6/@children.0/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.6/@children.1/@ports.1" targets="//@children.1/@children.6/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.7/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.12" incomingEdges="//@children.1/@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N16" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="96.0" text="incrementOutput"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="55.0" text="IsPresent"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.7/@children.1/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.7/@children.0/@ports.1" targets="//@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.7/@children.1/@ports.1" targets="//@children.1/@children.7/@children.0/@ports.0"/>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.5" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.3" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.4" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="80.0" text="samplePeriod"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="25.0" width="90.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="90.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L21" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P44" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N22">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L22" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P49" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" incomingEdges="//@children.5/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" incomingEdges="//@children.5/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N23" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E36" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E37" sources="//@children.5/@children.0/@children.0/@ports.1" targets="//@children.5/@children.0/@ports.3"/>
+      <containedEdges identifier="E38" sources="//@children.5/@children.0/@children.0/@ports.4" targets="//@children.5/@children.0/@ports.4"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.2" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.1/@ports.5"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.3" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.4" targets="//@children.1/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_powerplant_PowerPlant.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_powerplant_PowerPlant.elkg
@@ -1,0 +1,590 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="100.0" text="GeneratorTurbine"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="75.0" text="sensorSignal"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@ports.2"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="108.0" text="SupervisoryControl"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.1/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.6 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="95.0" text="ResettableTimer"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.1/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@ports.2" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@ports.3" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="9.25" y="-8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="9.25" y="41.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="26.5" y="-8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="26.5" y="41.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="43.75" y="41.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="43.75" y="-8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N19">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L19" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P48" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N20">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L20" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P55" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.3 //@children.3/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.1 //@children.3/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" incomingEdges="//@children.3/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" incomingEdges="//@children.3/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" incomingEdges="//@children.3/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N21" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="39.0" text="Plotter"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.8 //@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="46.0" text="Plotter2"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.3 //@children.3/@children.0/@containedEdges.13 //@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L23" height="15.0" width="104.0" text="heartbeatDetector"/>
+        <ports identifier="P64" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.7 //@children.3/@children.0/@containedEdges.8" incomingEdges="//@children.3/@children.0/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@children.2/@containedEdges.1" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.9 //@children.3/@children.0/@containedEdges.10 //@children.3/@children.0/@containedEdges.11" incomingEdges="//@children.3/@children.0/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@children.2/@containedEdges.0" incomingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N24" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L24" height="15.0" width="78.0" text="MissDetector"/>
+          <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.3/@children.0/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.3/@children.0/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N25" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="92.0" text="StatusClassifier"/>
+          <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P74" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.3/@children.0/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.3/@children.0/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E53" sources="//@children.3/@children.0/@children.2/@ports.3" targets="//@children.3/@children.0/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E54" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E55" sources="//@children.3/@children.0/@children.2/@children.0/@ports.2" targets="//@children.3/@children.0/@children.2/@children.1/@ports.0"/>
+        <containedEdges identifier="E56" sources="//@children.3/@children.0/@children.2/@children.0/@ports.3" targets="//@children.3/@children.0/@children.2/@children.1/@ports.1"/>
+        <containedEdges identifier="E57" sources="//@children.3/@children.0/@children.2/@children.1/@ports.2" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E58" sources="//@children.3/@children.0/@children.2/@children.1/@ports.3" targets="//@children.3/@children.0/@children.2/@ports.2"/>
+      </children>
+      <children identifier="N26" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="71.0" text="PlantControl"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="-1.0" incomingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="6.0" incomingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="13.0" incomingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="20.0" incomingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@children.3/@children.0/@containedEdges.12 //@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="27.0" incomingEdges="//@children.3/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-6"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="34.0" incomingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-7"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="8"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+          <properties key="org.eclipse.elk.port.index" value="9"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="46.0" text="Plotter3"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.15 //@children.3/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="64.0" text="LocalClock"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.16 //@children.3/@children.0/@containedEdges.17 //@children.3/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@children.0/@children.3/@ports.4"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.0/@ports.2" targets="//@children.3/@children.0/@children.3/@ports.3"/>
+      <containedEdges identifier="E41" sources="//@children.3/@children.0/@children.2/@ports.0" targets="//@children.3/@children.0/@ports.5"/>
+      <containedEdges identifier="E42" sources="//@children.3/@children.0/@children.2/@ports.0" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.3/@children.0/@children.2/@ports.2" targets="//@children.3/@children.0/@ports.6"/>
+      <containedEdges identifier="E44" sources="//@children.3/@children.0/@children.2/@ports.2" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.3/@children.0/@children.2/@ports.2" targets="//@children.3/@children.0/@children.3/@ports.6"/>
+      <containedEdges identifier="E46" sources="//@children.3/@children.0/@children.3/@ports.5" targets="//@children.3/@children.0/@ports.4"/>
+      <containedEdges identifier="E47" sources="//@children.3/@children.0/@children.3/@ports.5" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.3/@children.0/@children.3/@ports.0" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.3/@children.0/@children.3/@ports.8" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.3/@children.0/@children.5/@ports.0" targets="//@children.3/@children.0/@children.2/@ports.3"/>
+      <containedEdges identifier="E51" sources="//@children.3/@children.0/@children.5/@ports.0" targets="//@children.3/@children.0/@children.3/@ports.7"/>
+      <containedEdges identifier="E52" sources="//@children.3/@children.0/@children.5/@ports.0" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.5" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.3/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.2" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.4" targets="//@children.2/@ports.5"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.5" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.3/@ports.6" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E13" sources="//@children.3/@ports.4" targets="//@children.2/@ports.4"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_printingpress_PrintingPress.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_printingpress_PrintingPress.elkg
@@ -1,0 +1,6330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="58.0" text="feedRoller"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.39">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3" incomingEdges="//@children.0/@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="40.0" text="omega"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="78.0" text="Paper Radius"/>
+      <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.21 //@children.0/@containedEdges.22 //@children.0/@containedEdges.23" incomingEdges="//@children.0/@children.14/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N17" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.2 //@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="407.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="119.0" text="initialRadiusSquared"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.6 //@children.0/@children.14/@containedEdges.7 //@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="65.0" text="coreRadius"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.9 //@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="37.0" text="Select"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.14/@containedEdges.8 //@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E77" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.0/@children.14/@children.0/@ports.2" targets="//@children.0/@children.14/@children.4/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.0/@children.14/@children.1/@ports.1" targets="//@children.0/@children.14/@children.0/@ports.1"/>
+      <containedEdges identifier="E80" sources="//@children.0/@children.14/@children.1/@ports.1" targets="//@children.0/@children.14/@children.2/@ports.1"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.14/@children.2/@ports.0" targets="//@children.0/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.14/@children.3/@ports.1" targets="//@children.0/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.0/@children.14/@children.4/@ports.1" targets="//@children.0/@children.14/@children.5/@ports.1"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.14/@children.4/@ports.1" targets="//@children.0/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.14/@children.4/@ports.1" targets="//@children.0/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.14/@children.5/@ports.0" targets="//@children.0/@children.14/@children.6/@ports.1"/>
+      <containedEdges identifier="E87" sources="//@children.0/@children.14/@children.5/@ports.0" targets="//@children.0/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.14/@children.6/@ports.2" targets="//@children.0/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.0/@children.14/@children.7/@ports.1" targets="//@children.0/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E90" sources="//@children.0/@children.14/@children.8/@ports.1" targets="//@children.0/@children.14/@children.9/@ports.2"/>
+      <containedEdges identifier="E91" sources="//@children.0/@children.14/@children.9/@ports.1" targets="//@children.0/@children.14/@ports.1"/>
+    </children>
+    <children identifier="N27">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L27" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.15/@containedEdges.0 //@children.0/@children.15/@containedEdges.1 //@children.0/@children.15/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.24 //@children.0/@containedEdges.25 //@children.0/@containedEdges.26 //@children.0/@containedEdges.27" incomingEdges="//@children.0/@children.15/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N28" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.15/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.5 //@children.0/@children.15/@containedEdges.6 //@children.0/@children.15/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.15/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="25.0" width="88.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P85" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.15/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.15/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.15/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.15/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.15/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.15/@containedEdges.4 //@children.0/@children.15/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.15/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="91.0" text="coreMassScale"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.15/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.15/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E92" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.4/@ports.1"/>
+      <containedEdges identifier="E93" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.5/@ports.1"/>
+      <containedEdges identifier="E94" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.15/@children.6/@ports.0"/>
+      <containedEdges identifier="E95" sources="//@children.0/@children.15/@children.0/@ports.1" targets="//@children.0/@children.15/@children.3/@ports.0"/>
+      <containedEdges identifier="E96" sources="//@children.0/@children.15/@children.1/@ports.2" targets="//@children.0/@children.15/@children.11/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.0/@children.15/@children.2/@ports.1" targets="//@children.0/@children.15/@children.3/@ports.1"/>
+      <containedEdges identifier="E98" sources="//@children.0/@children.15/@children.2/@ports.1" targets="//@children.0/@children.15/@children.8/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.0/@children.15/@children.2/@ports.1" targets="//@children.0/@children.15/@children.12/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.0/@children.15/@children.3/@ports.2" targets="//@children.0/@children.15/@children.1/@ports.1"/>
+      <containedEdges identifier="E101" sources="//@children.0/@children.15/@children.4/@ports.0" targets="//@children.0/@children.15/@children.2/@ports.0"/>
+      <containedEdges identifier="E102" sources="//@children.0/@children.15/@children.5/@ports.0" targets="//@children.0/@children.15/@children.0/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.0/@children.15/@children.6/@ports.1" targets="//@children.0/@children.15/@children.9/@ports.0"/>
+      <containedEdges identifier="E104" sources="//@children.0/@children.15/@children.7/@ports.1" targets="//@children.0/@children.15/@children.1/@ports.0"/>
+      <containedEdges identifier="E105" sources="//@children.0/@children.15/@children.8/@ports.1" targets="//@children.0/@children.15/@children.10/@ports.1"/>
+      <containedEdges identifier="E106" sources="//@children.0/@children.15/@children.9/@ports.1" targets="//@children.0/@children.15/@children.10/@ports.0"/>
+      <containedEdges identifier="E107" sources="//@children.0/@children.15/@children.10/@ports.2" targets="//@children.0/@children.15/@children.7/@ports.0"/>
+      <containedEdges identifier="E108" sources="//@children.0/@children.15/@children.11/@ports.2" targets="//@children.0/@children.15/@ports.1"/>
+      <containedEdges identifier="E109" sources="//@children.0/@children.15/@children.12/@ports.1" targets="//@children.0/@children.15/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N41" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="103.0" text="PeriodicSampler2"/>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E46" sources="//@children.0/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E52" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E53" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E55" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E61" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E62" sources="//@children.0/@children.9/@ports.2" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.0/@children.12/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.18/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E71" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E72" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E73" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.13/@ports.1"/>
+    <containedEdges identifier="E74" sources="//@children.0/@children.16/@ports.2" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E75" sources="//@children.0/@children.17/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E76" sources="//@children.0/@children.18/@ports.1" targets="//@children.0/@ports.4"/>
+  </children>
+  <children identifier="N44">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L44" height="15.0" width="60.0" text="driveRoller"/>
+    <ports identifier="P110" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7 //@containedEdges.8" incomingEdges="//@children.1/@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N45" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P114" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3 //@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.13 //@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P130" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P136" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P139" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.15 //@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P140" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P142" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.16 //@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P146" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P149" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L58" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P150" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.13/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.21 //@children.1/@containedEdges.22 //@children.1/@containedEdges.23 //@children.1/@containedEdges.24" incomingEdges="//@children.1/@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N59" height="25.0" width="219.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P152" height="8.0" width="8.0" x="219.0" y="8.5" outgoingEdges="//@children.1/@children.13/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E140" sources="//@children.1/@children.13/@ports.0" targets="//@children.1/@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E141" sources="//@children.1/@children.13/@children.0/@ports.0" targets="//@children.1/@children.13/@ports.1"/>
+    </children>
+    <children identifier="N60" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P156" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="25.0" width="75.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P157" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N63" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="103.0" text="PeriodicSampler2"/>
+      <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P162" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N64" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="103.0" text="PeriodicSampler3"/>
+      <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P164" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E110" sources="//@children.1/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E111" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E112" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E113" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.15/@ports.1"/>
+    <containedEdges identifier="E114" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.17/@ports.0"/>
+    <containedEdges identifier="E115" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E116" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E117" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.18/@ports.0"/>
+    <containedEdges identifier="E118" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E119" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.12/@ports.0"/>
+    <containedEdges identifier="E120" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E121" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E122" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.13/@ports.0"/>
+    <containedEdges identifier="E123" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E124" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E125" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.10/@ports.1"/>
+    <containedEdges identifier="E126" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E127" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E128" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E129" sources="//@children.1/@children.11/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E130" sources="//@children.1/@children.12/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E131" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E132" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E133" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E134" sources="//@children.1/@children.13/@ports.1" targets="//@children.1/@children.12/@ports.1"/>
+    <containedEdges identifier="E135" sources="//@children.1/@children.14/@ports.2" targets="//@children.1/@children.16/@ports.0"/>
+    <containedEdges identifier="E136" sources="//@children.1/@children.15/@ports.0" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E137" sources="//@children.1/@children.16/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E138" sources="//@children.1/@children.17/@ports.1" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E139" sources="//@children.1/@children.18/@ports.1" targets="//@children.1/@ports.3"/>
+  </children>
+  <children identifier="N65">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L65" height="15.0" width="84.0" text="DriveController"/>
+    <ports identifier="P165" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P167" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.2/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N66" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P170" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N67">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L67" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P171" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P172" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.4" incomingEdges="//@children.2/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N68" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P174" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P175" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P176" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P179" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P180" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E151" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E152" sources="//@children.2/@children.1/@children.0/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E153" sources="//@children.2/@children.1/@children.1/@ports.0" targets="//@children.2/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N70" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P182" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N71">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L71" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P183" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P184" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P185" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P186" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N72">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L72" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P187" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.0 //@children.2/@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P188" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P189" height="8.0" width="8.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P190" height="8.0" width="8.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N73" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P192" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N74" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P196" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.4 //@children.2/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N75" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L75" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P198" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P199" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N76" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L76" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P201" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P202" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N77" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L77" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P204" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.3/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P205" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E154" sources="//@children.2/@children.3/@children.0/@ports.0" targets="//@children.2/@children.3/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E155" sources="//@children.2/@children.3/@children.0/@ports.0" targets="//@children.2/@children.3/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E156" sources="//@children.2/@children.3/@children.0/@ports.1" targets="//@children.2/@children.3/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E157" sources="//@children.2/@children.3/@children.0/@children.0/@ports.1" targets="//@children.2/@children.3/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E158" sources="//@children.2/@children.3/@children.0/@children.1/@ports.2" targets="//@children.2/@children.3/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E159" sources="//@children.2/@children.3/@children.0/@children.1/@ports.2" targets="//@children.2/@children.3/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E160" sources="//@children.2/@children.3/@children.0/@children.2/@ports.1" targets="//@children.2/@children.3/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E161" sources="//@children.2/@children.3/@children.0/@children.3/@ports.1" targets="//@children.2/@children.3/@children.0/@ports.2"/>
+        <containedEdges identifier="E162" sources="//@children.2/@children.3/@children.0/@children.4/@ports.1" targets="//@children.2/@children.3/@children.0/@ports.3"/>
+      </children>
+    </children>
+    <containedEdges identifier="E142" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E145" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E146" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E147" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E148" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E149" sources="//@children.2/@children.3/@ports.2" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E150" sources="//@children.2/@children.3/@ports.3" targets="//@children.2/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N78" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P207" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N79">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L79" height="15.0" width="133.0" text="DtoFTrackingController"/>
+    <ports identifier="P208" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P209" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P210" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.4/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P211" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.4/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N80">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L80" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P212" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P213" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N81" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P216" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P217" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P220" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P221" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E171" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E172" sources="//@children.4/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E173" sources="//@children.4/@children.0/@children.1/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N83">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L83" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P222" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P223" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.3" incomingEdges="//@children.4/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N84" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P225" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P226" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.4/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N85" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L85" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P227" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P230" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P231" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E174" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E175" sources="//@children.4/@children.1/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.1"/>
+      <containedEdges identifier="E176" sources="//@children.4/@children.1/@children.1/@ports.0" targets="//@children.4/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N86" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P233" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L87" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P234" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P235" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P236" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P237" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N88">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L88" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P238" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P239" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P240" height="8.0" width="8.0" incomingEdges="//@children.4/@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P241" height="8.0" width="8.0" incomingEdges="//@children.4/@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N89" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L89" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.3/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.3/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P244" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.3/@children.0/@containedEdges.2 //@children.4/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N90" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L90" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P246" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.3/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N91" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L91" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.3/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P249" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P250" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E177" sources="//@children.4/@children.3/@children.0/@ports.0" targets="//@children.4/@children.3/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E178" sources="//@children.4/@children.3/@children.0/@ports.1" targets="//@children.4/@children.3/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E179" sources="//@children.4/@children.3/@children.0/@children.0/@ports.2" targets="//@children.4/@children.3/@children.0/@ports.3"/>
+        <containedEdges identifier="E180" sources="//@children.4/@children.3/@children.0/@children.0/@ports.2" targets="//@children.4/@children.3/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E181" sources="//@children.4/@children.3/@children.0/@children.1/@ports.1" targets="//@children.4/@children.3/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E182" sources="//@children.4/@children.3/@children.0/@children.2/@ports.1" targets="//@children.4/@children.3/@children.0/@ports.2"/>
+      </children>
+    </children>
+    <containedEdges identifier="E163" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E164" sources="//@children.4/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E165" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E166" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E167" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@ports.3"/>
+    <containedEdges identifier="E168" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+    <containedEdges identifier="E169" sources="//@children.4/@children.3/@ports.3" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E170" sources="//@children.4/@children.3/@ports.2" targets="//@children.4/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N92">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L92" height="15.0" width="104.0" text="reserveFeedRoller"/>
+    <ports identifier="P251" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15 //@containedEdges.16" incomingEdges="//@children.5/@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.41">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P253" height="8.0" width="8.0" outgoingEdges="//@containedEdges.17" incomingEdges="//@children.5/@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P254" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" outgoingEdges="//@containedEdges.18" incomingEdges="//@children.5/@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P256" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.38">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N93" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L93" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P257" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P259" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.2 //@children.5/@containedEdges.3 //@children.5/@containedEdges.4 //@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P260" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N94" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L94" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P261" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P263" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.6 //@children.5/@containedEdges.7 //@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P264" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N95" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L95" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.13 //@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P267" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N96" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L96" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P269" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N97" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L97" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P271" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N98" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L98" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P273" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N99" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L99" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P276" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N100" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L100" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.7 //@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P279" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N101" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L101" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P282" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.15 //@children.5/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N102" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L102" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P283" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N103" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L103" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P285" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N104" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L104" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.16 //@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P289" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N105" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L105" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P292" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N106">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L106" height="15.0" width="78.0" text="Paper Radius"/>
+      <ports identifier="P293" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.21 //@children.5/@containedEdges.22 //@children.5/@containedEdges.23" incomingEdges="//@children.5/@children.13/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P294" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.13/@containedEdges.2" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P295" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.13/@containedEdges.0 //@children.5/@children.13/@containedEdges.1" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N107" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P298" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P300" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.13/@containedEdges.4 //@children.5/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N109" height="25.0" width="407.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L109" height="15.0" width="119.0" text="initialRadiusSquared"/>
+        <ports identifier="P301" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@children.5/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N110" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L110" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P304" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.5/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N111" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L111" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P306" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.13/@containedEdges.8 //@children.5/@children.13/@containedEdges.9 //@children.5/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N112" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L112" height="15.0" width="58.0" text="constzero"/>
+        <ports identifier="P307" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.5/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N113" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L113" height="15.0" width="40.0" text="omega"/>
+        <ports identifier="P309" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P311" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.5/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P312" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N114" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L114" height="15.0" width="65.0" text="constzero2"/>
+        <ports identifier="P313" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N115" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L115" height="15.0" width="65.0" text="coreRadius"/>
+        <ports identifier="P315" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.5/@children.13/@containedEdges.14 //@children.5/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N116" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L116" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.5/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P318" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.5/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P319" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N117" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L117" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P321" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.5/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N118" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L118" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.5/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P323" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.5/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N119" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L119" height="15.0" width="37.0" text="Select"/>
+        <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.13/@containedEdges.1 //@children.5/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P325" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.5/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P326" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.5/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N120" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L120" height="15.0" width="45.0" text="Select2"/>
+        <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.5/@children.13/@containedEdges.10 //@children.5/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P328" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.5/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P329" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.5/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E216" sources="//@children.5/@children.13/@ports.2" targets="//@children.5/@children.13/@children.5/@ports.1"/>
+      <containedEdges identifier="E217" sources="//@children.5/@children.13/@ports.2" targets="//@children.5/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E218" sources="//@children.5/@children.13/@ports.1" targets="//@children.5/@children.13/@children.7/@ports.1"/>
+      <containedEdges identifier="E219" sources="//@children.5/@children.13/@children.0/@ports.2" targets="//@children.5/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E220" sources="//@children.5/@children.13/@children.1/@ports.1" targets="//@children.5/@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E221" sources="//@children.5/@children.13/@children.1/@ports.1" targets="//@children.5/@children.13/@children.2/@ports.1"/>
+      <containedEdges identifier="E222" sources="//@children.5/@children.13/@children.2/@ports.0" targets="//@children.5/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E223" sources="//@children.5/@children.13/@children.3/@ports.1" targets="//@children.5/@children.13/@children.0/@ports.0"/>
+      <containedEdges identifier="E224" sources="//@children.5/@children.13/@children.4/@ports.1" targets="//@children.5/@children.13/@children.8/@ports.1"/>
+      <containedEdges identifier="E225" sources="//@children.5/@children.13/@children.4/@ports.1" targets="//@children.5/@children.13/@children.9/@ports.0"/>
+      <containedEdges identifier="E226" sources="//@children.5/@children.13/@children.4/@ports.1" targets="//@children.5/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E227" sources="//@children.5/@children.13/@children.5/@ports.0" targets="//@children.5/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E228" sources="//@children.5/@children.13/@children.6/@ports.2" targets="//@children.5/@children.13/@children.1/@ports.0"/>
+      <containedEdges identifier="E229" sources="//@children.5/@children.13/@children.7/@ports.0" targets="//@children.5/@children.13/@children.12/@ports.2"/>
+      <containedEdges identifier="E230" sources="//@children.5/@children.13/@children.8/@ports.0" targets="//@children.5/@children.13/@children.9/@ports.1"/>
+      <containedEdges identifier="E231" sources="//@children.5/@children.13/@children.8/@ports.0" targets="//@children.5/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E232" sources="//@children.5/@children.13/@children.9/@ports.2" targets="//@children.5/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E233" sources="//@children.5/@children.13/@children.10/@ports.1" targets="//@children.5/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E234" sources="//@children.5/@children.13/@children.11/@ports.1" targets="//@children.5/@children.13/@children.13/@ports.2"/>
+      <containedEdges identifier="E235" sources="//@children.5/@children.13/@children.12/@ports.1" targets="//@children.5/@children.13/@children.6/@ports.1"/>
+      <containedEdges identifier="E236" sources="//@children.5/@children.13/@children.13/@ports.1" targets="//@children.5/@children.13/@ports.0"/>
+    </children>
+    <children identifier="N121">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L121" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P330" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.14/@containedEdges.0 //@children.5/@children.14/@containedEdges.1 //@children.5/@children.14/@containedEdges.2" incomingEdges="//@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P331" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.24 //@children.5/@containedEdges.25 //@children.5/@containedEdges.26 //@children.5/@containedEdges.27" incomingEdges="//@children.5/@children.14/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N122" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L122" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P333" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.5/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N123" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L123" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P336" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N124" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L124" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P338" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.5/@children.14/@containedEdges.5 //@children.5/@children.14/@containedEdges.6 //@children.5/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N125" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L125" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P340" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P341" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N126" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L126" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P342" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.5/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N127" height="25.0" width="88.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L127" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P344" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.5/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N128" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L128" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P347" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.5/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N129" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L129" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+        <ports identifier="P348" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P349" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N130" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L130" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+        <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P351" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.5/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N131" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L131" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+        <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.5/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N132" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L132" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P356" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N133" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L133" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.14/@containedEdges.4 //@children.5/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P358" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P359" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N134" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L134" height="15.0" width="91.0" text="coreMassScale"/>
+        <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P361" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E237" sources="//@children.5/@children.14/@ports.0" targets="//@children.5/@children.14/@children.4/@ports.1"/>
+      <containedEdges identifier="E238" sources="//@children.5/@children.14/@ports.0" targets="//@children.5/@children.14/@children.5/@ports.1"/>
+      <containedEdges identifier="E239" sources="//@children.5/@children.14/@ports.0" targets="//@children.5/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E240" sources="//@children.5/@children.14/@children.0/@ports.1" targets="//@children.5/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E241" sources="//@children.5/@children.14/@children.1/@ports.2" targets="//@children.5/@children.14/@children.11/@ports.0"/>
+      <containedEdges identifier="E242" sources="//@children.5/@children.14/@children.2/@ports.1" targets="//@children.5/@children.14/@children.3/@ports.1"/>
+      <containedEdges identifier="E243" sources="//@children.5/@children.14/@children.2/@ports.1" targets="//@children.5/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E244" sources="//@children.5/@children.14/@children.2/@ports.1" targets="//@children.5/@children.14/@children.12/@ports.0"/>
+      <containedEdges identifier="E245" sources="//@children.5/@children.14/@children.3/@ports.2" targets="//@children.5/@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E246" sources="//@children.5/@children.14/@children.4/@ports.0" targets="//@children.5/@children.14/@children.2/@ports.0"/>
+      <containedEdges identifier="E247" sources="//@children.5/@children.14/@children.5/@ports.0" targets="//@children.5/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E248" sources="//@children.5/@children.14/@children.6/@ports.1" targets="//@children.5/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E249" sources="//@children.5/@children.14/@children.7/@ports.1" targets="//@children.5/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E250" sources="//@children.5/@children.14/@children.8/@ports.1" targets="//@children.5/@children.14/@children.10/@ports.1"/>
+      <containedEdges identifier="E251" sources="//@children.5/@children.14/@children.9/@ports.1" targets="//@children.5/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E252" sources="//@children.5/@children.14/@children.10/@ports.2" targets="//@children.5/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E253" sources="//@children.5/@children.14/@children.11/@ports.2" targets="//@children.5/@children.14/@ports.1"/>
+      <containedEdges identifier="E254" sources="//@children.5/@children.14/@children.12/@ports.1" targets="//@children.5/@children.14/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N135" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L135" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.4 //@children.5/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P364" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N136" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L136" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P366" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N137" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L137" height="15.0" width="103.0" text="PeriodicSampler2"/>
+      <ports identifier="P367" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P368" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N138" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L138" height="15.0" width="103.0" text="PeriodicSampler3"/>
+      <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P370" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N139" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L139" height="15.0" width="103.0" text="PeriodicSampler4"/>
+      <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P372" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E183" sources="//@children.5/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E184" sources="//@children.5/@ports.5" targets="//@children.5/@children.13/@ports.1"/>
+    <containedEdges identifier="E185" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E186" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.13/@ports.2"/>
+    <containedEdges identifier="E187" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.15/@ports.0"/>
+    <containedEdges identifier="E188" sources="//@children.5/@children.0/@ports.2" targets="//@children.5/@children.19/@ports.0"/>
+    <containedEdges identifier="E189" sources="//@children.5/@children.1/@ports.2" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E190" sources="//@children.5/@children.1/@ports.2" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E191" sources="//@children.5/@children.1/@ports.2" targets="//@children.5/@children.18/@ports.0"/>
+    <containedEdges identifier="E192" sources="//@children.5/@children.2/@ports.2" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E193" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.12/@ports.0"/>
+    <containedEdges identifier="E194" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.6/@ports.0"/>
+    <containedEdges identifier="E195" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E196" sources="//@children.5/@children.6/@ports.2" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E197" sources="//@children.5/@children.7/@ports.2" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E198" sources="//@children.5/@children.8/@ports.2" targets="//@children.5/@children.10/@ports.1"/>
+    <containedEdges identifier="E199" sources="//@children.5/@children.8/@ports.2" targets="//@children.5/@children.11/@ports.0"/>
+    <containedEdges identifier="E200" sources="//@children.5/@children.9/@ports.0" targets="//@children.5/@children.8/@ports.0"/>
+    <containedEdges identifier="E201" sources="//@children.5/@children.10/@ports.0" targets="//@children.5/@children.11/@ports.0"/>
+    <containedEdges identifier="E202" sources="//@children.5/@children.11/@ports.2" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E203" sources="//@children.5/@children.12/@ports.2" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E204" sources="//@children.5/@children.13/@ports.0" targets="//@children.5/@children.14/@ports.0"/>
+    <containedEdges identifier="E205" sources="//@children.5/@children.13/@ports.0" targets="//@children.5/@children.15/@ports.0"/>
+    <containedEdges identifier="E206" sources="//@children.5/@children.13/@ports.0" targets="//@children.5/@children.17/@ports.0"/>
+    <containedEdges identifier="E207" sources="//@children.5/@children.14/@ports.1" targets="//@children.5/@children.6/@ports.1"/>
+    <containedEdges identifier="E208" sources="//@children.5/@children.14/@ports.1" targets="//@children.5/@children.8/@ports.1"/>
+    <containedEdges identifier="E209" sources="//@children.5/@children.14/@ports.1" targets="//@children.5/@children.9/@ports.1"/>
+    <containedEdges identifier="E210" sources="//@children.5/@children.14/@ports.1" targets="//@children.5/@children.12/@ports.1"/>
+    <containedEdges identifier="E211" sources="//@children.5/@children.15/@ports.2" targets="//@children.5/@children.16/@ports.0"/>
+    <containedEdges identifier="E212" sources="//@children.5/@children.16/@ports.1" targets="//@children.5/@ports.0"/>
+    <containedEdges identifier="E213" sources="//@children.5/@children.17/@ports.1" targets="//@children.5/@ports.4"/>
+    <containedEdges identifier="E214" sources="//@children.5/@children.18/@ports.1" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E215" sources="//@children.5/@children.19/@ports.1" targets="//@children.5/@ports.2"/>
+  </children>
+  <children identifier="N140" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.40">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P374" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N141">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L141" height="15.0" width="134.0" text="DtoRTrackingController"/>
+    <ports identifier="P375" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P377" height="8.0" width="8.0" outgoingEdges="//@containedEdges.21" incomingEdges="//@children.7/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P378" height="8.0" width="8.0" outgoingEdges="//@containedEdges.20" incomingEdges="//@children.7/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N142">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L142" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P380" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P381" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.3" incomingEdges="//@children.7/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N143" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P383" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P384" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N144" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L144" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P385" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P388" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P389" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E266" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E267" sources="//@children.7/@children.0/@children.0/@ports.1" targets="//@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E268" sources="//@children.7/@children.0/@children.1/@ports.0" targets="//@children.7/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N145">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L145" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P390" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.1/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P391" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.4" incomingEdges="//@children.7/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N146" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L146" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P393" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P394" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N147" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L147" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P395" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P396" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P398" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P399" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E269" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E270" sources="//@children.7/@children.1/@children.0/@ports.1" targets="//@children.7/@children.1/@ports.1"/>
+      <containedEdges identifier="E271" sources="//@children.7/@children.1/@children.1/@ports.0" targets="//@children.7/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N148" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L148" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.6" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P401" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N149" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L149" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8" incomingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P403" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.7" incomingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N150">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L150" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P404" height="8.0" width="8.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P405" height="8.0" width="8.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P406" height="8.0" width="8.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P407" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P408" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N151">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L151" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P409" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P410" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P411" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P412" height="8.0" width="8.0" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P413" height="8.0" width="8.0" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N152" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L152" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P414" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P415" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P416" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.3 //@children.7/@children.4/@children.0/@containedEdges.4 //@children.7/@children.4/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N153" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L153" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P418" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P419" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N154" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L154" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P420" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N155" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L155" height="15.0" width="112.0" text="BooleanToAnything"/>
+          <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P423" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N156" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L156" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P424" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.5 //@children.7/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P425" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P426" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N157" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L157" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P427" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@children.4/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P428" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P429" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E272" sources="//@children.7/@children.4/@children.0/@ports.0" targets="//@children.7/@children.4/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E273" sources="//@children.7/@children.4/@children.0/@ports.1" targets="//@children.7/@children.4/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E274" sources="//@children.7/@children.4/@children.0/@ports.2" targets="//@children.7/@children.4/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E275" sources="//@children.7/@children.4/@children.0/@children.0/@ports.2" targets="//@children.7/@children.4/@children.0/@ports.3"/>
+        <containedEdges identifier="E276" sources="//@children.7/@children.4/@children.0/@children.0/@ports.2" targets="//@children.7/@children.4/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E277" sources="//@children.7/@children.4/@children.0/@children.0/@ports.2" targets="//@children.7/@children.4/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E278" sources="//@children.7/@children.4/@children.0/@children.1/@ports.1" targets="//@children.7/@children.4/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E279" sources="//@children.7/@children.4/@children.0/@children.2/@ports.0" targets="//@children.7/@children.4/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E280" sources="//@children.7/@children.4/@children.0/@children.3/@ports.1" targets="//@children.7/@children.4/@children.0/@children.4/@ports.2"/>
+        <containedEdges identifier="E281" sources="//@children.7/@children.4/@children.0/@children.4/@ports.1" targets="//@children.7/@children.4/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E282" sources="//@children.7/@children.4/@children.0/@children.5/@ports.1" targets="//@children.7/@children.4/@children.0/@ports.4"/>
+      </children>
+    </children>
+    <containedEdges identifier="E255" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E256" sources="//@children.7/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E257" sources="//@children.7/@ports.4" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E258" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E259" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.4/@ports.1"/>
+    <containedEdges identifier="E260" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.4/@ports.2"/>
+    <containedEdges identifier="E261" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.2/@ports.1"/>
+    <containedEdges identifier="E262" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@ports.3"/>
+    <containedEdges identifier="E263" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.3/@ports.1"/>
+    <containedEdges identifier="E264" sources="//@children.7/@children.4/@ports.3" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E265" sources="//@children.7/@children.4/@ports.4" targets="//@children.7/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N158">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L158" height="15.0" width="118.0" text="ReserveTargetProfile"/>
+    <ports identifier="P430" height="8.0" width="8.0" outgoingEdges="//@containedEdges.22 //@containedEdges.23" incomingEdges="//@children.8/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P431" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N159" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L159" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P432" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.2" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P433" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.1" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N160" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L160" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.4" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P435" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N161">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L161" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P436" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P437" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N162">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L162" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P438" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.0 //@children.8/@children.2/@children.0/@containedEdges.1 //@children.8/@children.2/@children.0/@containedEdges.2 //@children.8/@children.2/@children.0/@containedEdges.3 //@children.8/@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P439" height="8.0" width="8.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N163" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L163" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P440" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P442" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P443" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P444" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N164" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L164" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P445" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.6 //@children.8/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N165" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L165" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P447" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P448" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.8 //@children.8/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N166" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L166" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P449" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P450" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N167" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L167" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P451" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N168" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L168" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P453" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P454" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P455" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N169" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L169" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P456" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P457" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N170" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L170" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P459" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.14 //@children.8/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N171" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L171" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P460" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P461" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N172" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L172" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P462" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P463" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N173" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L173" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.16 //@children.8/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P465" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P466" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N174" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L174" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P467" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P468" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N175" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L175" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P469" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P470" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N176" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L176" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P471" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P472" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P473" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P474" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N177" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L177" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P475" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.0 //@children.8/@children.2/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P476" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N178" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L178" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P478" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P479" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P480" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N179" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L179" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P481" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.1 //@children.8/@children.2/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P482" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N180" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L180" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P483" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.13 //@children.8/@children.2/@children.0/@containedEdges.19 //@children.8/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P484" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N181" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L181" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P485" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P486" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P487" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N182" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L182" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P489" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P490" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P491" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N183" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L183" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P492" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.20 //@children.8/@children.2/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P493" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N184" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L184" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P494" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N185" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L185" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P496" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P497" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N186" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L186" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P498" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P499" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N187" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L187" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P501" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P502" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N188" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L188" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P503" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P504" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P505" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N189" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L189" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P506" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P507" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P508" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N190" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L190" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P510" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.38 //@children.8/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N191" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L191" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P511" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P512" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.8/@children.2/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E289" sources="//@children.8/@children.2/@children.0/@ports.0" targets="//@children.8/@children.2/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E290" sources="//@children.8/@children.2/@children.0/@ports.0" targets="//@children.8/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E291" sources="//@children.8/@children.2/@children.0/@ports.0" targets="//@children.8/@children.2/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E292" sources="//@children.8/@children.2/@children.0/@ports.0" targets="//@children.8/@children.2/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E293" sources="//@children.8/@children.2/@children.0/@ports.0" targets="//@children.8/@children.2/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E294" sources="//@children.8/@children.2/@children.0/@children.0/@ports.0" targets="//@children.8/@children.2/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E295" sources="//@children.8/@children.2/@children.0/@children.1/@ports.0" targets="//@children.8/@children.2/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E296" sources="//@children.8/@children.2/@children.0/@children.1/@ports.0" targets="//@children.8/@children.2/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E297" sources="//@children.8/@children.2/@children.0/@children.2/@ports.1" targets="//@children.8/@children.2/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E298" sources="//@children.8/@children.2/@children.0/@children.2/@ports.1" targets="//@children.8/@children.2/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E299" sources="//@children.8/@children.2/@children.0/@children.3/@ports.1" targets="//@children.8/@children.2/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E300" sources="//@children.8/@children.2/@children.0/@children.4/@ports.0" targets="//@children.8/@children.2/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E301" sources="//@children.8/@children.2/@children.0/@children.5/@ports.2" targets="//@children.8/@children.2/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E302" sources="//@children.8/@children.2/@children.0/@children.6/@ports.1" targets="//@children.8/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E303" sources="//@children.8/@children.2/@children.0/@children.7/@ports.1" targets="//@children.8/@children.2/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E304" sources="//@children.8/@children.2/@children.0/@children.7/@ports.1" targets="//@children.8/@children.2/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E305" sources="//@children.8/@children.2/@children.0/@children.8/@ports.1" targets="//@children.8/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E306" sources="//@children.8/@children.2/@children.0/@children.9/@ports.0" targets="//@children.8/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E307" sources="//@children.8/@children.2/@children.0/@children.10/@ports.2" targets="//@children.8/@children.2/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E308" sources="//@children.8/@children.2/@children.0/@children.11/@ports.1" targets="//@children.8/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E309" sources="//@children.8/@children.2/@children.0/@children.12/@ports.1" targets="//@children.8/@children.2/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E310" sources="//@children.8/@children.2/@children.0/@children.13/@ports.2" targets="//@children.8/@children.2/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E311" sources="//@children.8/@children.2/@children.0/@children.13/@ports.3" targets="//@children.8/@children.2/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E312" sources="//@children.8/@children.2/@children.0/@children.14/@ports.1" targets="//@children.8/@children.2/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E313" sources="//@children.8/@children.2/@children.0/@children.15/@ports.2" targets="//@children.8/@children.2/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E314" sources="//@children.8/@children.2/@children.0/@children.15/@ports.3" targets="//@children.8/@children.2/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E315" sources="//@children.8/@children.2/@children.0/@children.16/@ports.1" targets="//@children.8/@children.2/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E316" sources="//@children.8/@children.2/@children.0/@children.17/@ports.1" targets="//@children.8/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E317" sources="//@children.8/@children.2/@children.0/@children.18/@ports.2" targets="//@children.8/@children.2/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E318" sources="//@children.8/@children.2/@children.0/@children.19/@ports.2" targets="//@children.8/@children.2/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E319" sources="//@children.8/@children.2/@children.0/@children.19/@ports.3" targets="//@children.8/@children.2/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E320" sources="//@children.8/@children.2/@children.0/@children.20/@ports.1" targets="//@children.8/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E321" sources="//@children.8/@children.2/@children.0/@children.21/@ports.0" targets="//@children.8/@children.2/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E322" sources="//@children.8/@children.2/@children.0/@children.22/@ports.1" targets="//@children.8/@children.2/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E323" sources="//@children.8/@children.2/@children.0/@children.23/@ports.0" targets="//@children.8/@children.2/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E324" sources="//@children.8/@children.2/@children.0/@children.24/@ports.1" targets="//@children.8/@children.2/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E325" sources="//@children.8/@children.2/@children.0/@children.25/@ports.1" targets="//@children.8/@children.2/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E326" sources="//@children.8/@children.2/@children.0/@children.26/@ports.1" targets="//@children.8/@children.2/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E327" sources="//@children.8/@children.2/@children.0/@children.27/@ports.1" targets="//@children.8/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E328" sources="//@children.8/@children.2/@children.0/@children.27/@ports.1" targets="//@children.8/@children.2/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E329" sources="//@children.8/@children.2/@children.0/@children.28/@ports.1" targets="//@children.8/@children.2/@children.0/@children.14/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E283" sources="//@children.8/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E284" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E285" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.0/@ports.1"/>
+    <containedEdges identifier="E286" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@ports.0"/>
+    <containedEdges identifier="E287" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.1/@ports.1"/>
+    <containedEdges identifier="E288" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N192">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L192" height="15.0" width="100.0" text="DriveTargetProfile"/>
+    <ports identifier="P513" height="8.0" width="8.0" outgoingEdges="//@containedEdges.24 //@containedEdges.25" incomingEdges="//@children.9/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P514" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N193" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L193" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.2" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P516" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.1" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N194">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L194" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P517" height="8.0" width="8.0" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P518" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N195">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L195" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P519" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.0 //@children.9/@children.1/@children.0/@containedEdges.1 //@children.9/@children.1/@children.0/@containedEdges.2 //@children.9/@children.1/@children.0/@containedEdges.3 //@children.9/@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P520" height="8.0" width="8.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N196" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L196" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P521" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P522" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P523" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P524" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P525" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N197" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L197" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P526" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.6 //@children.9/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P527" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N198" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L198" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P528" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P529" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.8 //@children.9/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N199" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L199" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P531" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N200" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L200" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P532" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P533" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N201" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L201" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P534" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P535" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P536" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N202" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L202" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P537" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P538" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N203" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L203" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P539" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P540" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.14 //@children.9/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N204" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L204" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P541" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P542" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N205" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L205" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P543" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P544" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N206" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L206" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.16 //@children.9/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P547" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N207" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L207" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P548" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P549" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N208" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L208" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P551" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N209" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L209" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P552" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P553" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P554" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P555" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N210" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L210" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P556" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.0 //@children.9/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P557" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N211" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L211" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P558" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P559" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P560" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P561" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N212" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L212" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P562" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.1 //@children.9/@children.1/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P563" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N213" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L213" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P564" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.13 //@children.9/@children.1/@children.0/@containedEdges.19 //@children.9/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P565" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N214" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L214" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P567" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P568" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N215" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L215" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P569" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P570" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P571" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P572" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N216" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L216" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.20 //@children.9/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P574" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N217" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L217" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P575" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P576" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N218" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L218" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P577" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P578" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N219" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L219" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P579" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N220" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L220" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P581" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P582" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P583" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N221" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L221" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P584" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P585" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P586" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N222" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L222" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P587" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P588" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P589" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N223" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L223" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P591" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.38 //@children.9/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N224" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L224" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P592" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P593" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.9/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E334" sources="//@children.9/@children.1/@children.0/@ports.0" targets="//@children.9/@children.1/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E335" sources="//@children.9/@children.1/@children.0/@ports.0" targets="//@children.9/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E336" sources="//@children.9/@children.1/@children.0/@ports.0" targets="//@children.9/@children.1/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E337" sources="//@children.9/@children.1/@children.0/@ports.0" targets="//@children.9/@children.1/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E338" sources="//@children.9/@children.1/@children.0/@ports.0" targets="//@children.9/@children.1/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E339" sources="//@children.9/@children.1/@children.0/@children.0/@ports.0" targets="//@children.9/@children.1/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E340" sources="//@children.9/@children.1/@children.0/@children.1/@ports.0" targets="//@children.9/@children.1/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E341" sources="//@children.9/@children.1/@children.0/@children.1/@ports.0" targets="//@children.9/@children.1/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E342" sources="//@children.9/@children.1/@children.0/@children.2/@ports.1" targets="//@children.9/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E343" sources="//@children.9/@children.1/@children.0/@children.2/@ports.1" targets="//@children.9/@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E344" sources="//@children.9/@children.1/@children.0/@children.3/@ports.1" targets="//@children.9/@children.1/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E345" sources="//@children.9/@children.1/@children.0/@children.4/@ports.0" targets="//@children.9/@children.1/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E346" sources="//@children.9/@children.1/@children.0/@children.5/@ports.2" targets="//@children.9/@children.1/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E347" sources="//@children.9/@children.1/@children.0/@children.6/@ports.1" targets="//@children.9/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E348" sources="//@children.9/@children.1/@children.0/@children.7/@ports.1" targets="//@children.9/@children.1/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E349" sources="//@children.9/@children.1/@children.0/@children.7/@ports.1" targets="//@children.9/@children.1/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E350" sources="//@children.9/@children.1/@children.0/@children.8/@ports.1" targets="//@children.9/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E351" sources="//@children.9/@children.1/@children.0/@children.9/@ports.0" targets="//@children.9/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E352" sources="//@children.9/@children.1/@children.0/@children.10/@ports.2" targets="//@children.9/@children.1/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E353" sources="//@children.9/@children.1/@children.0/@children.11/@ports.1" targets="//@children.9/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E354" sources="//@children.9/@children.1/@children.0/@children.12/@ports.1" targets="//@children.9/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E355" sources="//@children.9/@children.1/@children.0/@children.13/@ports.2" targets="//@children.9/@children.1/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E356" sources="//@children.9/@children.1/@children.0/@children.13/@ports.3" targets="//@children.9/@children.1/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E357" sources="//@children.9/@children.1/@children.0/@children.14/@ports.1" targets="//@children.9/@children.1/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E358" sources="//@children.9/@children.1/@children.0/@children.15/@ports.2" targets="//@children.9/@children.1/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E359" sources="//@children.9/@children.1/@children.0/@children.15/@ports.3" targets="//@children.9/@children.1/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E360" sources="//@children.9/@children.1/@children.0/@children.16/@ports.1" targets="//@children.9/@children.1/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E361" sources="//@children.9/@children.1/@children.0/@children.17/@ports.1" targets="//@children.9/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E362" sources="//@children.9/@children.1/@children.0/@children.18/@ports.2" targets="//@children.9/@children.1/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E363" sources="//@children.9/@children.1/@children.0/@children.19/@ports.2" targets="//@children.9/@children.1/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E364" sources="//@children.9/@children.1/@children.0/@children.19/@ports.3" targets="//@children.9/@children.1/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E365" sources="//@children.9/@children.1/@children.0/@children.20/@ports.1" targets="//@children.9/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E366" sources="//@children.9/@children.1/@children.0/@children.21/@ports.0" targets="//@children.9/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E367" sources="//@children.9/@children.1/@children.0/@children.22/@ports.1" targets="//@children.9/@children.1/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E368" sources="//@children.9/@children.1/@children.0/@children.23/@ports.0" targets="//@children.9/@children.1/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E369" sources="//@children.9/@children.1/@children.0/@children.24/@ports.1" targets="//@children.9/@children.1/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E370" sources="//@children.9/@children.1/@children.0/@children.25/@ports.1" targets="//@children.9/@children.1/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E371" sources="//@children.9/@children.1/@children.0/@children.26/@ports.1" targets="//@children.9/@children.1/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E372" sources="//@children.9/@children.1/@children.0/@children.27/@ports.1" targets="//@children.9/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E373" sources="//@children.9/@children.1/@children.0/@children.27/@ports.1" targets="//@children.9/@children.1/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E374" sources="//@children.9/@children.1/@children.0/@children.28/@ports.1" targets="//@children.9/@children.1/@children.0/@children.14/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E330" sources="//@children.9/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E331" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@ports.0"/>
+    <containedEdges identifier="E332" sources="//@children.9/@children.0/@ports.0" targets="//@children.9/@children.0/@ports.1"/>
+    <containedEdges identifier="E333" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N225">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L225" height="15.0" width="101.0" text="FeedTargetProfile"/>
+    <ports identifier="P594" height="8.0" width="8.0" outgoingEdges="//@containedEdges.26" incomingEdges="//@children.10/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P595" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P596" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.34">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N226" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L226" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P597" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.3" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P598" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.2" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N227" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L227" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P599" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.5" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P600" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.4" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N228">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L228" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P601" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P602" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P603" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P604" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N229">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L229" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P605" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.0 //@children.10/@children.2/@children.0/@containedEdges.1 //@children.10/@children.2/@children.0/@containedEdges.2 //@children.10/@children.2/@children.0/@containedEdges.3 //@children.10/@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P606" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P607" height="8.0" width="8.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.28">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P608" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N230" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L230" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P609" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.7 //@children.10/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P610" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N231" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L231" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P611" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P612" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.9 //@children.10/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N232" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L232" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P613" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P614" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N233" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L233" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P615" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P616" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N234" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L234" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P618" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P619" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N235" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L235" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P620" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P621" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N236" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L236" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P622" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P623" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.15 //@children.10/@children.2/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N237" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L237" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P624" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P625" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N238" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L238" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P626" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N239" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L239" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P628" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.17 //@children.10/@children.2/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P629" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P630" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N240" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L240" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P631" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P632" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N241" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L241" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P633" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P634" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N242" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L242" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P635" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P636" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P637" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P638" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N243" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L243" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P639" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.0 //@children.10/@children.2/@children.0/@containedEdges.42">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P640" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N244" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L244" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P641" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P642" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P643" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P644" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N245" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L245" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P645" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.1 //@children.10/@children.2/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P646" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N246" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L246" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P647" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.14 //@children.10/@children.2/@children.0/@containedEdges.20 //@children.10/@children.2/@children.0/@containedEdges.45">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P648" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N247" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L247" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P649" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P650" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P651" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N248" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L248" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P653" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P654" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P655" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N249" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L249" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P656" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.21 //@children.10/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P657" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.32 //@children.10/@children.2/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N250" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L250" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P658" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P659" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N251" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L251" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P660" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P661" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N252" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L252" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P662" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P663" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N253" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L253" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P664" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P665" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P666" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N254" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L254" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P667" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P668" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P669" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.46">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N255" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L255" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P670" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P671" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P672" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.47">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N256" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L256" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P673" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P674" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.40 //@children.10/@children.2/@children.0/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N257" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L257" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P676" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.42">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N258" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L258" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P677" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.43">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P678" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N259" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L259" height="15.0" width="42.0" text="Const5"/>
+          <ports identifier="P679" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.44">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P680" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N260" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L260" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P681" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.33 //@children.10/@children.2/@children.0/@containedEdges.44">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P682" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.45">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P683" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.10/@children.2/@children.0/@containedEdges.43">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N261" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L261" height="15.0" width="42.0" text="Const6"/>
+          <ports identifier="P684" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.10/@children.2/@children.0/@containedEdges.46 //@children.10/@children.2/@children.0/@containedEdges.47">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P685" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E383" sources="//@children.10/@children.2/@children.0/@ports.0" targets="//@children.10/@children.2/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E384" sources="//@children.10/@children.2/@children.0/@ports.0" targets="//@children.10/@children.2/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E385" sources="//@children.10/@children.2/@children.0/@ports.0" targets="//@children.10/@children.2/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E386" sources="//@children.10/@children.2/@children.0/@ports.0" targets="//@children.10/@children.2/@children.0/@children.22/@ports.1"/>
+        <containedEdges identifier="E387" sources="//@children.10/@children.2/@children.0/@ports.0" targets="//@children.10/@children.2/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E388" sources="//@children.10/@children.2/@children.0/@ports.1" targets="//@children.10/@children.2/@children.0/@children.28/@ports.1"/>
+        <containedEdges identifier="E389" sources="//@children.10/@children.2/@children.0/@ports.3" targets="//@children.10/@children.2/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E390" sources="//@children.10/@children.2/@children.0/@children.0/@ports.0" targets="//@children.10/@children.2/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E391" sources="//@children.10/@children.2/@children.0/@children.0/@ports.0" targets="//@children.10/@children.2/@children.0/@children.23/@ports.2"/>
+        <containedEdges identifier="E392" sources="//@children.10/@children.2/@children.0/@children.1/@ports.1" targets="//@children.10/@children.2/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E393" sources="//@children.10/@children.2/@children.0/@children.1/@ports.1" targets="//@children.10/@children.2/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E394" sources="//@children.10/@children.2/@children.0/@children.2/@ports.1" targets="//@children.10/@children.2/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E395" sources="//@children.10/@children.2/@children.0/@children.3/@ports.0" targets="//@children.10/@children.2/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E396" sources="//@children.10/@children.2/@children.0/@children.4/@ports.2" targets="//@children.10/@children.2/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E397" sources="//@children.10/@children.2/@children.0/@children.5/@ports.1" targets="//@children.10/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E398" sources="//@children.10/@children.2/@children.0/@children.6/@ports.1" targets="//@children.10/@children.2/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E399" sources="//@children.10/@children.2/@children.0/@children.6/@ports.1" targets="//@children.10/@children.2/@children.0/@children.8/@ports.1"/>
+        <containedEdges identifier="E400" sources="//@children.10/@children.2/@children.0/@children.7/@ports.1" targets="//@children.10/@children.2/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E401" sources="//@children.10/@children.2/@children.0/@children.8/@ports.0" targets="//@children.10/@children.2/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E402" sources="//@children.10/@children.2/@children.0/@children.9/@ports.2" targets="//@children.10/@children.2/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E403" sources="//@children.10/@children.2/@children.0/@children.10/@ports.1" targets="//@children.10/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E404" sources="//@children.10/@children.2/@children.0/@children.11/@ports.1" targets="//@children.10/@children.2/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E405" sources="//@children.10/@children.2/@children.0/@children.12/@ports.2" targets="//@children.10/@children.2/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E406" sources="//@children.10/@children.2/@children.0/@children.12/@ports.3" targets="//@children.10/@children.2/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E407" sources="//@children.10/@children.2/@children.0/@children.13/@ports.1" targets="//@children.10/@children.2/@children.0/@children.12/@ports.1"/>
+        <containedEdges identifier="E408" sources="//@children.10/@children.2/@children.0/@children.14/@ports.2" targets="//@children.10/@children.2/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E409" sources="//@children.10/@children.2/@children.0/@children.14/@ports.3" targets="//@children.10/@children.2/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E410" sources="//@children.10/@children.2/@children.0/@children.15/@ports.1" targets="//@children.10/@children.2/@children.0/@children.14/@ports.1"/>
+        <containedEdges identifier="E411" sources="//@children.10/@children.2/@children.0/@children.16/@ports.1" targets="//@children.10/@children.2/@children.0/@ports.2"/>
+        <containedEdges identifier="E412" sources="//@children.10/@children.2/@children.0/@children.17/@ports.2" targets="//@children.10/@children.2/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E413" sources="//@children.10/@children.2/@children.0/@children.18/@ports.2" targets="//@children.10/@children.2/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E414" sources="//@children.10/@children.2/@children.0/@children.18/@ports.3" targets="//@children.10/@children.2/@children.0/@children.20/@ports.1"/>
+        <containedEdges identifier="E415" sources="//@children.10/@children.2/@children.0/@children.19/@ports.1" targets="//@children.10/@children.2/@children.0/@children.29/@ports.1"/>
+        <containedEdges identifier="E416" sources="//@children.10/@children.2/@children.0/@children.19/@ports.1" targets="//@children.10/@children.2/@children.0/@children.30/@ports.0"/>
+        <containedEdges identifier="E417" sources="//@children.10/@children.2/@children.0/@children.20/@ports.0" targets="//@children.10/@children.2/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E418" sources="//@children.10/@children.2/@children.0/@children.21/@ports.1" targets="//@children.10/@children.2/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E419" sources="//@children.10/@children.2/@children.0/@children.22/@ports.0" targets="//@children.10/@children.2/@children.0/@children.23/@ports.0"/>
+        <containedEdges identifier="E420" sources="//@children.10/@children.2/@children.0/@children.23/@ports.1" targets="//@children.10/@children.2/@children.0/@children.17/@ports.1"/>
+        <containedEdges identifier="E421" sources="//@children.10/@children.2/@children.0/@children.24/@ports.1" targets="//@children.10/@children.2/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E422" sources="//@children.10/@children.2/@children.0/@children.25/@ports.1" targets="//@children.10/@children.2/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E423" sources="//@children.10/@children.2/@children.0/@children.26/@ports.1" targets="//@children.10/@children.2/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E424" sources="//@children.10/@children.2/@children.0/@children.26/@ports.1" targets="//@children.10/@children.2/@children.0/@children.21/@ports.0"/>
+        <containedEdges identifier="E425" sources="//@children.10/@children.2/@children.0/@children.27/@ports.1" targets="//@children.10/@children.2/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E426" sources="//@children.10/@children.2/@children.0/@children.28/@ports.0" targets="//@children.10/@children.2/@children.0/@children.30/@ports.2"/>
+        <containedEdges identifier="E427" sources="//@children.10/@children.2/@children.0/@children.29/@ports.0" targets="//@children.10/@children.2/@children.0/@children.30/@ports.0"/>
+        <containedEdges identifier="E428" sources="//@children.10/@children.2/@children.0/@children.30/@ports.1" targets="//@children.10/@children.2/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E429" sources="//@children.10/@children.2/@children.0/@children.31/@ports.0" targets="//@children.10/@children.2/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E430" sources="//@children.10/@children.2/@children.0/@children.31/@ports.0" targets="//@children.10/@children.2/@children.0/@children.25/@ports.2"/>
+      </children>
+    </children>
+    <children identifier="N262" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L262" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P686" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P687" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P688" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P689" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P690" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E375" sources="//@children.10/@ports.2" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E376" sources="//@children.10/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E377" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.2/@ports.1"/>
+    <containedEdges identifier="E378" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@ports.1"/>
+    <containedEdges identifier="E379" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@ports.0"/>
+    <containedEdges identifier="E380" sources="//@children.10/@children.1/@ports.0" targets="//@children.10/@children.1/@ports.1"/>
+    <containedEdges identifier="E381" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E382" sources="//@children.10/@children.3/@ports.0" targets="//@children.10/@children.2/@ports.3"/>
+  </children>
+  <children identifier="N263" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L263" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P691" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.27 //@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N264">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L264" height="15.0" width="140.0" text="remainingPaperDetector"/>
+    <ports identifier="P692" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P693" height="8.0" width="8.0" outgoingEdges="//@containedEdges.29 //@containedEdges.30 //@containedEdges.31" incomingEdges="//@children.12/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P694" height="8.0" width="8.0" outgoingEdges="//@containedEdges.32 //@containedEdges.33" incomingEdges="//@children.12/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N265">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L265" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P695" height="8.0" width="8.0" outgoingEdges="//@children.12/@children.0/@containedEdges.0" incomingEdges="//@children.12/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P696" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.1" incomingEdges="//@children.12/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N266" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L266" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P697" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P698" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P699" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.12/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N267" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L267" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P700" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P701" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P702" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P703" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P704" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E439" sources="//@children.12/@children.0/@ports.0" targets="//@children.12/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E440" sources="//@children.12/@children.0/@children.0/@ports.1" targets="//@children.12/@children.0/@ports.1"/>
+      <containedEdges identifier="E441" sources="//@children.12/@children.0/@children.1/@ports.0" targets="//@children.12/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N268" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L268" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P705" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.3" incomingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P706" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.2" incomingEdges="//@children.12/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N269" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L269" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P707" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.5" incomingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P708" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.4" incomingEdges="//@children.12/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N270">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L270" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P709" height="8.0" width="8.0" incomingEdges="//@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P710" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P711" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N271">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L271" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P712" height="8.0" width="8.0" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.0 //@children.12/@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P713" height="8.0" width="8.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P714" height="8.0" width="8.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N272" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L272" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P715" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P717" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.2 //@children.12/@children.3/@children.0/@containedEdges.3 //@children.12/@children.3/@children.0/@containedEdges.4 //@children.12/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N273" height="25.0" width="111.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L273" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P718" height="8.0" width="8.0" x="111.0" y="8.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P719" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N274" height="25.0" width="75.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L274" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P720" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P721" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N275" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L275" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P722" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P723" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N276" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L276" height="15.0" width="68.0" text="Comparator"/>
+          <ports identifier="P724" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P725" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P726" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N277" height="25.0" width="72.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L277" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P727" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P728" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N278" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L278" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P729" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P730" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N279" height="31.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L279" height="15.0" width="75.0" text="Comparator2"/>
+          <ports identifier="P731" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P732" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P733" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N280" height="25.0" width="50.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L280" height="15.0" width="114.0" text="UnaryMathFunction"/>
+          <ports identifier="P734" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P735" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N281" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L281" height="15.0" width="54.0" text="TrueGate"/>
+          <ports identifier="P736" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P737" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N282" height="29.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L282" height="15.0" width="59.0" text="Sequence"/>
+          <ports identifier="P738" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P739" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N283" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L283" height="15.0" width="61.0" text="TrueGate2"/>
+          <ports identifier="P740" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P741" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N284" height="29.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L284" height="15.0" width="66.0" text="Sequence2"/>
+          <ports identifier="P742" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.12/@children.3/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P743" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.12/@children.3/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E442" sources="//@children.12/@children.3/@children.0/@ports.0" targets="//@children.12/@children.3/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E443" sources="//@children.12/@children.3/@children.0/@ports.0" targets="//@children.12/@children.3/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E444" sources="//@children.12/@children.3/@children.0/@children.0/@ports.2" targets="//@children.12/@children.3/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E445" sources="//@children.12/@children.3/@children.0/@children.0/@ports.2" targets="//@children.12/@children.3/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E446" sources="//@children.12/@children.3/@children.0/@children.0/@ports.2" targets="//@children.12/@children.3/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E447" sources="//@children.12/@children.3/@children.0/@children.0/@ports.2" targets="//@children.12/@children.3/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E448" sources="//@children.12/@children.3/@children.0/@children.1/@ports.0" targets="//@children.12/@children.3/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E449" sources="//@children.12/@children.3/@children.0/@children.2/@ports.0" targets="//@children.12/@children.3/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E450" sources="//@children.12/@children.3/@children.0/@children.3/@ports.1" targets="//@children.12/@children.3/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E451" sources="//@children.12/@children.3/@children.0/@children.4/@ports.2" targets="//@children.12/@children.3/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E452" sources="//@children.12/@children.3/@children.0/@children.5/@ports.0" targets="//@children.12/@children.3/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E453" sources="//@children.12/@children.3/@children.0/@children.6/@ports.1" targets="//@children.12/@children.3/@children.0/@children.7/@ports.1"/>
+        <containedEdges identifier="E454" sources="//@children.12/@children.3/@children.0/@children.7/@ports.2" targets="//@children.12/@children.3/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E455" sources="//@children.12/@children.3/@children.0/@children.8/@ports.1" targets="//@children.12/@children.3/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E456" sources="//@children.12/@children.3/@children.0/@children.9/@ports.1" targets="//@children.12/@children.3/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E457" sources="//@children.12/@children.3/@children.0/@children.10/@ports.1" targets="//@children.12/@children.3/@children.0/@ports.1"/>
+        <containedEdges identifier="E458" sources="//@children.12/@children.3/@children.0/@children.11/@ports.1" targets="//@children.12/@children.3/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E459" sources="//@children.12/@children.3/@children.0/@children.12/@ports.1" targets="//@children.12/@children.3/@children.0/@ports.2"/>
+      </children>
+    </children>
+    <containedEdges identifier="E431" sources="//@children.12/@ports.0" targets="//@children.12/@children.0/@ports.0"/>
+    <containedEdges identifier="E432" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@children.3/@ports.0"/>
+    <containedEdges identifier="E433" sources="//@children.12/@children.1/@ports.1" targets="//@children.12/@ports.2"/>
+    <containedEdges identifier="E434" sources="//@children.12/@children.1/@ports.0" targets="//@children.12/@children.1/@ports.1"/>
+    <containedEdges identifier="E435" sources="//@children.12/@children.2/@ports.1" targets="//@children.12/@ports.1"/>
+    <containedEdges identifier="E436" sources="//@children.12/@children.2/@ports.0" targets="//@children.12/@children.2/@ports.1"/>
+    <containedEdges identifier="E437" sources="//@children.12/@children.3/@ports.2" targets="//@children.12/@children.1/@ports.0"/>
+    <containedEdges identifier="E438" sources="//@children.12/@children.3/@ports.1" targets="//@children.12/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N285">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L285" height="15.0" width="101.0" text="ContactController"/>
+    <ports identifier="P744" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P745" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.1" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P746" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.2" incomingEdges="//@containedEdges.32">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P747" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P748" height="8.0" width="8.0" outgoingEdges="//@containedEdges.38" incomingEdges="//@children.13/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P749" height="8.0" width="8.0" outgoingEdges="//@containedEdges.34 //@containedEdges.35 //@containedEdges.36 //@containedEdges.37" incomingEdges="//@children.13/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N286">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L286" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P750" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.0/@containedEdges.0" incomingEdges="//@children.13/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P751" height="8.0" width="8.0" incomingEdges="//@children.13/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N287" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L287" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P752" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P753" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P754" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.13/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N288" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L288" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P755" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P756" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P757" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P758" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P759" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E474" sources="//@children.13/@children.0/@ports.0" targets="//@children.13/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E475" sources="//@children.13/@children.0/@children.0/@ports.1" targets="//@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E476" sources="//@children.13/@children.0/@children.1/@ports.0" targets="//@children.13/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N289">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L289" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P760" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.1/@containedEdges.0" incomingEdges="//@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P761" height="8.0" width="8.0" incomingEdges="//@children.13/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N290" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L290" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P762" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P763" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P764" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.13/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N291" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L291" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P765" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P766" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P767" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P768" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P769" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E477" sources="//@children.13/@children.1/@ports.0" targets="//@children.13/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E478" sources="//@children.13/@children.1/@children.0/@ports.1" targets="//@children.13/@children.1/@ports.1"/>
+      <containedEdges identifier="E479" sources="//@children.13/@children.1/@children.1/@ports.0" targets="//@children.13/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N292" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L292" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P770" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.4" incomingEdges="//@children.13/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P771" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.3" incomingEdges="//@children.13/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N293" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L293" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P772" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.6" incomingEdges="//@children.13/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P773" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.5" incomingEdges="//@children.13/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N294" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L294" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P774" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.8" incomingEdges="//@children.13/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P775" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.7" incomingEdges="//@children.13/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N295" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L295" height="15.0" width="101.0" text="CompositeActor7"/>
+      <ports identifier="P776" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.10" incomingEdges="//@children.13/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P777" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.9" incomingEdges="//@children.13/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N296">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L296" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P778" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P779" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P780" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P781" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N297">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L297" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P782" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P783" height="8.0" width="8.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P784" height="8.0" width="8.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P785" height="8.0" width="8.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N298" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L298" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P786" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.1 //@children.13/@children.6/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P787" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P788" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P789" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P790" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N299" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L299" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P791" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P792" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.3 //@children.13/@children.6/@children.0/@containedEdges.4 //@children.13/@children.6/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P793" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N300" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L300" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P794" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P795" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P796" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N301" height="25.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L301" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P797" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P798" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N302" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L302" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P799" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P800" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N303" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L303" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P801" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P802" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N304" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L304" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P803" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P804" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P805" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.13/@children.6/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N305" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L305" height="15.0" width="42.0" text="Const4"/>
+          <ports identifier="P806" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.13/@children.6/@children.0/@containedEdges.11 //@children.13/@children.6/@children.0/@containedEdges.12 //@children.13/@children.6/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P807" height="8.0" width="8.0" x="-8.0" y="8.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E480" sources="//@children.13/@children.6/@children.0/@ports.0" targets="//@children.13/@children.6/@children.0/@children.0/@ports.3"/>
+        <containedEdges identifier="E481" sources="//@children.13/@children.6/@children.0/@children.0/@ports.0" targets="//@children.13/@children.6/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E482" sources="//@children.13/@children.6/@children.0/@children.0/@ports.0" targets="//@children.13/@children.6/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E483" sources="//@children.13/@children.6/@children.0/@children.1/@ports.1" targets="//@children.13/@children.6/@children.0/@children.0/@ports.4"/>
+        <containedEdges identifier="E484" sources="//@children.13/@children.6/@children.0/@children.1/@ports.1" targets="//@children.13/@children.6/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E485" sources="//@children.13/@children.6/@children.0/@children.1/@ports.1" targets="//@children.13/@children.6/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E486" sources="//@children.13/@children.6/@children.0/@children.2/@ports.1" targets="//@children.13/@children.6/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E487" sources="//@children.13/@children.6/@children.0/@children.3/@ports.0" targets="//@children.13/@children.6/@children.0/@ports.1"/>
+        <containedEdges identifier="E488" sources="//@children.13/@children.6/@children.0/@children.4/@ports.0" targets="//@children.13/@children.6/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E489" sources="//@children.13/@children.6/@children.0/@children.5/@ports.0" targets="//@children.13/@children.6/@children.0/@ports.3"/>
+        <containedEdges identifier="E490" sources="//@children.13/@children.6/@children.0/@children.6/@ports.1" targets="//@children.13/@children.6/@children.0/@ports.2"/>
+        <containedEdges identifier="E491" sources="//@children.13/@children.6/@children.0/@children.7/@ports.0" targets="//@children.13/@children.6/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E492" sources="//@children.13/@children.6/@children.0/@children.7/@ports.0" targets="//@children.13/@children.6/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E493" sources="//@children.13/@children.6/@children.0/@children.7/@ports.0" targets="//@children.13/@children.6/@children.0/@children.6/@ports.2"/>
+      </children>
+    </children>
+    <containedEdges identifier="E460" sources="//@children.13/@ports.0" targets="//@children.13/@children.0/@ports.0"/>
+    <containedEdges identifier="E461" sources="//@children.13/@ports.1" targets="//@children.13/@children.1/@ports.0"/>
+    <containedEdges identifier="E462" sources="//@children.13/@ports.2" targets="//@children.13/@children.2/@ports.0"/>
+    <containedEdges identifier="E463" sources="//@children.13/@children.2/@ports.1" targets="//@children.13/@children.6/@ports.0"/>
+    <containedEdges identifier="E464" sources="//@children.13/@children.2/@ports.0" targets="//@children.13/@children.2/@ports.1"/>
+    <containedEdges identifier="E465" sources="//@children.13/@children.3/@ports.1" targets="//@children.13/@ports.5"/>
+    <containedEdges identifier="E466" sources="//@children.13/@children.3/@ports.0" targets="//@children.13/@children.3/@ports.1"/>
+    <containedEdges identifier="E467" sources="//@children.13/@children.4/@ports.1" targets="//@children.13/@ports.3"/>
+    <containedEdges identifier="E468" sources="//@children.13/@children.4/@ports.0" targets="//@children.13/@children.4/@ports.1"/>
+    <containedEdges identifier="E469" sources="//@children.13/@children.5/@ports.1" targets="//@children.13/@ports.4"/>
+    <containedEdges identifier="E470" sources="//@children.13/@children.5/@ports.0" targets="//@children.13/@children.5/@ports.1"/>
+    <containedEdges identifier="E471" sources="//@children.13/@children.6/@ports.1" targets="//@children.13/@children.4/@ports.0"/>
+    <containedEdges identifier="E472" sources="//@children.13/@children.6/@ports.3" targets="//@children.13/@children.3/@ports.0"/>
+    <containedEdges identifier="E473" sources="//@children.13/@children.6/@ports.2" targets="//@children.13/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N306">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L306" height="15.0" width="85.0" text="FeedController"/>
+    <ports identifier="P808" height="8.0" width="8.0" outgoingEdges="//@children.14/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P809" height="8.0" width="8.0" outgoingEdges="//@children.14/@containedEdges.1" incomingEdges="//@containedEdges.26">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P810" height="8.0" width="8.0" outgoingEdges="//@containedEdges.39" incomingEdges="//@children.14/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P811" height="8.0" width="8.0" incomingEdges="//@children.14/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P812" height="8.0" width="8.0" outgoingEdges="//@children.14/@containedEdges.2" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P813" height="8.0" width="8.0" outgoingEdges="//@children.14/@containedEdges.3" incomingEdges="//@containedEdges.35">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N307" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L307" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P814" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.5" incomingEdges="//@children.14/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P815" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.4" incomingEdges="//@children.14/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N308">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L308" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P816" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.1/@containedEdges.0" incomingEdges="//@children.14/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P817" height="8.0" width="8.0" outgoingEdges="//@children.14/@containedEdges.6" incomingEdges="//@children.14/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N309" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L309" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P818" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.14/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P819" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.14/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P820" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.14/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N310" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L310" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P821" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P822" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P823" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P824" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P825" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E509" sources="//@children.14/@children.1/@ports.0" targets="//@children.14/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E510" sources="//@children.14/@children.1/@children.0/@ports.1" targets="//@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E511" sources="//@children.14/@children.1/@children.1/@ports.0" targets="//@children.14/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N311" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L311" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P826" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.8" incomingEdges="//@children.14/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P827" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.7" incomingEdges="//@children.14/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N312" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L312" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P828" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.10" incomingEdges="//@children.14/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P829" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.9" incomingEdges="//@children.14/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N313" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L313" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P830" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.12" incomingEdges="//@children.14/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P831" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.11" incomingEdges="//@children.14/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N314">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L314" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P832" height="8.0" width="8.0" incomingEdges="//@children.14/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P833" height="8.0" width="8.0" incomingEdges="//@children.14/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P834" height="8.0" width="8.0" incomingEdges="//@children.14/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P835" height="8.0" width="8.0" incomingEdges="//@children.14/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P836" height="8.0" width="8.0" outgoingEdges="//@children.14/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P837" height="8.0" width="8.0" outgoingEdges="//@children.14/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N315">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L315" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P838" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P839" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.0 //@children.14/@children.5/@children.0/@containedEdges.1 //@children.14/@children.5/@children.0/@containedEdges.2 //@children.14/@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P840" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P841" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P842" height="8.0" width="8.0" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P843" height="8.0" width="8.0" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N316" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L316" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P844" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P845" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.7 //@children.14/@children.5/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P846" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N317" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L317" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P847" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P848" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.9 //@children.14/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P849" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N318" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L318" height="15.0" width="56.0" text="Register2"/>
+          <ports identifier="P850" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P851" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P852" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N319" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L319" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P853" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.2 //@children.14/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P854" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P855" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N320" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L320" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P856" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P857" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N321" height="25.0" width="70.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L321" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P858" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P859" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N322" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L322" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P860" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P861" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P862" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N323" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L323" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P863" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.8 //@children.14/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P864" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P865" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N324" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L324" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P866" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.14/@children.5/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P867" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.14/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P868" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E512" sources="//@children.14/@children.5/@children.0/@ports.1" targets="//@children.14/@children.5/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E513" sources="//@children.14/@children.5/@children.0/@ports.1" targets="//@children.14/@children.5/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E514" sources="//@children.14/@children.5/@children.0/@ports.1" targets="//@children.14/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E515" sources="//@children.14/@children.5/@children.0/@ports.1" targets="//@children.14/@children.5/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E516" sources="//@children.14/@children.5/@children.0/@ports.0" targets="//@children.14/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E517" sources="//@children.14/@children.5/@children.0/@ports.2" targets="//@children.14/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E518" sources="//@children.14/@children.5/@children.0/@ports.3" targets="//@children.14/@children.5/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E519" sources="//@children.14/@children.5/@children.0/@children.0/@ports.1" targets="//@children.14/@children.5/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E520" sources="//@children.14/@children.5/@children.0/@children.0/@ports.1" targets="//@children.14/@children.5/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E521" sources="//@children.14/@children.5/@children.0/@children.1/@ports.1" targets="//@children.14/@children.5/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E522" sources="//@children.14/@children.5/@children.0/@children.1/@ports.1" targets="//@children.14/@children.5/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E523" sources="//@children.14/@children.5/@children.0/@children.2/@ports.1" targets="//@children.14/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E524" sources="//@children.14/@children.5/@children.0/@children.3/@ports.2" targets="//@children.14/@children.5/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E525" sources="//@children.14/@children.5/@children.0/@children.4/@ports.0" targets="//@children.14/@children.5/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E526" sources="//@children.14/@children.5/@children.0/@children.5/@ports.0" targets="//@children.14/@children.5/@children.0/@children.7/@ports.2"/>
+        <containedEdges identifier="E527" sources="//@children.14/@children.5/@children.0/@children.6/@ports.2" targets="//@children.14/@children.5/@children.0/@ports.5"/>
+        <containedEdges identifier="E528" sources="//@children.14/@children.5/@children.0/@children.7/@ports.1" targets="//@children.14/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E529" sources="//@children.14/@children.5/@children.0/@children.8/@ports.1" targets="//@children.14/@children.5/@children.0/@ports.4"/>
+      </children>
+    </children>
+    <containedEdges identifier="E494" sources="//@children.14/@ports.0" targets="//@children.14/@children.1/@ports.0"/>
+    <containedEdges identifier="E495" sources="//@children.14/@ports.1" targets="//@children.14/@children.0/@ports.0"/>
+    <containedEdges identifier="E496" sources="//@children.14/@ports.4" targets="//@children.14/@children.2/@ports.0"/>
+    <containedEdges identifier="E497" sources="//@children.14/@ports.5" targets="//@children.14/@children.4/@ports.0"/>
+    <containedEdges identifier="E498" sources="//@children.14/@children.0/@ports.1" targets="//@children.14/@children.5/@ports.1"/>
+    <containedEdges identifier="E499" sources="//@children.14/@children.0/@ports.0" targets="//@children.14/@children.0/@ports.1"/>
+    <containedEdges identifier="E500" sources="//@children.14/@children.1/@ports.1" targets="//@children.14/@children.5/@ports.2"/>
+    <containedEdges identifier="E501" sources="//@children.14/@children.2/@ports.1" targets="//@children.14/@children.5/@ports.0"/>
+    <containedEdges identifier="E502" sources="//@children.14/@children.2/@ports.0" targets="//@children.14/@children.2/@ports.1"/>
+    <containedEdges identifier="E503" sources="//@children.14/@children.3/@ports.1" targets="//@children.14/@ports.2"/>
+    <containedEdges identifier="E504" sources="//@children.14/@children.3/@ports.0" targets="//@children.14/@children.3/@ports.1"/>
+    <containedEdges identifier="E505" sources="//@children.14/@children.4/@ports.1" targets="//@children.14/@children.5/@ports.3"/>
+    <containedEdges identifier="E506" sources="//@children.14/@children.4/@ports.0" targets="//@children.14/@children.4/@ports.1"/>
+    <containedEdges identifier="E507" sources="//@children.14/@children.5/@ports.4" targets="//@children.14/@children.3/@ports.0"/>
+    <containedEdges identifier="E508" sources="//@children.14/@children.5/@ports.5" targets="//@children.14/@ports.3"/>
+  </children>
+  <children identifier="N325">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L325" height="15.0" width="102.0" text="ReserveController"/>
+    <ports identifier="P869" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P870" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.1" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P871" height="8.0" width="8.0" outgoingEdges="//@containedEdges.41" incomingEdges="//@children.15/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P872" height="8.0" width="8.0" outgoingEdges="//@containedEdges.40" incomingEdges="//@children.15/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P873" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.2" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+    <ports identifier="P874" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.3" incomingEdges="//@containedEdges.36">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N326" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L326" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P875" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.5" incomingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P876" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.4" incomingEdges="//@children.15/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N327">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L327" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P877" height="8.0" width="8.0" outgoingEdges="//@children.15/@children.1/@containedEdges.0" incomingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P878" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.6" incomingEdges="//@children.15/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N328" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L328" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P879" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.15/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P880" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P881" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.15/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N329" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L329" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P882" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P883" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P884" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P885" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P886" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E545" sources="//@children.15/@children.1/@ports.0" targets="//@children.15/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E546" sources="//@children.15/@children.1/@children.0/@ports.1" targets="//@children.15/@children.1/@ports.1"/>
+      <containedEdges identifier="E547" sources="//@children.15/@children.1/@children.1/@ports.0" targets="//@children.15/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N330" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L330" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P887" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.8" incomingEdges="//@children.15/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P888" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.7" incomingEdges="//@children.15/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N331" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L331" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P889" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.10" incomingEdges="//@children.15/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P890" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.9" incomingEdges="//@children.15/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N332" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L332" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P891" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.12" incomingEdges="//@children.15/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P892" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.11" incomingEdges="//@children.15/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N333">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L333" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P893" height="8.0" width="8.0" incomingEdges="//@children.15/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P894" height="8.0" width="8.0" incomingEdges="//@children.15/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P895" height="8.0" width="8.0" incomingEdges="//@children.15/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P896" height="8.0" width="8.0" incomingEdges="//@children.15/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P897" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P898" height="8.0" width="8.0" outgoingEdges="//@children.15/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N334">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L334" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P899" height="8.0" width="8.0" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P900" height="8.0" width="8.0" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.0 //@children.15/@children.5/@children.0/@containedEdges.1 //@children.15/@children.5/@children.0/@containedEdges.2 //@children.15/@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P901" height="8.0" width="8.0" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P902" height="8.0" width="8.0" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P903" height="8.0" width="8.0" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P904" height="8.0" width="8.0" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N335" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L335" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P905" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P906" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.7 //@children.15/@children.5/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P907" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N336" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L336" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P908" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P909" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.9 //@children.15/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P910" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N337" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L337" height="15.0" width="56.0" text="Register2"/>
+          <ports identifier="P911" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P912" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P913" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N338" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L338" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P914" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.2 //@children.15/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P915" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P916" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N339" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L339" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P917" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P918" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N340" height="25.0" width="70.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L340" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P919" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P920" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N341" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L341" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P921" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P922" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P923" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N342" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L342" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P924" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P925" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P926" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N343" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L343" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P927" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.8 //@children.15/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P928" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.15/@children.5/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P929" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.15/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E548" sources="//@children.15/@children.5/@children.0/@ports.1" targets="//@children.15/@children.5/@children.0/@children.1/@ports.2"/>
+        <containedEdges identifier="E549" sources="//@children.15/@children.5/@children.0/@ports.1" targets="//@children.15/@children.5/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E550" sources="//@children.15/@children.5/@children.0/@ports.1" targets="//@children.15/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E551" sources="//@children.15/@children.5/@children.0/@ports.1" targets="//@children.15/@children.5/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E552" sources="//@children.15/@children.5/@children.0/@ports.3" targets="//@children.15/@children.5/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E553" sources="//@children.15/@children.5/@children.0/@ports.2" targets="//@children.15/@children.5/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E554" sources="//@children.15/@children.5/@children.0/@ports.0" targets="//@children.15/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E555" sources="//@children.15/@children.5/@children.0/@children.0/@ports.1" targets="//@children.15/@children.5/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E556" sources="//@children.15/@children.5/@children.0/@children.0/@ports.1" targets="//@children.15/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E557" sources="//@children.15/@children.5/@children.0/@children.1/@ports.1" targets="//@children.15/@children.5/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E558" sources="//@children.15/@children.5/@children.0/@children.1/@ports.1" targets="//@children.15/@children.5/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E559" sources="//@children.15/@children.5/@children.0/@children.2/@ports.1" targets="//@children.15/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E560" sources="//@children.15/@children.5/@children.0/@children.3/@ports.2" targets="//@children.15/@children.5/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E561" sources="//@children.15/@children.5/@children.0/@children.4/@ports.0" targets="//@children.15/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E562" sources="//@children.15/@children.5/@children.0/@children.5/@ports.0" targets="//@children.15/@children.5/@children.0/@children.8/@ports.2"/>
+        <containedEdges identifier="E563" sources="//@children.15/@children.5/@children.0/@children.6/@ports.2" targets="//@children.15/@children.5/@children.0/@ports.5"/>
+        <containedEdges identifier="E564" sources="//@children.15/@children.5/@children.0/@children.7/@ports.1" targets="//@children.15/@children.5/@children.0/@ports.4"/>
+        <containedEdges identifier="E565" sources="//@children.15/@children.5/@children.0/@children.8/@ports.1" targets="//@children.15/@children.5/@children.0/@children.7/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E530" sources="//@children.15/@ports.0" targets="//@children.15/@children.1/@ports.0"/>
+    <containedEdges identifier="E531" sources="//@children.15/@ports.1" targets="//@children.15/@children.0/@ports.0"/>
+    <containedEdges identifier="E532" sources="//@children.15/@ports.4" targets="//@children.15/@children.2/@ports.0"/>
+    <containedEdges identifier="E533" sources="//@children.15/@ports.5" targets="//@children.15/@children.3/@ports.0"/>
+    <containedEdges identifier="E534" sources="//@children.15/@children.0/@ports.1" targets="//@children.15/@children.5/@ports.1"/>
+    <containedEdges identifier="E535" sources="//@children.15/@children.0/@ports.0" targets="//@children.15/@children.0/@ports.1"/>
+    <containedEdges identifier="E536" sources="//@children.15/@children.1/@ports.1" targets="//@children.15/@children.5/@ports.2"/>
+    <containedEdges identifier="E537" sources="//@children.15/@children.2/@ports.1" targets="//@children.15/@children.5/@ports.0"/>
+    <containedEdges identifier="E538" sources="//@children.15/@children.2/@ports.0" targets="//@children.15/@children.2/@ports.1"/>
+    <containedEdges identifier="E539" sources="//@children.15/@children.3/@ports.1" targets="//@children.15/@children.5/@ports.3"/>
+    <containedEdges identifier="E540" sources="//@children.15/@children.3/@ports.0" targets="//@children.15/@children.3/@ports.1"/>
+    <containedEdges identifier="E541" sources="//@children.15/@children.4/@ports.1" targets="//@children.15/@ports.2"/>
+    <containedEdges identifier="E542" sources="//@children.15/@children.4/@ports.0" targets="//@children.15/@children.4/@ports.1"/>
+    <containedEdges identifier="E543" sources="//@children.15/@children.5/@ports.5" targets="//@children.15/@ports.3"/>
+    <containedEdges identifier="E544" sources="//@children.15/@children.5/@ports.4" targets="//@children.15/@children.4/@ports.0"/>
+  </children>
+  <children identifier="N344">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L344" height="15.0" width="114.0" text="reserveFeedMonitor"/>
+    <ports identifier="P930" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.1" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P931" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.2" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P932" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N345">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L345" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P933" height="8.0" width="8.0" outgoingEdges="//@children.16/@children.0/@containedEdges.0" incomingEdges="//@children.16/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P934" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.3" incomingEdges="//@children.16/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N346" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L346" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P935" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.16/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P936" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P937" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.16/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N347" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L347" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P938" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.16/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P939" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P940" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P941" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P942" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E573" sources="//@children.16/@children.0/@ports.0" targets="//@children.16/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E574" sources="//@children.16/@children.0/@children.0/@ports.1" targets="//@children.16/@children.0/@ports.1"/>
+      <containedEdges identifier="E575" sources="//@children.16/@children.0/@children.1/@ports.0" targets="//@children.16/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N348" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L348" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P943" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.5" incomingEdges="//@children.16/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P944" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.16/@containedEdges.4" incomingEdges="//@children.16/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N349">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L349" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P945" height="8.0" width="8.0" incomingEdges="//@children.16/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P946" height="8.0" width="8.0" outgoingEdges="//@children.16/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N350" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L350" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P947" height="8.0" width="8.0" x="-8.0" y="16.0" outgoingEdges="//@children.16/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P948" height="8.0" width="8.0" x="60.0" y="16.0" incomingEdges="//@children.16/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E576" sources="//@children.16/@children.2/@children.0/@ports.0" targets="//@children.16/@children.2/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N351" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L351" height="15.0" width="78.0" text="NonStrictTest"/>
+      <ports identifier="P949" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.16/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N352" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L352" height="15.0" width="86.0" text="NonStrictTest2"/>
+      <ports identifier="P950" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.16/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N353" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L353" height="15.0" width="86.0" text="NonStrictTest3"/>
+      <ports identifier="P951" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.16/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E566" sources="//@children.16/@ports.2" targets="//@children.16/@children.1/@ports.0"/>
+    <containedEdges identifier="E567" sources="//@children.16/@ports.0" targets="//@children.16/@children.0/@ports.0"/>
+    <containedEdges identifier="E568" sources="//@children.16/@ports.1" targets="//@children.16/@children.4/@ports.0"/>
+    <containedEdges identifier="E569" sources="//@children.16/@children.0/@ports.1" targets="//@children.16/@children.3/@ports.0"/>
+    <containedEdges identifier="E570" sources="//@children.16/@children.1/@ports.1" targets="//@children.16/@children.2/@ports.0"/>
+    <containedEdges identifier="E571" sources="//@children.16/@children.1/@ports.0" targets="//@children.16/@children.1/@ports.1"/>
+    <containedEdges identifier="E572" sources="//@children.16/@children.2/@ports.1" targets="//@children.16/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N354">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L354" height="15.0" width="93.0" text="PtidesPlatform2"/>
+    <ports identifier="P952" height="8.0" width="8.0" incomingEdges="//@containedEdges.31">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P953" height="8.0" width="8.0" outgoingEdges="//@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P954" height="8.0" width="8.0" incomingEdges="//@containedEdges.33">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P955" height="8.0" width="8.0" outgoingEdges="//@containedEdges.43">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P956" height="8.0" width="8.0" incomingEdges="//@containedEdges.37">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P957" height="8.0" width="8.0" outgoingEdges="//@containedEdges.42">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N355">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L355" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P958" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P959" height="8.0" width="8.0" incomingEdges="//@children.17/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P960" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P961" height="8.0" width="8.0" incomingEdges="//@children.17/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P962" height="8.0" width="8.0" outgoingEdges="//@children.17/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P963" height="8.0" width="8.0" incomingEdges="//@children.17/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N356" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L356" height="15.0" width="112.0" text="BooleanToAnything"/>
+        <ports identifier="P964" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.17/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P965" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.17/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N357" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L357" height="15.0" width="119.0" text="BooleanToAnything2"/>
+        <ports identifier="P966" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.17/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P967" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.17/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N358" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L358" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P968" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.17/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P969" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.17/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E577" sources="//@children.17/@children.0/@ports.4" targets="//@children.17/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E578" sources="//@children.17/@children.0/@ports.2" targets="//@children.17/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E579" sources="//@children.17/@children.0/@ports.0" targets="//@children.17/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E580" sources="//@children.17/@children.0/@children.0/@ports.1" targets="//@children.17/@children.0/@ports.1"/>
+      <containedEdges identifier="E581" sources="//@children.17/@children.0/@children.1/@ports.1" targets="//@children.17/@children.0/@ports.3"/>
+      <containedEdges identifier="E582" sources="//@children.17/@children.0/@children.2/@ports.1" targets="//@children.17/@children.0/@ports.5"/>
+    </children>
+  </children>
+  <children identifier="N359" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L359" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P970" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8 //@containedEdges.11 //@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N360" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L360" height="15.0" width="98.0" text="feedPaperRadius"/>
+    <ports identifier="P971" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.42 //@containedEdges.43 //@containedEdges.44">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N361" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L361" height="15.0" width="106.0" text="feedPaperRadius2"/>
+    <ports identifier="P972" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N362" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L362" height="15.0" width="97.0" text="driveToFeedError"/>
+    <ports identifier="P973" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N363" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L363" height="15.0" width="152.0" text="reserveFeedPaperRadius2"/>
+    <ports identifier="P974" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N364" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L364" height="15.0" width="114.0" text="driveToReserveError"/>
+    <ports identifier="P975" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.4" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.3/@ports.1" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.4/@ports.3" targets="//@children.14/@ports.4"/>
+  <containedEdges identifier="E14" sources="//@children.4/@ports.2" targets="//@children.21/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.5/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.5/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.5/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.5/@ports.2" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.5/@ports.4" targets="//@children.22/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.6/@ports.1" targets="//@children.16/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.7/@ports.3" targets="//@children.15/@ports.4"/>
+  <containedEdges identifier="E22" sources="//@children.7/@ports.2" targets="//@children.23/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.8/@ports.0" targets="//@children.15/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.8/@ports.0" targets="//@children.16/@ports.2"/>
+  <containedEdges identifier="E25" sources="//@children.9/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E26" sources="//@children.9/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E27" sources="//@children.10/@ports.0" targets="//@children.14/@ports.1"/>
+  <containedEdges identifier="E28" sources="//@children.11/@ports.0" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E29" sources="//@children.11/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E30" sources="//@children.12/@ports.1" targets="//@children.7/@ports.4"/>
+  <containedEdges identifier="E31" sources="//@children.12/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E32" sources="//@children.12/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E33" sources="//@children.12/@ports.2" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E34" sources="//@children.12/@ports.2" targets="//@children.17/@ports.2"/>
+  <containedEdges identifier="E35" sources="//@children.13/@ports.5" targets="//@children.10/@ports.2"/>
+  <containedEdges identifier="E36" sources="//@children.13/@ports.5" targets="//@children.14/@ports.5"/>
+  <containedEdges identifier="E37" sources="//@children.13/@ports.5" targets="//@children.15/@ports.5"/>
+  <containedEdges identifier="E38" sources="//@children.13/@ports.5" targets="//@children.17/@ports.4"/>
+  <containedEdges identifier="E39" sources="//@children.13/@ports.4" targets="//@children.5/@ports.5"/>
+  <containedEdges identifier="E40" sources="//@children.14/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E41" sources="//@children.15/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E42" sources="//@children.15/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E43" sources="//@children.17/@ports.5" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E44" sources="//@children.17/@ports.3" targets="//@children.19/@ports.0"/>
+  <containedEdges identifier="E45" sources="//@children.17/@ports.1" targets="//@children.19/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_printingpress_PrintingPress_AnimationsOnly.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_printingpress_PrintingPress_AnimationsOnly.elkg
@@ -1,0 +1,2334 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="PaperRoll"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="89.0" text="DiscreteClock3"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="74.0" text="SetVariable4"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="SetVariable5"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="SetVariable6"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide6"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="79.0" text="TrigFunction3"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="79.0" text="TrigFunction4"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="87.0" text="MultiplyDivide7"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11 //@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="42.0" text="Ramp3"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="89.0" text="DiscreteClock4"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="87.0" text="MultiplyDivide8"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.14 //@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.18 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="89.0" text="DiscreteClock5"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="57.0" text="initRadius"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.0/@ports.0" targets="//@children.0/@children.17/@ports.4"/>
+    <containedEdges identifier="E24" sources="//@children.0/@ports.1" targets="//@children.0/@children.17/@ports.3"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.10/@ports.2" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.10/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.12/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.12/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.15/@ports.1"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.16/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.16/@ports.0" targets="//@children.0/@children.14/@ports.1"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.17/@ports.0" targets="//@children.0/@children.18/@ports.1"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.18/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L23" height="15.0" width="25.0" text="roll2"/>
+    <children identifier="N24" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="72.0" text="TrigFunction"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="79.0" text="TrigFunction2"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.8 //@children.3/@containedEdges.9 //@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.7 //@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.11 //@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="89.0" text="DiscreteClock3"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="57.0" text="initRadius"/>
+      <ports identifier="P105" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.16 //@children.3/@containedEdges.17 //@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E47" sources="//@children.3/@children.3/@ports.2" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.3/@children.4/@ports.2" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.3/@children.8/@ports.0" targets="//@children.3/@children.7/@ports.1"/>
+    <containedEdges identifier="E54" sources="//@children.3/@children.9/@ports.0" targets="//@children.3/@children.11/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.3/@children.10/@ports.0" targets="//@children.3/@children.9/@ports.1"/>
+    <containedEdges identifier="E56" sources="//@children.3/@children.10/@ports.0" targets="//@children.3/@children.12/@ports.1"/>
+    <containedEdges identifier="E57" sources="//@children.3/@children.10/@ports.0" targets="//@children.3/@children.13/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.3/@children.11/@ports.2" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.3/@children.11/@ports.2" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.3/@children.12/@ports.0" targets="//@children.3/@children.11/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.3/@children.13/@ports.0" targets="//@children.3/@children.11/@ports.1"/>
+    <containedEdges identifier="E62" sources="//@children.3/@children.14/@ports.0" targets="//@children.3/@children.15/@ports.1"/>
+    <containedEdges identifier="E63" sources="//@children.3/@children.15/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.3/@children.15/@ports.0" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.3/@children.15/@ports.0" targets="//@children.3/@children.8/@ports.1"/>
+  </children>
+  <children identifier="N40" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="74.0" text="SetVariable2"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P109" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="74.0" text="SetVariable3"/>
+    <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P111" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="74.0" text="SetVariable4"/>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P118" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N46">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L46" height="15.0" width="25.0" text="roll3"/>
+    <children identifier="N47" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.2 //@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.3 //@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="72.0" text="TrigFunction"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="79.0" text="TrigFunction2"/>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.4 //@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P139" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P141" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P144" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.8 //@children.10/@containedEdges.9 //@children.10/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.7 //@children.10/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.11 //@children.10/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P152" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N60" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P154" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P156" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P159" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="57.0" text="initRadius"/>
+      <ports identifier="P161" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.16 //@children.10/@containedEdges.17 //@children.10/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E66" sources="//@children.10/@children.3/@ports.2" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.10/@children.4/@ports.2" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.10/@children.5/@ports.1" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.10/@children.6/@ports.1" targets="//@children.10/@children.4/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.10/@children.7/@ports.2" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E71" sources="//@children.10/@children.7/@ports.2" targets="//@children.10/@children.4/@ports.0"/>
+    <containedEdges identifier="E72" sources="//@children.10/@children.8/@ports.0" targets="//@children.10/@children.7/@ports.1"/>
+    <containedEdges identifier="E73" sources="//@children.10/@children.9/@ports.0" targets="//@children.10/@children.11/@ports.0"/>
+    <containedEdges identifier="E74" sources="//@children.10/@children.10/@ports.0" targets="//@children.10/@children.9/@ports.1"/>
+    <containedEdges identifier="E75" sources="//@children.10/@children.10/@ports.0" targets="//@children.10/@children.12/@ports.1"/>
+    <containedEdges identifier="E76" sources="//@children.10/@children.10/@ports.0" targets="//@children.10/@children.13/@ports.1"/>
+    <containedEdges identifier="E77" sources="//@children.10/@children.11/@ports.2" targets="//@children.10/@children.5/@ports.0"/>
+    <containedEdges identifier="E78" sources="//@children.10/@children.11/@ports.2" targets="//@children.10/@children.6/@ports.0"/>
+    <containedEdges identifier="E79" sources="//@children.10/@children.12/@ports.0" targets="//@children.10/@children.11/@ports.0"/>
+    <containedEdges identifier="E80" sources="//@children.10/@children.13/@ports.0" targets="//@children.10/@children.11/@ports.1"/>
+    <containedEdges identifier="E81" sources="//@children.10/@children.14/@ports.0" targets="//@children.10/@children.15/@ports.1"/>
+    <containedEdges identifier="E82" sources="//@children.10/@children.15/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E83" sources="//@children.10/@children.15/@ports.0" targets="//@children.10/@children.7/@ports.0"/>
+    <containedEdges identifier="E84" sources="//@children.10/@children.15/@ports.0" targets="//@children.10/@children.8/@ports.1"/>
+  </children>
+  <children identifier="N63" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L63" height="15.0" width="74.0" text="SetVariable5"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P164" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N64" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L64" height="15.0" width="74.0" text="SetVariable6"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P166" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N65" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="76.0" text="SingleEvent3"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L66" height="15.0" width="25.0" text="roll4"/>
+    <children identifier="N67" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.14/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P169" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.14/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P171" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.14/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P173" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@containedEdges.2 //@children.14/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@containedEdges.3 //@children.14/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P179" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N72" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L72" height="15.0" width="72.0" text="TrigFunction"/>
+      <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P181" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N73" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="79.0" text="TrigFunction2"/>
+      <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P183" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.14/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P186" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.4 //@children.14/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P187" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P189" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P192" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.8 //@children.14/@containedEdges.9 //@children.14/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P195" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P196" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N78" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L78" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.14/@containedEdges.7 //@children.14/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.14/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P199" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.11 //@children.14/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N79" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L79" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P200" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N80" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L80" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P202" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N81" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L81" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P204" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.14/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P207" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P208" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N82" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L82" height="15.0" width="57.0" text="initRadius"/>
+      <ports identifier="P209" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.16 //@children.14/@containedEdges.17 //@children.14/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P210" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.14/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E85" sources="//@children.14/@children.3/@ports.2" targets="//@children.14/@children.1/@ports.0"/>
+    <containedEdges identifier="E86" sources="//@children.14/@children.4/@ports.2" targets="//@children.14/@children.2/@ports.0"/>
+    <containedEdges identifier="E87" sources="//@children.14/@children.5/@ports.1" targets="//@children.14/@children.3/@ports.0"/>
+    <containedEdges identifier="E88" sources="//@children.14/@children.6/@ports.1" targets="//@children.14/@children.4/@ports.0"/>
+    <containedEdges identifier="E89" sources="//@children.14/@children.7/@ports.2" targets="//@children.14/@children.3/@ports.0"/>
+    <containedEdges identifier="E90" sources="//@children.14/@children.7/@ports.2" targets="//@children.14/@children.4/@ports.0"/>
+    <containedEdges identifier="E91" sources="//@children.14/@children.8/@ports.0" targets="//@children.14/@children.7/@ports.1"/>
+    <containedEdges identifier="E92" sources="//@children.14/@children.9/@ports.0" targets="//@children.14/@children.11/@ports.0"/>
+    <containedEdges identifier="E93" sources="//@children.14/@children.10/@ports.0" targets="//@children.14/@children.9/@ports.1"/>
+    <containedEdges identifier="E94" sources="//@children.14/@children.10/@ports.0" targets="//@children.14/@children.12/@ports.1"/>
+    <containedEdges identifier="E95" sources="//@children.14/@children.10/@ports.0" targets="//@children.14/@children.13/@ports.1"/>
+    <containedEdges identifier="E96" sources="//@children.14/@children.11/@ports.2" targets="//@children.14/@children.5/@ports.0"/>
+    <containedEdges identifier="E97" sources="//@children.14/@children.11/@ports.2" targets="//@children.14/@children.6/@ports.0"/>
+    <containedEdges identifier="E98" sources="//@children.14/@children.12/@ports.0" targets="//@children.14/@children.11/@ports.0"/>
+    <containedEdges identifier="E99" sources="//@children.14/@children.13/@ports.0" targets="//@children.14/@children.11/@ports.1"/>
+    <containedEdges identifier="E100" sources="//@children.14/@children.14/@ports.0" targets="//@children.14/@children.15/@ports.1"/>
+    <containedEdges identifier="E101" sources="//@children.14/@children.15/@ports.0" targets="//@children.14/@children.0/@ports.0"/>
+    <containedEdges identifier="E102" sources="//@children.14/@children.15/@ports.0" targets="//@children.14/@children.7/@ports.0"/>
+    <containedEdges identifier="E103" sources="//@children.14/@children.15/@ports.0" targets="//@children.14/@children.8/@ports.1"/>
+  </children>
+  <children identifier="N83">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L83" height="15.0" width="25.0" text="roll5"/>
+    <children identifier="N84" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L84" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.15/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P212" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N85" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P214" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P216" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L87" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@containedEdges.2 //@children.15/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P219" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N88" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L88" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@containedEdges.3 //@children.15/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N89" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L89" height="15.0" width="72.0" text="TrigFunction"/>
+      <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P224" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N90" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L90" height="15.0" width="79.0" text="TrigFunction2"/>
+      <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P226" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N91" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L91" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.15/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P229" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.4 //@children.15/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N92" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L92" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P230" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N93" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L93" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P232" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N94" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L94" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P235" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.8 //@children.15/@containedEdges.9 //@children.15/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P238" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P239" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N95" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L95" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.15/@containedEdges.7 //@children.15/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.15/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P242" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.11 //@children.15/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N96" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L96" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P243" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N97" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L97" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P245" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N98" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L98" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P247" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.15/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P250" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P251" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N99" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L99" height="15.0" width="57.0" text="initRadius"/>
+      <ports identifier="P252" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.16 //@children.15/@containedEdges.17 //@children.15/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.15/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E104" sources="//@children.15/@children.3/@ports.2" targets="//@children.15/@children.1/@ports.0"/>
+    <containedEdges identifier="E105" sources="//@children.15/@children.4/@ports.2" targets="//@children.15/@children.2/@ports.0"/>
+    <containedEdges identifier="E106" sources="//@children.15/@children.5/@ports.1" targets="//@children.15/@children.3/@ports.0"/>
+    <containedEdges identifier="E107" sources="//@children.15/@children.6/@ports.1" targets="//@children.15/@children.4/@ports.0"/>
+    <containedEdges identifier="E108" sources="//@children.15/@children.7/@ports.2" targets="//@children.15/@children.3/@ports.0"/>
+    <containedEdges identifier="E109" sources="//@children.15/@children.7/@ports.2" targets="//@children.15/@children.4/@ports.0"/>
+    <containedEdges identifier="E110" sources="//@children.15/@children.8/@ports.0" targets="//@children.15/@children.7/@ports.1"/>
+    <containedEdges identifier="E111" sources="//@children.15/@children.9/@ports.0" targets="//@children.15/@children.11/@ports.0"/>
+    <containedEdges identifier="E112" sources="//@children.15/@children.10/@ports.0" targets="//@children.15/@children.9/@ports.1"/>
+    <containedEdges identifier="E113" sources="//@children.15/@children.10/@ports.0" targets="//@children.15/@children.12/@ports.1"/>
+    <containedEdges identifier="E114" sources="//@children.15/@children.10/@ports.0" targets="//@children.15/@children.13/@ports.1"/>
+    <containedEdges identifier="E115" sources="//@children.15/@children.11/@ports.2" targets="//@children.15/@children.5/@ports.0"/>
+    <containedEdges identifier="E116" sources="//@children.15/@children.11/@ports.2" targets="//@children.15/@children.6/@ports.0"/>
+    <containedEdges identifier="E117" sources="//@children.15/@children.12/@ports.0" targets="//@children.15/@children.11/@ports.0"/>
+    <containedEdges identifier="E118" sources="//@children.15/@children.13/@ports.0" targets="//@children.15/@children.11/@ports.1"/>
+    <containedEdges identifier="E119" sources="//@children.15/@children.14/@ports.0" targets="//@children.15/@children.15/@ports.1"/>
+    <containedEdges identifier="E120" sources="//@children.15/@children.15/@ports.0" targets="//@children.15/@children.0/@ports.0"/>
+    <containedEdges identifier="E121" sources="//@children.15/@children.15/@ports.0" targets="//@children.15/@children.7/@ports.0"/>
+    <containedEdges identifier="E122" sources="//@children.15/@children.15/@ports.0" targets="//@children.15/@children.8/@ports.1"/>
+  </children>
+  <children identifier="N100" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L100" height="15.0" width="74.0" text="SetVariable7"/>
+    <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P255" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N101" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L101" height="15.0" width="76.0" text="SingleEvent4"/>
+    <ports identifier="P256" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N102" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L102" height="15.0" width="74.0" text="SetVariable8"/>
+    <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P258" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N103" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L103" height="15.0" width="76.0" text="SingleEvent5"/>
+    <ports identifier="P259" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N104" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L104" height="15.0" width="74.0" text="SetVariable9"/>
+    <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P261" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N105" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L105" height="15.0" width="76.0" text="SingleEvent6"/>
+    <ports identifier="P262" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N106" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L106" height="15.0" width="76.0" text="SingleEvent7"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N107" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="71.0" text="startSecond"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="52.0" text="startFirst"/>
+    <ports identifier="P265" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L109" height="15.0" width="64.0" text="PaperRoll2"/>
+    <ports identifier="P266" height="8.0" width="8.0" outgoingEdges="//@children.25/@containedEdges.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P267" height="8.0" width="8.0" outgoingEdges="//@children.25/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N110" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L110" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P268" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.25/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N111" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L111" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.25/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P272" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.3 //@children.25/@containedEdges.4 //@children.25/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P273" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.25/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N112" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L112" height="15.0" width="89.0" text="DiscreteClock3"/>
+      <ports identifier="P274" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P277" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P278" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N113" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L113" height="15.0" width="74.0" text="SetVariable4"/>
+      <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.25/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P280" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N114" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L114" height="15.0" width="74.0" text="SetVariable5"/>
+      <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.25/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P282" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N115" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L115" height="15.0" width="74.0" text="SetVariable6"/>
+      <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.25/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P284" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N116" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L116" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.25/@containedEdges.9 //@children.25/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P287" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N117" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L117" height="15.0" width="87.0" text="MultiplyDivide6"/>
+      <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.25/@containedEdges.10 //@children.25/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P290" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N118" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L118" height="15.0" width="79.0" text="TrigFunction3"/>
+      <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.25/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P292" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.25/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N119" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L119" height="15.0" width="79.0" text="TrigFunction4"/>
+      <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.25/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P294" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.25/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N120" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L120" height="15.0" width="87.0" text="MultiplyDivide7"/>
+      <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.25/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.25/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P297" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.11 //@children.25/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N121" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L121" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P298" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.25/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.25/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N122" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L122" height="15.0" width="42.0" text="Ramp3"/>
+      <ports identifier="P300" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P301" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.25/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N123" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L123" height="15.0" width="89.0" text="DiscreteClock4"/>
+      <ports identifier="P303" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.15 //@children.25/@containedEdges.16 //@children.25/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P306" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P307" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N124" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L124" height="15.0" width="87.0" text="MultiplyDivide8"/>
+      <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.25/@containedEdges.14 //@children.25/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.25/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P310" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.18 //@children.25/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N125" height="25.0" width="20.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L125" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P311" height="8.0" width="8.0" x="20.0" y="8.5" outgoingEdges="//@children.25/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.25/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N126" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L126" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P313" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.25/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.25/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N127" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L127" height="15.0" width="89.0" text="DiscreteClock5"/>
+      <ports identifier="P315" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.25/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P318" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@children.25/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P319" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@children.25/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N128" height="25.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L128" height="15.0" width="57.0" text="initRadius"/>
+      <ports identifier="P320" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.25/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.25/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E123" sources="//@children.25/@ports.0" targets="//@children.25/@children.17/@ports.4"/>
+    <containedEdges identifier="E124" sources="//@children.25/@ports.1" targets="//@children.25/@children.17/@ports.3"/>
+    <containedEdges identifier="E125" sources="//@children.25/@children.0/@ports.0" targets="//@children.25/@children.1/@ports.0"/>
+    <containedEdges identifier="E126" sources="//@children.25/@children.1/@ports.1" targets="//@children.25/@children.3/@ports.0"/>
+    <containedEdges identifier="E127" sources="//@children.25/@children.1/@ports.1" targets="//@children.25/@children.10/@ports.0"/>
+    <containedEdges identifier="E128" sources="//@children.25/@children.1/@ports.1" targets="//@children.25/@children.11/@ports.1"/>
+    <containedEdges identifier="E129" sources="//@children.25/@children.2/@ports.0" targets="//@children.25/@children.1/@ports.2"/>
+    <containedEdges identifier="E130" sources="//@children.25/@children.6/@ports.2" targets="//@children.25/@children.4/@ports.0"/>
+    <containedEdges identifier="E131" sources="//@children.25/@children.7/@ports.2" targets="//@children.25/@children.5/@ports.0"/>
+    <containedEdges identifier="E132" sources="//@children.25/@children.8/@ports.1" targets="//@children.25/@children.6/@ports.0"/>
+    <containedEdges identifier="E133" sources="//@children.25/@children.9/@ports.1" targets="//@children.25/@children.7/@ports.0"/>
+    <containedEdges identifier="E134" sources="//@children.25/@children.10/@ports.2" targets="//@children.25/@children.6/@ports.0"/>
+    <containedEdges identifier="E135" sources="//@children.25/@children.10/@ports.2" targets="//@children.25/@children.7/@ports.0"/>
+    <containedEdges identifier="E136" sources="//@children.25/@children.11/@ports.0" targets="//@children.25/@children.10/@ports.1"/>
+    <containedEdges identifier="E137" sources="//@children.25/@children.12/@ports.0" targets="//@children.25/@children.14/@ports.0"/>
+    <containedEdges identifier="E138" sources="//@children.25/@children.13/@ports.0" targets="//@children.25/@children.12/@ports.1"/>
+    <containedEdges identifier="E139" sources="//@children.25/@children.13/@ports.0" targets="//@children.25/@children.15/@ports.1"/>
+    <containedEdges identifier="E140" sources="//@children.25/@children.13/@ports.0" targets="//@children.25/@children.16/@ports.1"/>
+    <containedEdges identifier="E141" sources="//@children.25/@children.14/@ports.2" targets="//@children.25/@children.8/@ports.0"/>
+    <containedEdges identifier="E142" sources="//@children.25/@children.14/@ports.2" targets="//@children.25/@children.9/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.25/@children.15/@ports.0" targets="//@children.25/@children.14/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.25/@children.16/@ports.0" targets="//@children.25/@children.14/@ports.1"/>
+    <containedEdges identifier="E145" sources="//@children.25/@children.17/@ports.0" targets="//@children.25/@children.18/@ports.1"/>
+    <containedEdges identifier="E146" sources="//@children.25/@children.18/@ports.0" targets="//@children.25/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N129" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L129" height="15.0" width="70.0" text="stopSecond"/>
+    <ports identifier="P322" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N130" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L130" height="15.0" width="81.0" text="SetVariable10"/>
+    <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P324" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N131" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L131" height="15.0" width="83.0" text="SingleEvent12"/>
+    <ports identifier="P325" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N132" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L132" height="15.0" width="80.0" text="SetVariable11"/>
+    <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P327" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N133" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="82.0" text="SingleEvent11"/>
+    <ports identifier="P328" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L134" height="15.0" width="35.0" text="mover"/>
+    <ports identifier="P329" height="8.0" width="8.0" outgoingEdges="//@children.31/@containedEdges.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P330" height="8.0" width="8.0" outgoingEdges="//@children.31/@containedEdges.1" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N135" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L135" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P331" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.31/@containedEdges.2 //@children.31/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P332" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P334" height="8.0" width="8.0" x="8.333333015441895" y="41.0" incomingEdges="//@children.31/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P335" height="8.0" width="8.0" x="24.66666603088379" y="41.0" incomingEdges="//@children.31/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N136" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L136" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P336" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.31/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P337" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.31/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N137" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L137" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.31/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P340" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N138" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L138" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.31/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P342" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E147" sources="//@children.31/@ports.0" targets="//@children.31/@children.0/@ports.3"/>
+    <containedEdges identifier="E148" sources="//@children.31/@ports.1" targets="//@children.31/@children.0/@ports.4"/>
+    <containedEdges identifier="E149" sources="//@children.31/@children.0/@ports.0" targets="//@children.31/@children.1/@ports.1"/>
+    <containedEdges identifier="E150" sources="//@children.31/@children.0/@ports.0" targets="//@children.31/@children.3/@ports.0"/>
+    <containedEdges identifier="E151" sources="//@children.31/@children.1/@ports.0" targets="//@children.31/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N139" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L139" height="15.0" width="81.0" text="SetVariable13"/>
+    <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N140" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L140" height="15.0" width="83.0" text="SingleEvent14"/>
+    <ports identifier="P345" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N141" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L141" height="15.0" width="61.0" text="startMover"/>
+    <ports identifier="P346" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N142" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L142" height="15.0" width="60.0" text="stopMover"/>
+    <ports identifier="P347" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N143" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L143" height="15.0" width="83.0" text="SingleEvent16"/>
+    <ports identifier="P348" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N144" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L144" height="15.0" width="81.0" text="SetVariable15"/>
+    <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P350" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N145" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L145" height="15.0" width="81.0" text="SetVariable17"/>
+    <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P352" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N146" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L146" height="15.0" width="83.0" text="SingleEvent17"/>
+    <ports identifier="P353" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N147" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L147" height="15.0" width="81.0" text="SetVariable18"/>
+    <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P355" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.5/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.7/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.9/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.17/@ports.0" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.19/@ports.0" targets="//@children.18/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.21/@ports.0" targets="//@children.20/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.22/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.23/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.23/@ports.0" targets="//@children.25/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.23/@ports.0" targets="//@children.38/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.24/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.24/@ports.0" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.26/@ports.0" targets="//@children.25/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.28/@ports.0" targets="//@children.27/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.30/@ports.0" targets="//@children.29/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.33/@ports.0" targets="//@children.32/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.34/@ports.0" targets="//@children.31/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.35/@ports.0" targets="//@children.31/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.36/@ports.0" targets="//@children.37/@ports.0"/>
+  <containedEdges identifier="E22" sources="//@children.39/@ports.0" targets="//@children.40/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_ptidessynchrophasor_PtidesSynchrophasor.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_ptidessynchrophasor_PtidesSynchrophasor.elkg
@@ -1,0 +1,705 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.8 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="65.0" text="Power Grid"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3" incomingEdges="//@children.1/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="55.0" text="Sinewave"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="57.0" text="nom_sine"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="53.0" text="nom_cos"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="62.0" text="Sinewave2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="10.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P24" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N13">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L13" height="15.0" width="30.0" text="PMU"/>
+        <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.0 //@children.2/@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.2" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.3" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.4" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N14" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L14" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.0 //@children.2/@children.0/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N15" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L15" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.1 //@children.2/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N16" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="25.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P51" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="16.0" text="IIR"/>
+          <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P53" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N19" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L19" height="15.0" width="23.0" text="IIR2"/>
+          <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E25" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E26" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E27" sources="//@children.2/@children.0/@children.1/@ports.1" targets="//@children.2/@children.0/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E28" sources="//@children.2/@children.0/@children.1/@ports.2" targets="//@children.2/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E29" sources="//@children.2/@children.0/@children.1/@children.0/@ports.2" targets="//@children.2/@children.0/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E30" sources="//@children.2/@children.0/@children.1/@children.1/@ports.2" targets="//@children.2/@children.0/@children.1/@children.5/@ports.0"/>
+        <containedEdges identifier="E31" sources="//@children.2/@children.0/@children.1/@children.2/@ports.2" targets="//@children.2/@children.0/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E32" sources="//@children.2/@children.0/@children.1/@children.3/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.3"/>
+        <containedEdges identifier="E33" sources="//@children.2/@children.0/@children.1/@children.4/@ports.1" targets="//@children.2/@children.0/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E34" sources="//@children.2/@children.0/@children.1/@children.5/@ports.1" targets="//@children.2/@children.0/@children.1/@children.2/@ports.1"/>
+      </children>
+      <children identifier="N20" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="49.0" text="Register"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E19" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E20" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E21" sources="//@children.2/@children.0/@ports.2" targets="//@children.2/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E22" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E23" sources="//@children.2/@children.0/@children.1/@ports.3" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.3"/>
+    </children>
+  </children>
+  <children identifier="N21">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L21" height="15.0" width="93.0" text="PtidesPlatform2"/>
+    <ports identifier="P59" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N22">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L22" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P63" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" incomingEdges="//@children.3/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N23" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N24">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L24" height="15.0" width="30.0" text="PMU"/>
+        <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.0 //@children.3/@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.2" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.3" incomingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.4" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N25" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L25" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.0 //@children.3/@children.0/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N26" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.1 //@children.3/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P81" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N27" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P84" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="25.0" width="36.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P86" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N29" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L29" height="15.0" width="16.0" text="IIR"/>
+          <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P88" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N30" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L30" height="15.0" width="23.0" text="IIR2"/>
+          <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P90" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@children.1/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E41" sources="//@children.3/@children.0/@children.1/@ports.0" targets="//@children.3/@children.0/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E42" sources="//@children.3/@children.0/@children.1/@ports.0" targets="//@children.3/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E43" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E44" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E45" sources="//@children.3/@children.0/@children.1/@children.0/@ports.2" targets="//@children.3/@children.0/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E46" sources="//@children.3/@children.0/@children.1/@children.1/@ports.2" targets="//@children.3/@children.0/@children.1/@children.5/@ports.0"/>
+        <containedEdges identifier="E47" sources="//@children.3/@children.0/@children.1/@children.2/@ports.2" targets="//@children.3/@children.0/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E48" sources="//@children.3/@children.0/@children.1/@children.3/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.3"/>
+        <containedEdges identifier="E49" sources="//@children.3/@children.0/@children.1/@children.4/@ports.1" targets="//@children.3/@children.0/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E50" sources="//@children.3/@children.0/@children.1/@children.5/@ports.1" targets="//@children.3/@children.0/@children.1/@children.2/@ports.1"/>
+      </children>
+      <children identifier="N31" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="49.0" text="Register"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E35" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.0/@ports.2" targets="//@children.3/@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E38" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.0/@children.1/@ports.3" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    </children>
+  </children>
+  <children identifier="N32">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L32" height="15.0" width="93.0" text="PtidesPlatform3"/>
+    <ports identifier="P94" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P95" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N33">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L33" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P97" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N34" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="100.0" text="SetControlOutput"/>
+        <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P101" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="84.0" text="AbsoluteValue"/>
+        <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E51" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.4/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@ports.2"/>
+      <containedEdges identifier="E54" sources="//@children.4/@children.0/@children.1/@ports.2" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.3" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.2" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_srinptides_SRinPtides.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_srinptides_SRinPtides.elkg
@@ -1,0 +1,777 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.7 //@containedEdges.14 //@containedEdges.16 //@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="45.0" text="SR App"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.2/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="95.0" text="NonStrictDelay2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E22" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="30.0" text="d0+a"/>
+    <ports identifier="P15" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N9">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L9" height="15.0" width="45.0" text="SR App"/>
+        <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.1" incomingEdges="//@children.3/@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N10" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L10" height="15.0" width="87.0" text="NonStrictDelay"/>
+          <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P22" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N11" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N12" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L12" height="15.0" width="95.0" text="NonStrictDelay2"/>
+          <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P26" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E28" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E29" sources="//@children.3/@children.0/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E30" sources="//@children.3/@children.0/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E31" sources="//@children.3/@children.0/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.1"/>
+      </children>
+      <containedEdges identifier="E26" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E27" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="30.0" text="d2+a"/>
+    <ports identifier="P27" height="8.0" width="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L14" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N15">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L15" height="15.0" width="42.0" text="SRApp"/>
+        <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1" incomingEdges="//@children.4/@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N16" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L16" height="15.0" width="87.0" text="NonStrictDelay"/>
+          <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P34" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N17" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N18" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L18" height="15.0" width="95.0" text="NonStrictDelay2"/>
+          <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P38" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E34" sources="//@children.4/@children.0/@children.0/@ports.0" targets="//@children.4/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E35" sources="//@children.4/@children.0/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E36" sources="//@children.4/@children.0/@children.0/@children.1/@ports.1" targets="//@children.4/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E37" sources="//@children.4/@children.0/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@children.0/@ports.1"/>
+      </children>
+      <containedEdges identifier="E32" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.4/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N23">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L23" height="15.0" width="37.0" text="d2+na"/>
+    <ports identifier="P52" height="8.0" width="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N24">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L24" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P54" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" incomingEdges="//@children.9/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N25">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L25" height="15.0" width="42.0" text="SRApp"/>
+        <ports identifier="P56" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.9/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.0/@containedEdges.1" incomingEdges="//@children.9/@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N26" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L26" height="15.0" width="87.0" text="NonStrictDelay"/>
+          <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P59" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.9/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N27" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L27" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N28" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L28" height="15.0" width="95.0" text="NonStrictDelay2"/>
+          <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P63" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.9/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E40" sources="//@children.9/@children.0/@children.0/@ports.0" targets="//@children.9/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E41" sources="//@children.9/@children.0/@children.0/@children.0/@ports.1" targets="//@children.9/@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E42" sources="//@children.9/@children.0/@children.0/@children.1/@ports.1" targets="//@children.9/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E43" sources="//@children.9/@children.0/@children.0/@children.2/@ports.1" targets="//@children.9/@children.0/@children.0/@ports.1"/>
+      </children>
+      <containedEdges identifier="E38" sources="//@children.9/@children.0/@ports.0" targets="//@children.9/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.9/@children.0/@children.0/@ports.1" targets="//@children.9/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N29">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L29" height="15.0" width="43.0" text="dist1_a"/>
+    <ports identifier="P64" height="8.0" width="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L31" height="15.0" width="42.0" text="SRApp"/>
+        <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.1" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N32" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L32" height="15.0" width="87.0" text="NonStrictDelay"/>
+          <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P71" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N33" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L33" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P73" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E46" sources="//@children.10/@children.0/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E47" sources="//@children.10/@children.0/@children.0/@children.0/@ports.1" targets="//@children.10/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E48" sources="//@children.10/@children.0/@children.0/@children.1/@ports.1" targets="//@children.10/@children.0/@children.0/@children.0/@ports.0"/>
+      </children>
+      <containedEdges identifier="E44" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.10/@children.0/@children.0/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N34">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L34" height="15.0" width="43.0" text="dist1_b"/>
+    <ports identifier="P74" height="8.0" width="8.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N35">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L35" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P76" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" incomingEdges="//@children.11/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N36">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L36" height="15.0" width="42.0" text="SRApp"/>
+        <ports identifier="P78" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.1" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N37" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L37" height="15.0" width="87.0" text="NonStrictDelay"/>
+          <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P81" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N38" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L38" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P83" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E51" sources="//@children.11/@children.0/@children.0/@ports.0" targets="//@children.11/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E52" sources="//@children.11/@children.0/@children.0/@children.0/@ports.1" targets="//@children.11/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E53" sources="//@children.11/@children.0/@children.0/@children.1/@ports.1" targets="//@children.11/@children.0/@children.0/@children.0/@ports.0"/>
+      </children>
+      <containedEdges identifier="E49" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.11/@children.0/@children.0/@ports.1" targets="//@children.11/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N39" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P86" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N40">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L40" height="15.0" width="43.0" text="dist2_a"/>
+    <ports identifier="P87" height="8.0" width="8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N41">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L41" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P89" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" incomingEdges="//@children.13/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N42">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L42" height="15.0" width="42.0" text="SRApp"/>
+        <ports identifier="P91" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.13/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.0/@containedEdges.1" incomingEdges="//@children.13/@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N43" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L43" height="15.0" width="87.0" text="NonStrictDelay"/>
+          <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P94" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.13/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N44" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L44" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.0/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N45" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L45" height="15.0" width="95.0" text="NonStrictDelay2"/>
+          <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P98" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.13/@children.0/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E56" sources="//@children.13/@children.0/@children.0/@ports.0" targets="//@children.13/@children.0/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E57" sources="//@children.13/@children.0/@children.0/@children.0/@ports.1" targets="//@children.13/@children.0/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E58" sources="//@children.13/@children.0/@children.0/@children.1/@ports.1" targets="//@children.13/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E59" sources="//@children.13/@children.0/@children.0/@children.2/@ports.1" targets="//@children.13/@children.0/@children.0/@ports.1"/>
+      </children>
+      <containedEdges identifier="E54" sources="//@children.13/@children.0/@ports.0" targets="//@children.13/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.13/@children.0/@children.0/@ports.1" targets="//@children.13/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N46">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L46" height="15.0" width="43.0" text="dist2_b"/>
+    <ports identifier="P99" height="8.0" width="8.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N47">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L47" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P101" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" incomingEdges="//@children.14/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N48">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L48" height="15.0" width="42.0" text="SRApp"/>
+        <ports identifier="P103" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.14/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@children.14/@children.0/@containedEdges.1" incomingEdges="//@children.14/@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N49" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L49" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.14/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P106" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.14/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E62" sources="//@children.14/@children.0/@children.0/@ports.0" targets="//@children.14/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E63" sources="//@children.14/@children.0/@children.0/@children.0/@ports.1" targets="//@children.14/@children.0/@children.0/@ports.1"/>
+      </children>
+      <containedEdges identifier="E60" sources="//@children.14/@children.0/@ports.0" targets="//@children.14/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.14/@children.0/@children.0/@ports.1" targets="//@children.14/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N50" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L50" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.1" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.13/@ports.1" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.14/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.15/@ports.1" targets="//@children.14/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_srinptides_SRinPtidesLoop.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_srinptides_SRinPtidesLoop.elkg
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="30.0" text="d2+a"/>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L4" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" incomingEdges="//@children.2/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N5">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L5" height="15.0" width="94.0" text="CompositeActor"/>
+        <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.1" incomingEdges="//@children.2/@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N6" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L6" height="15.0" width="95.0" text="NonStrictDelay2"/>
+          <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P14" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E15" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E16" sources="//@children.2/@children.0/@children.0/@children.0/@ports.1" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+      </children>
+      <children identifier="N7">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L7" height="15.0" width="101.0" text="CompositeActor2"/>
+        <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.0" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.2" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N8" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.0 //@children.2/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N9" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L9" height="15.0" width="87.0" text="NonStrictDelay"/>
+          <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P21" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.1/@containedEdges.2 //@children.2/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E17" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E18" sources="//@children.2/@children.0/@children.1/@children.0/@ports.2" targets="//@children.2/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E19" sources="//@children.2/@children.0/@children.1/@children.1/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E20" sources="//@children.2/@children.0/@children.1/@children.1/@ports.1" targets="//@children.2/@children.0/@children.1/@children.0/@ports.0"/>
+      </children>
+      <children identifier="N10">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L10" height="15.0" width="101.0" text="CompositeActor3"/>
+        <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@children.2/@containedEdges.0" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.3" incomingEdges="//@children.2/@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N11" height="25.0" width="14.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L11" height="15.0" width="95.0" text="NonStrictDelay3"/>
+          <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@children.2/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P25" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@children.0/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E21" sources="//@children.2/@children.0/@children.2/@ports.0" targets="//@children.2/@children.0/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E22" sources="//@children.2/@children.0/@children.2/@children.0/@ports.1" targets="//@children.2/@children.0/@children.2/@ports.1"/>
+      </children>
+      <containedEdges identifier="E11" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.2/@children.0/@children.0/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.2/@children.0/@children.1/@ports.1" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="19.0" text="SR"/>
+    <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.8/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.2 //@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.2 //@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="95.0" text="NonStrictDelay2"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="95.0" text="NonStrictDelay3"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.8/@ports.0" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.8/@children.0/@ports.2" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_trex_TREX.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_trex_TREX.elkg
@@ -1,0 +1,2568 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="104.0" text="reserveFeedRoller"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="78.0" text="Paper Radius"/>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.21 //@children.0/@containedEdges.22 //@children.0/@containedEdges.23" incomingEdges="//@children.0/@children.13/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.13/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.13/@containedEdges.0 //@children.0/@children.13/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.13/@containedEdges.4 //@children.0/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="407.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="119.0" text="initialRadiusSquared"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.13/@containedEdges.8 //@children.0/@children.13/@containedEdges.9 //@children.0/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="58.0" text="constzero"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="40.0" text="omega"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="65.0" text="constzero2"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="65.0" text="coreRadius"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.14 //@children.0/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="37.0" text="Select"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.13/@containedEdges.1 //@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="45.0" text="Select2"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.13/@containedEdges.10 //@children.0/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E50" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.13/@children.5/@ports.1"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.13/@children.7/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.13/@children.0/@ports.2" targets="//@children.0/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.13/@children.1/@ports.1" targets="//@children.0/@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.13/@children.1/@ports.1" targets="//@children.0/@children.13/@children.2/@ports.1"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.13/@children.2/@ports.0" targets="//@children.0/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.13/@children.3/@ports.1" targets="//@children.0/@children.13/@children.0/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.8/@ports.1"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.9/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.13/@children.5/@ports.0" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.13/@children.6/@ports.2" targets="//@children.0/@children.13/@children.1/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.13/@children.7/@ports.0" targets="//@children.0/@children.13/@children.12/@ports.2"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.13/@children.8/@ports.0" targets="//@children.0/@children.13/@children.9/@ports.1"/>
+      <containedEdges identifier="E65" sources="//@children.0/@children.13/@children.8/@ports.0" targets="//@children.0/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.13/@children.9/@ports.2" targets="//@children.0/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.13/@children.10/@ports.1" targets="//@children.0/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.13/@children.11/@ports.1" targets="//@children.0/@children.13/@children.13/@ports.2"/>
+      <containedEdges identifier="E69" sources="//@children.0/@children.13/@children.12/@ports.1" targets="//@children.0/@children.13/@children.6/@ports.1"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.13/@children.13/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    </children>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.0 //@children.0/@children.14/@containedEdges.1 //@children.0/@children.14/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.24 //@children.0/@containedEdges.25 //@children.0/@containedEdges.26 //@children.0/@containedEdges.27" incomingEdges="//@children.0/@children.14/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.5 //@children.0/@children.14/@containedEdges.6 //@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="88.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P94" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+        <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P101" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+        <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.4 //@children.0/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="91.0" text="coreMassScale"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E71" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.4/@ports.1"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.5/@ports.1"/>
+      <containedEdges identifier="E73" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E74" sources="//@children.0/@children.14/@children.0/@ports.1" targets="//@children.0/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.0/@children.14/@children.1/@ports.2" targets="//@children.0/@children.14/@children.11/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.3/@ports.1"/>
+      <containedEdges identifier="E77" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.12/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.0/@children.14/@children.3/@ports.2" targets="//@children.0/@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E80" sources="//@children.0/@children.14/@children.4/@ports.0" targets="//@children.0/@children.14/@children.2/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.14/@children.5/@ports.0" targets="//@children.0/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.14/@children.6/@ports.1" targets="//@children.0/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.0/@children.14/@children.7/@ports.1" targets="//@children.0/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.14/@children.8/@ports.1" targets="//@children.0/@children.14/@children.10/@ports.1"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.14/@children.9/@ports.1" targets="//@children.0/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.14/@children.10/@ports.2" targets="//@children.0/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.0/@children.14/@children.11/@ports.2" targets="//@children.0/@children.14/@ports.1"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.14/@children.12/@ports.1" targets="//@children.0/@children.14/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N44" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.0/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@ports.5" targets="//@children.0/@children.13/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.13/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.12/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.12/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.15/@ports.2" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L47" height="15.0" width="118.0" text="ReserveTargetProfile"/>
+    <ports identifier="P118" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5" incomingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P119" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N48" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L49" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P122" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N50">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L50" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P124" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.0 //@children.3/@children.1/@children.0/@containedEdges.1 //@children.3/@children.1/@children.0/@containedEdges.2 //@children.3/@children.1/@children.0/@containedEdges.3 //@children.3/@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P125" height="8.0" width="8.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N51" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L51" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P126" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P129" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P130" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N52" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L52" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P131" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.6 //@children.3/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N53" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L53" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P134" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.8 //@children.3/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N54" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L54" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P136" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N55" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L55" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P137" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N56" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L56" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P141" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N57" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L57" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P143" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N58" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L58" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P145" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.14 //@children.3/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N59" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P147" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N60" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L60" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P148" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N61" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L61" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.16 //@children.3/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N62" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L62" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P154" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N63" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L63" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P156" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N64" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L64" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P158" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P159" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P160" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N65" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L65" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.0 //@children.3/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P162" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N66" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L66" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P164" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P165" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P166" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N67" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L67" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.1 //@children.3/@children.1/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P168" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N68" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.13 //@children.3/@children.1/@children.0/@containedEdges.19 //@children.3/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P170" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P172" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P173" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P175" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P176" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P177" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N71" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.20 //@children.3/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P179" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P180" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N73" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P183" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N74" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L74" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P184" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N75" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L75" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P187" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P188" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N76" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L76" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P190" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P191" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N77" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L77" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P193" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P194" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N78" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L78" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P196" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.38 //@children.3/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N79" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L79" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P198" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E93" sources="//@children.3/@children.1/@children.0/@ports.0" targets="//@children.3/@children.1/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E94" sources="//@children.3/@children.1/@children.0/@ports.0" targets="//@children.3/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E95" sources="//@children.3/@children.1/@children.0/@ports.0" targets="//@children.3/@children.1/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E96" sources="//@children.3/@children.1/@children.0/@ports.0" targets="//@children.3/@children.1/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E97" sources="//@children.3/@children.1/@children.0/@ports.0" targets="//@children.3/@children.1/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E98" sources="//@children.3/@children.1/@children.0/@children.0/@ports.0" targets="//@children.3/@children.1/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E99" sources="//@children.3/@children.1/@children.0/@children.1/@ports.0" targets="//@children.3/@children.1/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E100" sources="//@children.3/@children.1/@children.0/@children.1/@ports.0" targets="//@children.3/@children.1/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E101" sources="//@children.3/@children.1/@children.0/@children.2/@ports.1" targets="//@children.3/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E102" sources="//@children.3/@children.1/@children.0/@children.2/@ports.1" targets="//@children.3/@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E103" sources="//@children.3/@children.1/@children.0/@children.3/@ports.1" targets="//@children.3/@children.1/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E104" sources="//@children.3/@children.1/@children.0/@children.4/@ports.0" targets="//@children.3/@children.1/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E105" sources="//@children.3/@children.1/@children.0/@children.5/@ports.2" targets="//@children.3/@children.1/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E106" sources="//@children.3/@children.1/@children.0/@children.6/@ports.1" targets="//@children.3/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E107" sources="//@children.3/@children.1/@children.0/@children.7/@ports.1" targets="//@children.3/@children.1/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E108" sources="//@children.3/@children.1/@children.0/@children.7/@ports.1" targets="//@children.3/@children.1/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E109" sources="//@children.3/@children.1/@children.0/@children.8/@ports.1" targets="//@children.3/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E110" sources="//@children.3/@children.1/@children.0/@children.9/@ports.0" targets="//@children.3/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E111" sources="//@children.3/@children.1/@children.0/@children.10/@ports.2" targets="//@children.3/@children.1/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E112" sources="//@children.3/@children.1/@children.0/@children.11/@ports.1" targets="//@children.3/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E113" sources="//@children.3/@children.1/@children.0/@children.12/@ports.1" targets="//@children.3/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E114" sources="//@children.3/@children.1/@children.0/@children.13/@ports.2" targets="//@children.3/@children.1/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E115" sources="//@children.3/@children.1/@children.0/@children.13/@ports.3" targets="//@children.3/@children.1/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E116" sources="//@children.3/@children.1/@children.0/@children.14/@ports.1" targets="//@children.3/@children.1/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E117" sources="//@children.3/@children.1/@children.0/@children.15/@ports.2" targets="//@children.3/@children.1/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E118" sources="//@children.3/@children.1/@children.0/@children.15/@ports.3" targets="//@children.3/@children.1/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E119" sources="//@children.3/@children.1/@children.0/@children.16/@ports.1" targets="//@children.3/@children.1/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E120" sources="//@children.3/@children.1/@children.0/@children.17/@ports.1" targets="//@children.3/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E121" sources="//@children.3/@children.1/@children.0/@children.18/@ports.2" targets="//@children.3/@children.1/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E122" sources="//@children.3/@children.1/@children.0/@children.19/@ports.2" targets="//@children.3/@children.1/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E123" sources="//@children.3/@children.1/@children.0/@children.19/@ports.3" targets="//@children.3/@children.1/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E124" sources="//@children.3/@children.1/@children.0/@children.20/@ports.1" targets="//@children.3/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E125" sources="//@children.3/@children.1/@children.0/@children.21/@ports.0" targets="//@children.3/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E126" sources="//@children.3/@children.1/@children.0/@children.22/@ports.1" targets="//@children.3/@children.1/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E127" sources="//@children.3/@children.1/@children.0/@children.23/@ports.0" targets="//@children.3/@children.1/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E128" sources="//@children.3/@children.1/@children.0/@children.24/@ports.1" targets="//@children.3/@children.1/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E129" sources="//@children.3/@children.1/@children.0/@children.25/@ports.1" targets="//@children.3/@children.1/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E130" sources="//@children.3/@children.1/@children.0/@children.26/@ports.1" targets="//@children.3/@children.1/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E131" sources="//@children.3/@children.1/@children.0/@children.27/@ports.1" targets="//@children.3/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E132" sources="//@children.3/@children.1/@children.0/@children.27/@ports.1" targets="//@children.3/@children.1/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E133" sources="//@children.3/@children.1/@children.0/@children.28/@ports.1" targets="//@children.3/@children.1/@children.0/@children.14/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E89" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E90" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E91" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E92" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N80" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P199" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N81">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L81" height="15.0" width="101.0" text="ContactController"/>
+    <ports identifier="P200" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P201" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P202" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12" incomingEdges="//@children.5/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10" incomingEdges="//@children.5/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.2" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.3" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P206" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8" incomingEdges="//@children.5/@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N82">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L82" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P207" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P208" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.4" incomingEdges="//@children.5/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N83" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P211" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P212" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P216" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E154" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E155" sources="//@children.5/@children.0/@children.0/@ports.1" targets="//@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E156" sources="//@children.5/@children.0/@children.1/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N85" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.6" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P218" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.5" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.8" incomingEdges="//@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P220" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.7" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L87" height="15.0" width="101.0" text="CompositeActor7"/>
+      <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.10" incomingEdges="//@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P222" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.9" incomingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N88" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L88" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.12" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P224" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.11" incomingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N89" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L89" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.14" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P226" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.13" incomingEdges="//@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N90" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L90" height="15.0" width="101.0" text="CompositeActor8"/>
+      <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.16" incomingEdges="//@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P228" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.15" incomingEdges="//@children.5/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N91">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L91" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P229" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P230" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P231" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P232" height="8.0" width="8.0" incomingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P233" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P234" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P235" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N92">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L92" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P236" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P237" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.0 //@children.5/@children.7/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P238" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P239" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P240" height="8.0" width="8.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P241" height="8.0" width="8.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P242" height="8.0" width="8.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N93" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P243" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P244" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P245" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N95" height="25.0" width="136.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L95" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P247" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N96" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L96" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P250" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P251" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N97" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L97" height="15.0" width="53.0" text="TimeGap"/>
+          <ports identifier="P252" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P253" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.9 //@children.5/@children.7/@children.0/@containedEdges.10 //@children.5/@children.7/@children.0/@containedEdges.11 //@children.5/@children.7/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N98" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L98" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P256" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.13 //@children.5/@children.7/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N99" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L99" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P258" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P259" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N100" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L100" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.1 //@children.5/@children.7/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P261" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N101" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L101" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.13 //@children.5/@children.7/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P264" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N102" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L102" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P266" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P267" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N103" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L103" height="15.0" width="56.0" text="Register2"/>
+          <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P269" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P270" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N104" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L104" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P271" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.2 //@children.5/@children.7/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P272" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N105" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L105" height="15.0" width="54.0" text="TrueGate"/>
+          <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P274" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.21 //@children.5/@children.7/@children.0/@containedEdges.22 //@children.5/@children.7/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N106" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L106" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P275" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.7 //@children.5/@children.7/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P277" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N107" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L107" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P279" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@children.7/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P280" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.5/@children.7/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E157" sources="//@children.5/@children.7/@children.0/@ports.1" targets="//@children.5/@children.7/@children.0/@children.6/@ports.2"/>
+        <containedEdges identifier="E158" sources="//@children.5/@children.7/@children.0/@ports.1" targets="//@children.5/@children.7/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E159" sources="//@children.5/@children.7/@children.0/@ports.0" targets="//@children.5/@children.7/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E160" sources="//@children.5/@children.7/@children.0/@ports.2" targets="//@children.5/@children.7/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E161" sources="//@children.5/@children.7/@children.0/@ports.3" targets="//@children.5/@children.7/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E162" sources="//@children.5/@children.7/@children.0/@children.0/@ports.0" targets="//@children.5/@children.7/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E163" sources="//@children.5/@children.7/@children.0/@children.1/@ports.0" targets="//@children.5/@children.7/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E164" sources="//@children.5/@children.7/@children.0/@children.2/@ports.0" targets="//@children.5/@children.7/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E165" sources="//@children.5/@children.7/@children.0/@children.3/@ports.1" targets="//@children.5/@children.7/@children.0/@ports.4"/>
+        <containedEdges identifier="E166" sources="//@children.5/@children.7/@children.0/@children.4/@ports.1" targets="//@children.5/@children.7/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E167" sources="//@children.5/@children.7/@children.0/@children.4/@ports.1" targets="//@children.5/@children.7/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E168" sources="//@children.5/@children.7/@children.0/@children.4/@ports.1" targets="//@children.5/@children.7/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E169" sources="//@children.5/@children.7/@children.0/@children.4/@ports.1" targets="//@children.5/@children.7/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E170" sources="//@children.5/@children.7/@children.0/@children.5/@ports.2" targets="//@children.5/@children.7/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E171" sources="//@children.5/@children.7/@children.0/@children.5/@ports.2" targets="//@children.5/@children.7/@children.0/@children.10/@ports.2"/>
+        <containedEdges identifier="E172" sources="//@children.5/@children.7/@children.0/@children.6/@ports.1" targets="//@children.5/@children.7/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E173" sources="//@children.5/@children.7/@children.0/@children.7/@ports.1" targets="//@children.5/@children.7/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E174" sources="//@children.5/@children.7/@children.0/@children.8/@ports.2" targets="//@children.5/@children.7/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E175" sources="//@children.5/@children.7/@children.0/@children.9/@ports.1" targets="//@children.5/@children.7/@children.0/@ports.6"/>
+        <containedEdges identifier="E176" sources="//@children.5/@children.7/@children.0/@children.10/@ports.1" targets="//@children.5/@children.7/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E177" sources="//@children.5/@children.7/@children.0/@children.11/@ports.1" targets="//@children.5/@children.7/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E178" sources="//@children.5/@children.7/@children.0/@children.12/@ports.1" targets="//@children.5/@children.7/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E179" sources="//@children.5/@children.7/@children.0/@children.12/@ports.1" targets="//@children.5/@children.7/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E180" sources="//@children.5/@children.7/@children.0/@children.12/@ports.1" targets="//@children.5/@children.7/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E181" sources="//@children.5/@children.7/@children.0/@children.13/@ports.2" targets="//@children.5/@children.7/@children.0/@children.14/@ports.2"/>
+        <containedEdges identifier="E182" sources="//@children.5/@children.7/@children.0/@children.14/@ports.1" targets="//@children.5/@children.7/@children.0/@ports.5"/>
+      </children>
+    </children>
+    <containedEdges identifier="E134" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E135" sources="//@children.5/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E136" sources="//@children.5/@ports.4" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E137" sources="//@children.5/@ports.5" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E138" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.7/@ports.2"/>
+    <containedEdges identifier="E139" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E140" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E141" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E142" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E143" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@ports.2"/>
+    <containedEdges identifier="E144" sources="//@children.5/@children.3/@ports.0" targets="//@children.5/@children.3/@ports.1"/>
+    <containedEdges identifier="E145" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.7/@ports.3"/>
+    <containedEdges identifier="E146" sources="//@children.5/@children.4/@ports.0" targets="//@children.5/@children.4/@ports.1"/>
+    <containedEdges identifier="E147" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.7/@ports.1"/>
+    <containedEdges identifier="E148" sources="//@children.5/@children.5/@ports.0" targets="//@children.5/@children.5/@ports.1"/>
+    <containedEdges identifier="E149" sources="//@children.5/@children.6/@ports.1" targets="//@children.5/@ports.6"/>
+    <containedEdges identifier="E150" sources="//@children.5/@children.6/@ports.0" targets="//@children.5/@children.6/@ports.1"/>
+    <containedEdges identifier="E151" sources="//@children.5/@children.7/@ports.4" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E152" sources="//@children.5/@children.7/@ports.5" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E153" sources="//@children.5/@children.7/@ports.6" targets="//@children.5/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N108">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L108" height="15.0" width="102.0" text="ReserveController"/>
+    <ports identifier="P281" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P282" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P283" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.6/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P284" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.6/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P285" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N109" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L109" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P287" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N110">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L110" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P288" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P289" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.5" incomingEdges="//@children.6/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N111" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L111" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P291" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P292" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N112" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L112" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P293" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P296" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P297" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E195" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E196" sources="//@children.6/@children.1/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+      <containedEdges identifier="E197" sources="//@children.6/@children.1/@children.1/@ports.0" targets="//@children.6/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N113" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L113" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.7" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P299" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.6" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N114" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L114" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.9" incomingEdges="//@children.6/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P301" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.8" incomingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N115">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L115" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P302" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P303" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P304" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P305" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P306" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N116">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L116" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P307" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.0 //@children.6/@children.4/@children.0/@containedEdges.1 //@children.6/@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P308" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P309" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P311" height="8.0" width="8.0" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N117" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P313" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.5 //@children.6/@children.4/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N118" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L118" height="15.0" width="68.0" text="TimedDelay"/>
+          <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P316" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N119" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P318" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.8 //@children.6/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P319" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N120" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L120" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P322" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N121" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L121" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P323" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N122" height="25.0" width="70.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L122" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P325" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N123" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L123" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P329" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N124" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L124" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.6 //@children.6/@children.4/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P331" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.6/@children.4/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P332" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.6/@children.4/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E198" sources="//@children.6/@children.4/@children.0/@ports.0" targets="//@children.6/@children.4/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E199" sources="//@children.6/@children.4/@children.0/@ports.0" targets="//@children.6/@children.4/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E200" sources="//@children.6/@children.4/@children.0/@ports.0" targets="//@children.6/@children.4/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E201" sources="//@children.6/@children.4/@children.0/@ports.1" targets="//@children.6/@children.4/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E202" sources="//@children.6/@children.4/@children.0/@ports.2" targets="//@children.6/@children.4/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E203" sources="//@children.6/@children.4/@children.0/@children.0/@ports.1" targets="//@children.6/@children.4/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E204" sources="//@children.6/@children.4/@children.0/@children.0/@ports.1" targets="//@children.6/@children.4/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E205" sources="//@children.6/@children.4/@children.0/@children.1/@ports.1" targets="//@children.6/@children.4/@children.0/@ports.3"/>
+        <containedEdges identifier="E206" sources="//@children.6/@children.4/@children.0/@children.2/@ports.1" targets="//@children.6/@children.4/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E207" sources="//@children.6/@children.4/@children.0/@children.2/@ports.1" targets="//@children.6/@children.4/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E208" sources="//@children.6/@children.4/@children.0/@children.3/@ports.2" targets="//@children.6/@children.4/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E209" sources="//@children.6/@children.4/@children.0/@children.4/@ports.0" targets="//@children.6/@children.4/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E210" sources="//@children.6/@children.4/@children.0/@children.5/@ports.0" targets="//@children.6/@children.4/@children.0/@children.7/@ports.2"/>
+        <containedEdges identifier="E211" sources="//@children.6/@children.4/@children.0/@children.6/@ports.2" targets="//@children.6/@children.4/@children.0/@ports.4"/>
+        <containedEdges identifier="E212" sources="//@children.6/@children.4/@children.0/@children.7/@ports.1" targets="//@children.6/@children.4/@children.0/@children.1/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E183" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E184" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E185" sources="//@children.6/@ports.4" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E186" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E187" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E188" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.4/@ports.1"/>
+    <containedEdges identifier="E189" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.4/@ports.2"/>
+    <containedEdges identifier="E190" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.2/@ports.1"/>
+    <containedEdges identifier="E191" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E192" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E193" sources="//@children.6/@children.4/@ports.4" targets="//@children.6/@ports.3"/>
+    <containedEdges identifier="E194" sources="//@children.6/@children.4/@ports.3" targets="//@children.6/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N125">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L125" height="15.0" width="114.0" text="reserveFeedMonitor"/>
+    <ports identifier="P333" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P334" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P335" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N126">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L126" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P336" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P337" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.3" incomingEdges="//@children.7/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N127" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L127" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P339" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P340" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N128" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L128" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P341" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P344" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P345" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E219" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E220" sources="//@children.7/@children.0/@children.0/@ports.1" targets="//@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E221" sources="//@children.7/@children.0/@children.1/@ports.0" targets="//@children.7/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N129" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L129" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P346" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P347" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.4" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N130">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L130" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P348" height="8.0" width="8.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P349" height="8.0" width="8.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P350" height="8.0" width="8.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N131">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L131" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P351" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P352" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N132" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L132" height="15.0" width="150.0" text="reserveFeedPaperVelocity"/>
+          <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@children.2/@children.0/@containedEdges.0 //@children.7/@children.2/@children.0/@containedEdges.1 //@children.7/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E222" sources="//@children.7/@children.2/@children.0/@ports.0" targets="//@children.7/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E223" sources="//@children.7/@children.2/@children.0/@ports.1" targets="//@children.7/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E224" sources="//@children.7/@children.2/@children.0/@ports.2" targets="//@children.7/@children.2/@children.0/@children.0/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E213" sources="//@children.7/@ports.2" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E214" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E215" sources="//@children.7/@ports.1" targets="//@children.7/@children.2/@ports.1"/>
+    <containedEdges identifier="E216" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E217" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.2/@ports.2"/>
+    <containedEdges identifier="E218" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N133" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L133" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P355" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N134">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L134" height="15.0" width="89.0" text="topDeadCEnter"/>
+    <ports identifier="P356" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P357" height="8.0" width="8.0" outgoingEdges="//@containedEdges.18 //@containedEdges.19" incomingEdges="//@children.9/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P358" height="8.0" width="8.0" outgoingEdges="//@containedEdges.17" incomingEdges="//@children.9/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N135" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L135" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P359" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P360" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N136" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L136" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P361" height="8.0" width="8.0" x="9.333333015441895" y="46.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P363" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.2 //@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P364" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N137" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L137" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P366" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N138" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L138" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+      <ports identifier="P367" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.5 //@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P368" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N139" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L139" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P370" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P371" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N140" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L140" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+      <ports identifier="P372" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E225" sources="//@children.9/@ports.0" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E226" sources="//@children.9/@children.0/@ports.0" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E227" sources="//@children.9/@children.1/@ports.2" targets="//@children.9/@children.3/@ports.1"/>
+    <containedEdges identifier="E228" sources="//@children.9/@children.1/@ports.2" targets="//@children.9/@children.5/@ports.1"/>
+    <containedEdges identifier="E229" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.1/@ports.1"/>
+    <containedEdges identifier="E230" sources="//@children.9/@children.3/@ports.0" targets="//@children.9/@ports.1"/>
+    <containedEdges identifier="E231" sources="//@children.9/@children.3/@ports.0" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E232" sources="//@children.9/@children.4/@ports.1" targets="//@children.9/@children.0/@ports.1"/>
+    <containedEdges identifier="E233" sources="//@children.9/@children.5/@ports.0" targets="//@children.9/@ports.2"/>
+  </children>
+  <children identifier="N141">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L141" height="15.0" width="128.0" text="contactControlMonitor"/>
+    <ports identifier="P374" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P375" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P376" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.2" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P377" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.3" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N142">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L142" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P378" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P379" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.1" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P380" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.2" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P381" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.3" incomingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N143" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="128.0" text="contactControlMonitor"/>
+        <ports identifier="P382" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.0/@containedEdges.0 //@children.10/@children.0/@containedEdges.1 //@children.10/@children.0/@containedEdges.2 //@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E242" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E243" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E244" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E245" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N144" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L144" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P384" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N145" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L145" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P385" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P386" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N146" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L146" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P388" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N147" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L147" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P390" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E234" sources="//@children.10/@ports.0" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E235" sources="//@children.10/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E236" sources="//@children.10/@ports.2" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E237" sources="//@children.10/@ports.3" targets="//@children.10/@children.4/@ports.0"/>
+    <containedEdges identifier="E238" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E239" sources="//@children.10/@children.2/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+    <containedEdges identifier="E240" sources="//@children.10/@children.3/@ports.1" targets="//@children.10/@children.0/@ports.2"/>
+    <containedEdges identifier="E241" sources="//@children.10/@children.4/@ports.1" targets="//@children.10/@children.0/@ports.3"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.4" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.4" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.6" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.6" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.3" targets="//@children.6/@ports.4"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.3" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.2" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.6/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E17" sources="//@children.8/@ports.0" targets="//@children.10/@ports.3"/>
+  <containedEdges identifier="E18" sources="//@children.9/@ports.2" targets="//@children.5/@ports.5"/>
+  <containedEdges identifier="E19" sources="//@children.9/@ports.1" targets="//@children.5/@ports.4"/>
+  <containedEdges identifier="E20" sources="//@children.9/@ports.1" targets="//@children.10/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_trex_TREXNetworkV1.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_trex_TREXNetworkV1.elkg
@@ -1,0 +1,2677 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="104.0" text="reserveFeedRoller"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.28">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="78.0" text="Paper Radius"/>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.21 //@children.0/@containedEdges.22 //@children.0/@containedEdges.23" incomingEdges="//@children.0/@children.13/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.13/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.13/@containedEdges.0 //@children.0/@children.13/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.13/@containedEdges.4 //@children.0/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="407.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="119.0" text="initialRadiusSquared"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.13/@containedEdges.8 //@children.0/@children.13/@containedEdges.9 //@children.0/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="58.0" text="constzero"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="40.0" text="omega"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="65.0" text="constzero2"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="65.0" text="coreRadius"/>
+        <ports identifier="P65" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.14 //@children.0/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="37.0" text="Select"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.13/@containedEdges.1 //@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="45.0" text="Select2"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.13/@containedEdges.10 //@children.0/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E52" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.13/@children.5/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.13/@children.7/@ports.1"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.13/@children.0/@ports.2" targets="//@children.0/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.13/@children.1/@ports.1" targets="//@children.0/@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.13/@children.1/@ports.1" targets="//@children.0/@children.13/@children.2/@ports.1"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.13/@children.2/@ports.0" targets="//@children.0/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.13/@children.3/@ports.1" targets="//@children.0/@children.13/@children.0/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.8/@ports.1"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.9/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.13/@children.5/@ports.0" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.13/@children.6/@ports.2" targets="//@children.0/@children.13/@children.1/@ports.0"/>
+      <containedEdges identifier="E65" sources="//@children.0/@children.13/@children.7/@ports.0" targets="//@children.0/@children.13/@children.12/@ports.2"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.13/@children.8/@ports.0" targets="//@children.0/@children.13/@children.9/@ports.1"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.13/@children.8/@ports.0" targets="//@children.0/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.13/@children.9/@ports.2" targets="//@children.0/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E69" sources="//@children.0/@children.13/@children.10/@ports.1" targets="//@children.0/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.13/@children.11/@ports.1" targets="//@children.0/@children.13/@children.13/@ports.2"/>
+      <containedEdges identifier="E71" sources="//@children.0/@children.13/@children.12/@ports.1" targets="//@children.0/@children.13/@children.6/@ports.1"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.13/@children.13/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    </children>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.0 //@children.0/@children.14/@containedEdges.1 //@children.0/@children.14/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.24 //@children.0/@containedEdges.25 //@children.0/@containedEdges.26 //@children.0/@containedEdges.27" incomingEdges="//@children.0/@children.14/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.5 //@children.0/@children.14/@containedEdges.6 //@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P92" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="88.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P94" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P97" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P99" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+        <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P101" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+        <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.4 //@children.0/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="91.0" text="coreMassScale"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E73" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.4/@ports.1"/>
+      <containedEdges identifier="E74" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.5/@ports.1"/>
+      <containedEdges identifier="E75" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E76" sources="//@children.0/@children.14/@children.0/@ports.1" targets="//@children.0/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E77" sources="//@children.0/@children.14/@children.1/@ports.2" targets="//@children.0/@children.14/@children.11/@ports.0"/>
+      <containedEdges identifier="E78" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.3/@ports.1"/>
+      <containedEdges identifier="E79" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.12/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.14/@children.3/@ports.2" targets="//@children.0/@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.14/@children.4/@ports.0" targets="//@children.0/@children.14/@children.2/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.0/@children.14/@children.5/@ports.0" targets="//@children.0/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.14/@children.6/@ports.1" targets="//@children.0/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.14/@children.7/@ports.1" targets="//@children.0/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.14/@children.8/@ports.1" targets="//@children.0/@children.14/@children.10/@ports.1"/>
+      <containedEdges identifier="E87" sources="//@children.0/@children.14/@children.9/@ports.1" targets="//@children.0/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.14/@children.10/@ports.2" targets="//@children.0/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.0/@children.14/@children.11/@ports.2" targets="//@children.0/@children.14/@ports.1"/>
+      <containedEdges identifier="E90" sources="//@children.0/@children.14/@children.12/@ports.1" targets="//@children.0/@children.14/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N44" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E23" sources="//@children.0/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@ports.5" targets="//@children.0/@children.13/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.13/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.12/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.12/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.0/@children.15/@ports.2" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N45" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P117" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L48" height="15.0" width="101.0" text="ContactController"/>
+    <ports identifier="P119" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8" incomingEdges="//@children.4/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.4/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N49" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.3" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.6" incomingEdges="//@children.4/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="101.0" text="CompositeActor7"/>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.8" incomingEdges="//@children.4/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.7" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.10" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.9" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.12" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.11" incomingEdges="//@children.4/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L54" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P134" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P136" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P137" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N55">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L55" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P139" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.0 //@children.4/@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.2 //@children.4/@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N56" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L56" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P144" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N57" height="25.0" width="136.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L57" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P146" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N58" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L58" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P149" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P150" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N59" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P152" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P153" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N60" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L60" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.1 //@children.4/@children.5/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P155" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N61" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L61" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.4 //@children.4/@children.5/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P157" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N62" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L62" height="15.0" width="54.0" text="TrueGate"/>
+          <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P159" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.11 //@children.4/@children.5/@children.0/@containedEdges.12 //@children.4/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N63" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L63" height="15.0" width="79.0" text="VariableDelay"/>
+          <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P161" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N64" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L64" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.5/@children.0/@containedEdges.3 //@children.4/@children.5/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.5/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E106" sources="//@children.4/@children.5/@children.0/@ports.1" targets="//@children.4/@children.5/@children.0/@children.3/@ports.2"/>
+        <containedEdges identifier="E107" sources="//@children.4/@children.5/@children.0/@ports.1" targets="//@children.4/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E108" sources="//@children.4/@children.5/@children.0/@ports.2" targets="//@children.4/@children.5/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E109" sources="//@children.4/@children.5/@children.0/@ports.2" targets="//@children.4/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E110" sources="//@children.4/@children.5/@children.0/@ports.0" targets="//@children.4/@children.5/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E111" sources="//@children.4/@children.5/@children.0/@children.0/@ports.0" targets="//@children.4/@children.5/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E112" sources="//@children.4/@children.5/@children.0/@children.1/@ports.0" targets="//@children.4/@children.5/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E113" sources="//@children.4/@children.5/@children.0/@children.2/@ports.1" targets="//@children.4/@children.5/@children.0/@ports.3"/>
+        <containedEdges identifier="E114" sources="//@children.4/@children.5/@children.0/@children.3/@ports.1" targets="//@children.4/@children.5/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E115" sources="//@children.4/@children.5/@children.0/@children.4/@ports.1" targets="//@children.4/@children.5/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E116" sources="//@children.4/@children.5/@children.0/@children.5/@ports.1" targets="//@children.4/@children.5/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E117" sources="//@children.4/@children.5/@children.0/@children.6/@ports.1" targets="//@children.4/@children.5/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E118" sources="//@children.4/@children.5/@children.0/@children.6/@ports.1" targets="//@children.4/@children.5/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E119" sources="//@children.4/@children.5/@children.0/@children.6/@ports.1" targets="//@children.4/@children.5/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E120" sources="//@children.4/@children.5/@children.0/@children.7/@ports.1" targets="//@children.4/@children.5/@children.0/@ports.4"/>
+        <containedEdges identifier="E121" sources="//@children.4/@children.5/@children.0/@children.8/@ports.2" targets="//@children.4/@children.5/@children.0/@children.7/@ports.2"/>
+      </children>
+    </children>
+    <containedEdges identifier="E91" sources="//@children.4/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E92" sources="//@children.4/@ports.4" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E93" sources="//@children.4/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E94" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E95" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E96" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@ports.3"/>
+    <containedEdges identifier="E97" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E98" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E99" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+    <containedEdges identifier="E100" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.5/@ports.1"/>
+    <containedEdges identifier="E101" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E102" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.5/@ports.2"/>
+    <containedEdges identifier="E103" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E104" sources="//@children.4/@children.5/@ports.4" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E105" sources="//@children.4/@children.5/@ports.3" targets="//@children.4/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N65" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L65" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N66">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L66" height="15.0" width="89.0" text="topDeadCEnter"/>
+    <ports identifier="P167" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P168" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13" incomingEdges="//@children.6/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.6/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N67" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P170" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P172" height="8.0" width="8.0" x="9.333333015441895" y="46.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P174" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+      <ports identifier="P178" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.5 //@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P181" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P182" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N72" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L72" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+      <ports identifier="P183" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E122" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E123" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E124" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E125" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.5/@ports.1"/>
+    <containedEdges identifier="E126" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E127" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+    <containedEdges identifier="E128" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E129" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E130" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  </children>
+  <children identifier="N73">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L73" height="15.0" width="128.0" text="contactControlMonitor"/>
+    <ports identifier="P185" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P186" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P187" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P188" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.3" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N74">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L74" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P189" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P190" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P191" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.2" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P192" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.3" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N75" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L75" height="15.0" width="128.0" text="contactControlMonitor"/>
+        <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@children.0/@containedEdges.0 //@children.7/@children.0/@containedEdges.1 //@children.7/@children.0/@containedEdges.2 //@children.7/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E139" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E140" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E141" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E142" sources="//@children.7/@children.0/@ports.3" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N76" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P195" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P197" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N78" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L78" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P198" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P199" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N79" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L79" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P201" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E131" sources="//@children.7/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E132" sources="//@children.7/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E133" sources="//@children.7/@ports.2" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E134" sources="//@children.7/@ports.3" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E135" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E136" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.0/@ports.1"/>
+    <containedEdges identifier="E137" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.0/@ports.2"/>
+    <containedEdges identifier="E138" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N80">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L80" height="15.0" width="134.0" text="ShaftEncoderController"/>
+    <ports identifier="P202" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P203" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.1" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P204" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14 //@containedEdges.15" incomingEdges="//@children.8/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P205" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16" incomingEdges="//@children.8/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N81">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L81" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P206" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.0/@containedEdges.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P207" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.2" incomingEdges="//@children.8/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N82" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P209" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P211" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P214" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E154" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E155" sources="//@children.8/@children.0/@children.0/@ports.1" targets="//@children.8/@children.0/@ports.1"/>
+      <containedEdges identifier="E156" sources="//@children.8/@children.0/@children.1/@ports.0" targets="//@children.8/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N84" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L84" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.4" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P217" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N85" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="101.0" text="CompositeActor8"/>
+      <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.6" incomingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P219" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.5" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.8" incomingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P221" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.7" incomingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L87" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P222" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P223" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P224" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P225" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N88">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L88" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P226" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P227" height="8.0" width="8.0" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P228" height="8.0" width="8.0" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P229" height="8.0" width="8.0" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N89" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L89" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P230" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N90" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L90" height="15.0" width="53.0" text="TimeGap"/>
+          <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P233" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.3 //@children.8/@children.4/@children.0/@containedEdges.4 //@children.8/@children.4/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N91" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L91" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P236" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.6 //@children.8/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N92" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L92" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.6 //@children.8/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P238" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P239" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N93" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P240" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P241" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P242" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P244" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P245" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N95" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L95" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@children.4/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P247" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@children.4/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P248" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E157" sources="//@children.8/@children.4/@children.0/@ports.0" targets="//@children.8/@children.4/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E158" sources="//@children.8/@children.4/@children.0/@ports.1" targets="//@children.8/@children.4/@children.0/@children.1/@ports.0"/>
+        <containedEdges identifier="E159" sources="//@children.8/@children.4/@children.0/@children.0/@ports.0" targets="//@children.8/@children.4/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E160" sources="//@children.8/@children.4/@children.0/@children.1/@ports.1" targets="//@children.8/@children.4/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E161" sources="//@children.8/@children.4/@children.0/@children.1/@ports.1" targets="//@children.8/@children.4/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E162" sources="//@children.8/@children.4/@children.0/@children.1/@ports.1" targets="//@children.8/@children.4/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E163" sources="//@children.8/@children.4/@children.0/@children.2/@ports.2" targets="//@children.8/@children.4/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E164" sources="//@children.8/@children.4/@children.0/@children.2/@ports.2" targets="//@children.8/@children.4/@children.0/@children.5/@ports.2"/>
+        <containedEdges identifier="E165" sources="//@children.8/@children.4/@children.0/@children.3/@ports.2" targets="//@children.8/@children.4/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E166" sources="//@children.8/@children.4/@children.0/@children.4/@ports.1" targets="//@children.8/@children.4/@children.0/@ports.2"/>
+        <containedEdges identifier="E167" sources="//@children.8/@children.4/@children.0/@children.5/@ports.1" targets="//@children.8/@children.4/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E168" sources="//@children.8/@children.4/@children.0/@children.6/@ports.1" targets="//@children.8/@children.4/@children.0/@ports.3"/>
+      </children>
+    </children>
+    <containedEdges identifier="E143" sources="//@children.8/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.8/@ports.1" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E145" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.4/@ports.0"/>
+    <containedEdges identifier="E146" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.4/@ports.1"/>
+    <containedEdges identifier="E147" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.1/@ports.1"/>
+    <containedEdges identifier="E148" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E149" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.2/@ports.1"/>
+    <containedEdges identifier="E150" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@ports.3"/>
+    <containedEdges identifier="E151" sources="//@children.8/@children.3/@ports.0" targets="//@children.8/@children.3/@ports.1"/>
+    <containedEdges identifier="E152" sources="//@children.8/@children.4/@ports.3" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E153" sources="//@children.8/@children.4/@ports.2" targets="//@children.8/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N96">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L96" height="15.0" width="121.0" text="reserveFeedMonitor2"/>
+    <ports identifier="P249" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.2" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N97">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L97" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P252" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.0/@containedEdges.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P253" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.3" incomingEdges="//@children.9/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N98" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L98" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P255" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P256" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.9/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N99" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P257" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P260" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P261" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E175" sources="//@children.9/@children.0/@ports.0" targets="//@children.9/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E176" sources="//@children.9/@children.0/@children.0/@ports.1" targets="//@children.9/@children.0/@ports.1"/>
+      <containedEdges identifier="E177" sources="//@children.9/@children.0/@children.1/@ports.0" targets="//@children.9/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N100" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L100" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P263" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.4" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N101">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L101" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P264" height="8.0" width="8.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P265" height="8.0" width="8.0" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P266" height="8.0" width="8.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N102">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L102" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P267" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P268" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P269" height="8.0" width="8.0" outgoingEdges="//@children.9/@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N103" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L103" height="15.0" width="150.0" text="reserveFeedPaperVelocity"/>
+          <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@children.2/@children.0/@containedEdges.0 //@children.9/@children.2/@children.0/@containedEdges.1 //@children.9/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E178" sources="//@children.9/@children.2/@children.0/@ports.0" targets="//@children.9/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E179" sources="//@children.9/@children.2/@children.0/@ports.1" targets="//@children.9/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E180" sources="//@children.9/@children.2/@children.0/@ports.2" targets="//@children.9/@children.2/@children.0/@children.0/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E169" sources="//@children.9/@ports.2" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E170" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E171" sources="//@children.9/@ports.1" targets="//@children.9/@children.2/@ports.1"/>
+    <containedEdges identifier="E172" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E173" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.2/@ports.2"/>
+    <containedEdges identifier="E174" sources="//@children.9/@children.1/@ports.0" targets="//@children.9/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N104">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L104" height="15.0" width="125.0" text="ReserveTargetProfile2"/>
+    <ports identifier="P271" height="8.0" width="8.0" outgoingEdges="//@containedEdges.17 //@containedEdges.18" incomingEdges="//@children.10/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P272" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N105" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L105" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.2" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P274" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N106">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L106" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P275" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P276" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N107">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L107" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P277" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.0 //@children.10/@children.1/@children.0/@containedEdges.1 //@children.10/@children.1/@children.0/@containedEdges.2 //@children.10/@children.1/@children.0/@containedEdges.3 //@children.10/@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P278" height="8.0" width="8.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N108" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L108" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P279" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P282" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P283" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N109" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L109" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P284" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.6 //@children.10/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N110" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L110" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P287" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.8 //@children.10/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N111" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L111" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P288" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P289" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N112" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P290" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P294" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N114" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L114" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P296" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N115" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L115" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P298" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.14 //@children.10/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N116" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L116" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P300" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N117" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P301" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N118" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L118" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.16 //@children.10/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P305" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N119" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P306" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P307" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N120" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L120" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P309" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N121" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L121" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P311" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P312" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P313" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N122" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L122" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.0 //@children.10/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P315" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N123" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L123" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P317" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P318" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P319" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N124" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L124" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.1 //@children.10/@children.1/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P321" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N125" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L125" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.13 //@children.10/@children.1/@children.0/@containedEdges.19 //@children.10/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P323" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N126" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L126" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P326" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N127" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L127" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P328" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P329" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P330" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N128" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L128" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.20 //@children.10/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P332" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N129" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L129" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P333" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N130" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L130" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P336" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N131" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L131" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N132" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L132" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P340" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P341" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N133" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L133" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P342" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P343" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P344" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N134" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L134" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P346" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P347" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N135" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L135" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P348" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P349" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.38 //@children.10/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N136" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L136" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P351" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.10/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E185" sources="//@children.10/@children.1/@children.0/@ports.0" targets="//@children.10/@children.1/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E186" sources="//@children.10/@children.1/@children.0/@ports.0" targets="//@children.10/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E187" sources="//@children.10/@children.1/@children.0/@ports.0" targets="//@children.10/@children.1/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E188" sources="//@children.10/@children.1/@children.0/@ports.0" targets="//@children.10/@children.1/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E189" sources="//@children.10/@children.1/@children.0/@ports.0" targets="//@children.10/@children.1/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E190" sources="//@children.10/@children.1/@children.0/@children.0/@ports.0" targets="//@children.10/@children.1/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E191" sources="//@children.10/@children.1/@children.0/@children.1/@ports.0" targets="//@children.10/@children.1/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E192" sources="//@children.10/@children.1/@children.0/@children.1/@ports.0" targets="//@children.10/@children.1/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E193" sources="//@children.10/@children.1/@children.0/@children.2/@ports.1" targets="//@children.10/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E194" sources="//@children.10/@children.1/@children.0/@children.2/@ports.1" targets="//@children.10/@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E195" sources="//@children.10/@children.1/@children.0/@children.3/@ports.1" targets="//@children.10/@children.1/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E196" sources="//@children.10/@children.1/@children.0/@children.4/@ports.0" targets="//@children.10/@children.1/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E197" sources="//@children.10/@children.1/@children.0/@children.5/@ports.2" targets="//@children.10/@children.1/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E198" sources="//@children.10/@children.1/@children.0/@children.6/@ports.1" targets="//@children.10/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E199" sources="//@children.10/@children.1/@children.0/@children.7/@ports.1" targets="//@children.10/@children.1/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E200" sources="//@children.10/@children.1/@children.0/@children.7/@ports.1" targets="//@children.10/@children.1/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E201" sources="//@children.10/@children.1/@children.0/@children.8/@ports.1" targets="//@children.10/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E202" sources="//@children.10/@children.1/@children.0/@children.9/@ports.0" targets="//@children.10/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E203" sources="//@children.10/@children.1/@children.0/@children.10/@ports.2" targets="//@children.10/@children.1/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E204" sources="//@children.10/@children.1/@children.0/@children.11/@ports.1" targets="//@children.10/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E205" sources="//@children.10/@children.1/@children.0/@children.12/@ports.1" targets="//@children.10/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E206" sources="//@children.10/@children.1/@children.0/@children.13/@ports.2" targets="//@children.10/@children.1/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E207" sources="//@children.10/@children.1/@children.0/@children.13/@ports.3" targets="//@children.10/@children.1/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E208" sources="//@children.10/@children.1/@children.0/@children.14/@ports.1" targets="//@children.10/@children.1/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E209" sources="//@children.10/@children.1/@children.0/@children.15/@ports.2" targets="//@children.10/@children.1/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E210" sources="//@children.10/@children.1/@children.0/@children.15/@ports.3" targets="//@children.10/@children.1/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E211" sources="//@children.10/@children.1/@children.0/@children.16/@ports.1" targets="//@children.10/@children.1/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E212" sources="//@children.10/@children.1/@children.0/@children.17/@ports.1" targets="//@children.10/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E213" sources="//@children.10/@children.1/@children.0/@children.18/@ports.2" targets="//@children.10/@children.1/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E214" sources="//@children.10/@children.1/@children.0/@children.19/@ports.2" targets="//@children.10/@children.1/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E215" sources="//@children.10/@children.1/@children.0/@children.19/@ports.3" targets="//@children.10/@children.1/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E216" sources="//@children.10/@children.1/@children.0/@children.20/@ports.1" targets="//@children.10/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E217" sources="//@children.10/@children.1/@children.0/@children.21/@ports.0" targets="//@children.10/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E218" sources="//@children.10/@children.1/@children.0/@children.22/@ports.1" targets="//@children.10/@children.1/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E219" sources="//@children.10/@children.1/@children.0/@children.23/@ports.0" targets="//@children.10/@children.1/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E220" sources="//@children.10/@children.1/@children.0/@children.24/@ports.1" targets="//@children.10/@children.1/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E221" sources="//@children.10/@children.1/@children.0/@children.25/@ports.1" targets="//@children.10/@children.1/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E222" sources="//@children.10/@children.1/@children.0/@children.26/@ports.1" targets="//@children.10/@children.1/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E223" sources="//@children.10/@children.1/@children.0/@children.27/@ports.1" targets="//@children.10/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E224" sources="//@children.10/@children.1/@children.0/@children.27/@ports.1" targets="//@children.10/@children.1/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E225" sources="//@children.10/@children.1/@children.0/@children.28/@ports.1" targets="//@children.10/@children.1/@children.0/@children.14/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E181" sources="//@children.10/@ports.1" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E182" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@ports.0"/>
+    <containedEdges identifier="E183" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@ports.1"/>
+    <containedEdges identifier="E184" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N137">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L137" height="15.0" width="109.0" text="ReserveController2"/>
+    <ports identifier="P352" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P353" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.1" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P354" height="8.0" width="8.0" outgoingEdges="//@containedEdges.20" incomingEdges="//@children.11/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P355" height="8.0" width="8.0" outgoingEdges="//@containedEdges.19" incomingEdges="//@children.11/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P356" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.2" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N138" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L138" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.4" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P358" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.3" incomingEdges="//@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N139">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L139" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P359" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.1/@containedEdges.0" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P360" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.5" incomingEdges="//@children.11/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N140" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L140" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P361" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P362" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P363" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.11/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N141" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L141" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P364" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P367" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P368" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E238" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E239" sources="//@children.11/@children.1/@children.0/@ports.1" targets="//@children.11/@children.1/@ports.1"/>
+      <containedEdges identifier="E240" sources="//@children.11/@children.1/@children.1/@ports.0" targets="//@children.11/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N142" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L142" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.7" incomingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P370" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.6" incomingEdges="//@children.11/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N143" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L143" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.9" incomingEdges="//@children.11/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P372" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.8" incomingEdges="//@children.11/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N144">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L144" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P373" height="8.0" width="8.0" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P374" height="8.0" width="8.0" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P375" height="8.0" width="8.0" incomingEdges="//@children.11/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P376" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P377" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N145">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L145" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P378" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.0 //@children.11/@children.4/@children.0/@containedEdges.1 //@children.11/@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P379" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P380" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P381" height="8.0" width="8.0" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P382" height="8.0" width="8.0" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N146" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L146" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P384" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.5 //@children.11/@children.4/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P385" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N147" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L147" height="15.0" width="68.0" text="TimedDelay"/>
+          <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P387" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N148" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L148" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P388" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P389" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.8 //@children.11/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P390" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N149" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L149" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P391" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P393" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N150" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L150" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P394" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P395" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N151" height="25.0" width="70.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L151" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P396" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P397" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N152" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L152" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P400" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N153" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L153" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P401" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.6 //@children.11/@children.4/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P402" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.11/@children.4/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P403" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.11/@children.4/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E241" sources="//@children.11/@children.4/@children.0/@ports.0" targets="//@children.11/@children.4/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E242" sources="//@children.11/@children.4/@children.0/@ports.0" targets="//@children.11/@children.4/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E243" sources="//@children.11/@children.4/@children.0/@ports.0" targets="//@children.11/@children.4/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E244" sources="//@children.11/@children.4/@children.0/@ports.1" targets="//@children.11/@children.4/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E245" sources="//@children.11/@children.4/@children.0/@ports.2" targets="//@children.11/@children.4/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E246" sources="//@children.11/@children.4/@children.0/@children.0/@ports.1" targets="//@children.11/@children.4/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E247" sources="//@children.11/@children.4/@children.0/@children.0/@ports.1" targets="//@children.11/@children.4/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E248" sources="//@children.11/@children.4/@children.0/@children.1/@ports.1" targets="//@children.11/@children.4/@children.0/@ports.3"/>
+        <containedEdges identifier="E249" sources="//@children.11/@children.4/@children.0/@children.2/@ports.1" targets="//@children.11/@children.4/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E250" sources="//@children.11/@children.4/@children.0/@children.2/@ports.1" targets="//@children.11/@children.4/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E251" sources="//@children.11/@children.4/@children.0/@children.3/@ports.2" targets="//@children.11/@children.4/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E252" sources="//@children.11/@children.4/@children.0/@children.4/@ports.0" targets="//@children.11/@children.4/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E253" sources="//@children.11/@children.4/@children.0/@children.5/@ports.0" targets="//@children.11/@children.4/@children.0/@children.7/@ports.2"/>
+        <containedEdges identifier="E254" sources="//@children.11/@children.4/@children.0/@children.6/@ports.2" targets="//@children.11/@children.4/@children.0/@ports.4"/>
+        <containedEdges identifier="E255" sources="//@children.11/@children.4/@children.0/@children.7/@ports.1" targets="//@children.11/@children.4/@children.0/@children.1/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E226" sources="//@children.11/@ports.0" targets="//@children.11/@children.1/@ports.0"/>
+    <containedEdges identifier="E227" sources="//@children.11/@ports.1" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E228" sources="//@children.11/@ports.4" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E229" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.4/@ports.0"/>
+    <containedEdges identifier="E230" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@children.0/@ports.1"/>
+    <containedEdges identifier="E231" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@children.4/@ports.1"/>
+    <containedEdges identifier="E232" sources="//@children.11/@children.2/@ports.1" targets="//@children.11/@children.4/@ports.2"/>
+    <containedEdges identifier="E233" sources="//@children.11/@children.2/@ports.0" targets="//@children.11/@children.2/@ports.1"/>
+    <containedEdges identifier="E234" sources="//@children.11/@children.3/@ports.1" targets="//@children.11/@ports.2"/>
+    <containedEdges identifier="E235" sources="//@children.11/@children.3/@ports.0" targets="//@children.11/@children.3/@ports.1"/>
+    <containedEdges identifier="E236" sources="//@children.11/@children.4/@ports.4" targets="//@children.11/@ports.3"/>
+    <containedEdges identifier="E237" sources="//@children.11/@children.4/@ports.3" targets="//@children.11/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N154" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L154" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P404" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P405" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P406" height="8.0" width="8.0" x="29.0" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.4" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.4" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.3" targets="//@children.11/@ports.4"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.2" targets="//@children.4/@ports.4"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.8/@ports.3" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.0" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E19" sources="//@children.10/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E20" sources="//@children.11/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.11/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.12/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_trex_TREXNoNetworkAllDigital.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_trex_TREXNoNetworkAllDigital.elkg
@@ -1,0 +1,2586 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="104.0" text="reserveFeedRoller"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.0/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.0/@containedEdges.30">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="MultiplyDivide4"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="87.0" text="MultiplyDivide5"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="78.0" text="Paper Radius"/>
+      <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.21 //@children.0/@containedEdges.22 //@children.0/@containedEdges.23 //@children.0/@containedEdges.24" incomingEdges="//@children.0/@children.13/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.13/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.13/@containedEdges.0 //@children.0/@children.13/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.13/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.13/@containedEdges.4 //@children.0/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="407.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="119.0" text="initialRadiusSquared"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="407.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="40.0" text="Limiter"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.13/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.13/@containedEdges.8 //@children.0/@children.13/@containedEdges.9 //@children.0/@children.13/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="58.0" text="constzero"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="40.0" text="omega"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@children.13/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="65.0" text="constzero2"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="65.0" text="coreRadius"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.13/@containedEdges.14 //@children.0/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.13/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="68.0" text="Comparator"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@children.13/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@children.13/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="54.0" text="TrueGate"/>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.13/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="29.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="59.0" text="Sequence"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.0/@children.13/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="37.0" text="Select"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.13/@containedEdges.1 //@children.0/@children.13/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.13/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.13/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="47.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="45.0" text="Select2"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.0/@children.13/@containedEdges.10 //@children.0/@children.13/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.0/@children.13/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.0/@children.13/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E56" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.13/@children.5/@ports.1"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.13/@ports.2" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.13/@children.7/@ports.1"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.13/@children.0/@ports.2" targets="//@children.0/@children.13/@children.4/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.13/@children.1/@ports.1" targets="//@children.0/@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.13/@children.1/@ports.1" targets="//@children.0/@children.13/@children.2/@ports.1"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.13/@children.2/@ports.0" targets="//@children.0/@children.13/@children.3/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.13/@children.3/@ports.1" targets="//@children.0/@children.13/@children.0/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.8/@ports.1"/>
+      <containedEdges identifier="E65" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.9/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.13/@children.4/@ports.1" targets="//@children.0/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.13/@children.5/@ports.0" targets="//@children.0/@children.13/@children.12/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.13/@children.6/@ports.2" targets="//@children.0/@children.13/@children.1/@ports.0"/>
+      <containedEdges identifier="E69" sources="//@children.0/@children.13/@children.7/@ports.0" targets="//@children.0/@children.13/@children.12/@ports.2"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.13/@children.8/@ports.0" targets="//@children.0/@children.13/@children.9/@ports.1"/>
+      <containedEdges identifier="E71" sources="//@children.0/@children.13/@children.8/@ports.0" targets="//@children.0/@children.13/@children.13/@ports.0"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.13/@children.9/@ports.2" targets="//@children.0/@children.13/@children.10/@ports.0"/>
+      <containedEdges identifier="E73" sources="//@children.0/@children.13/@children.10/@ports.1" targets="//@children.0/@children.13/@children.11/@ports.0"/>
+      <containedEdges identifier="E74" sources="//@children.0/@children.13/@children.11/@ports.1" targets="//@children.0/@children.13/@children.13/@ports.2"/>
+      <containedEdges identifier="E75" sources="//@children.0/@children.13/@children.12/@ports.1" targets="//@children.0/@children.13/@children.6/@ports.1"/>
+      <containedEdges identifier="E76" sources="//@children.0/@children.13/@children.13/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    </children>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="96.0" text="momentOfInertia"/>
+      <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.0 //@children.0/@children.14/@containedEdges.1 //@children.0/@children.14/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.25 //@children.0/@containedEdges.26 //@children.0/@containedEdges.27 //@children.0/@containedEdges.28" incomingEdges="//@children.0/@children.14/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="121.0" text="UnaryMathFunction2"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.5 //@children.0/@children.14/@containedEdges.6 //@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="25.0" width="75.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P93" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="88.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P95" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="121.0" text="UnaryMathFunction3"/>
+        <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P98" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="121.0" text="halfOfmassOfFullRoll"/>
+        <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N39" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="121.0" text="UnaryMathFunction4"/>
+        <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="121.0" text="UnaryMathFunction6"/>
+        <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.14/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P107" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="80.0" text="AddSubtract3"/>
+        <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.4 //@children.0/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P110" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="91.0" text="coreMassScale"/>
+        <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E77" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.4/@ports.1"/>
+      <containedEdges identifier="E78" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.5/@ports.1"/>
+      <containedEdges identifier="E79" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.6/@ports.0"/>
+      <containedEdges identifier="E80" sources="//@children.0/@children.14/@children.0/@ports.1" targets="//@children.0/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.0/@children.14/@children.1/@ports.2" targets="//@children.0/@children.14/@children.11/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.3/@ports.1"/>
+      <containedEdges identifier="E83" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.8/@ports.0"/>
+      <containedEdges identifier="E84" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.12/@ports.0"/>
+      <containedEdges identifier="E85" sources="//@children.0/@children.14/@children.3/@ports.2" targets="//@children.0/@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E86" sources="//@children.0/@children.14/@children.4/@ports.0" targets="//@children.0/@children.14/@children.2/@ports.0"/>
+      <containedEdges identifier="E87" sources="//@children.0/@children.14/@children.5/@ports.0" targets="//@children.0/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E88" sources="//@children.0/@children.14/@children.6/@ports.1" targets="//@children.0/@children.14/@children.9/@ports.0"/>
+      <containedEdges identifier="E89" sources="//@children.0/@children.14/@children.7/@ports.1" targets="//@children.0/@children.14/@children.1/@ports.0"/>
+      <containedEdges identifier="E90" sources="//@children.0/@children.14/@children.8/@ports.1" targets="//@children.0/@children.14/@children.10/@ports.1"/>
+      <containedEdges identifier="E91" sources="//@children.0/@children.14/@children.9/@ports.1" targets="//@children.0/@children.14/@children.10/@ports.0"/>
+      <containedEdges identifier="E92" sources="//@children.0/@children.14/@children.10/@ports.2" targets="//@children.0/@children.14/@children.7/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.0/@children.14/@children.11/@ports.2" targets="//@children.0/@children.14/@ports.1"/>
+      <containedEdges identifier="E94" sources="//@children.0/@children.14/@children.12/@ports.1" targets="//@children.0/@children.14/@children.11/@ports.0"/>
+    </children>
+    <children identifier="N44" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E25" sources="//@children.0/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@ports.5" targets="//@children.0/@children.13/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.13/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.12/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.13/@ports.0" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E52" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E53" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.12/@ports.1"/>
+    <containedEdges identifier="E54" sources="//@children.0/@children.15/@ports.2" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.0/@children.16/@ports.1" targets="//@children.0/@ports.6"/>
+  </children>
+  <children identifier="N46" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L46" height="15.0" width="144.0" text="reserveFeedPaperRadius"/>
+    <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N47" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P120" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="76.0" text="SingleEvent2"/>
+    <ports identifier="P121" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L49" height="15.0" width="101.0" text="ContactController"/>
+    <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.3" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P124" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10" incomingEdges="//@children.4/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P125" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8" incomingEdges="//@children.4/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P126" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P127" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P128" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.4/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N50" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P130" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.7" incomingEdges="//@children.4/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P132" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.6" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="101.0" text="CompositeActor7"/>
+      <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.9" incomingEdges="//@children.4/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P134" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.8" incomingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.11" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P136" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.10" incomingEdges="//@children.4/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.13" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P138" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.12" incomingEdges="//@children.4/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="101.0" text="CompositeActor8"/>
+      <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.15" incomingEdges="//@children.4/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.14" incomingEdges="//@children.4/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.17" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P142" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.16" incomingEdges="//@children.4/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N57">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L57" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P143" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P144" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P146" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P149" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N58">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L58" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P150" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P151" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.0 //@children.4/@children.7/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P152" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P153" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P154" height="8.0" width="8.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P155" height="8.0" width="8.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.25">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P156" height="8.0" width="8.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="6"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N59" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L59" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P157" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N60" height="25.0" width="38.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L60" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P159" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N61" height="25.0" width="136.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L61" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P161" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N62" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L62" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P164" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P165" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N63" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L63" height="15.0" width="53.0" text="TimeGap"/>
+          <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P167" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.9 //@children.4/@children.7/@children.0/@containedEdges.10 //@children.4/@children.7/@children.0/@containedEdges.11 //@children.4/@children.7/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N64" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L64" height="15.0" width="80.0" text="MultiplyDivide"/>
+          <ports identifier="P168" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P169" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P170" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.13 //@children.4/@children.7/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N65" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L65" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P172" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P173" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N66" height="25.0" width="32.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L66" height="15.0" width="82.0" text="LogicFunction"/>
+          <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.1 //@children.4/@children.7/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P175" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N67" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L67" height="15.0" width="87.0" text="MultiplyDivide2"/>
+          <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.13 //@children.4/@children.7/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P178" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N68" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L68" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P179" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P180" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P181" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N69" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L69" height="15.0" width="56.0" text="Register2"/>
+          <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P183" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P184" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N70" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L70" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.2 //@children.4/@children.7/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P186" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N71" height="31.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L71" height="15.0" width="54.0" text="TrueGate"/>
+          <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P188" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.21 //@children.4/@children.7/@children.0/@containedEdges.22 //@children.4/@children.7/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N72" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L72" height="15.0" width="87.0" text="MultiplyDivide3"/>
+          <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.7 //@children.4/@children.7/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P191" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N73" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L73" height="15.0" width="69.0" text="TimeDelay3"/>
+          <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P193" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.7/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P194" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.4/@children.7/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E116" sources="//@children.4/@children.7/@children.0/@ports.1" targets="//@children.4/@children.7/@children.0/@children.6/@ports.2"/>
+        <containedEdges identifier="E117" sources="//@children.4/@children.7/@children.0/@ports.1" targets="//@children.4/@children.7/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E118" sources="//@children.4/@children.7/@children.0/@ports.0" targets="//@children.4/@children.7/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E119" sources="//@children.4/@children.7/@children.0/@ports.2" targets="//@children.4/@children.7/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E120" sources="//@children.4/@children.7/@children.0/@ports.3" targets="//@children.4/@children.7/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E121" sources="//@children.4/@children.7/@children.0/@children.0/@ports.0" targets="//@children.4/@children.7/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E122" sources="//@children.4/@children.7/@children.0/@children.1/@ports.0" targets="//@children.4/@children.7/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E123" sources="//@children.4/@children.7/@children.0/@children.2/@ports.0" targets="//@children.4/@children.7/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E124" sources="//@children.4/@children.7/@children.0/@children.3/@ports.1" targets="//@children.4/@children.7/@children.0/@ports.4"/>
+        <containedEdges identifier="E125" sources="//@children.4/@children.7/@children.0/@children.4/@ports.1" targets="//@children.4/@children.7/@children.0/@children.0/@ports.1"/>
+        <containedEdges identifier="E126" sources="//@children.4/@children.7/@children.0/@children.4/@ports.1" targets="//@children.4/@children.7/@children.0/@children.2/@ports.1"/>
+        <containedEdges identifier="E127" sources="//@children.4/@children.7/@children.0/@children.4/@ports.1" targets="//@children.4/@children.7/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E128" sources="//@children.4/@children.7/@children.0/@children.4/@ports.1" targets="//@children.4/@children.7/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E129" sources="//@children.4/@children.7/@children.0/@children.5/@ports.2" targets="//@children.4/@children.7/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E130" sources="//@children.4/@children.7/@children.0/@children.5/@ports.2" targets="//@children.4/@children.7/@children.0/@children.10/@ports.2"/>
+        <containedEdges identifier="E131" sources="//@children.4/@children.7/@children.0/@children.6/@ports.1" targets="//@children.4/@children.7/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E132" sources="//@children.4/@children.7/@children.0/@children.7/@ports.1" targets="//@children.4/@children.7/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E133" sources="//@children.4/@children.7/@children.0/@children.8/@ports.2" targets="//@children.4/@children.7/@children.0/@children.9/@ports.0"/>
+        <containedEdges identifier="E134" sources="//@children.4/@children.7/@children.0/@children.9/@ports.1" targets="//@children.4/@children.7/@children.0/@ports.6"/>
+        <containedEdges identifier="E135" sources="//@children.4/@children.7/@children.0/@children.10/@ports.1" targets="//@children.4/@children.7/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E136" sources="//@children.4/@children.7/@children.0/@children.11/@ports.1" targets="//@children.4/@children.7/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E137" sources="//@children.4/@children.7/@children.0/@children.12/@ports.1" targets="//@children.4/@children.7/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E138" sources="//@children.4/@children.7/@children.0/@children.12/@ports.1" targets="//@children.4/@children.7/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E139" sources="//@children.4/@children.7/@children.0/@children.12/@ports.1" targets="//@children.4/@children.7/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E140" sources="//@children.4/@children.7/@children.0/@children.13/@ports.2" targets="//@children.4/@children.7/@children.0/@children.14/@ports.2"/>
+        <containedEdges identifier="E141" sources="//@children.4/@children.7/@children.0/@children.14/@ports.1" targets="//@children.4/@children.7/@children.0/@ports.5"/>
+      </children>
+    </children>
+    <containedEdges identifier="E95" sources="//@children.4/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E96" sources="//@children.4/@ports.4" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E97" sources="//@children.4/@ports.5" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E98" sources="//@children.4/@ports.0" targets="//@children.4/@children.6/@ports.0"/>
+    <containedEdges identifier="E99" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E100" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E101" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@ports.3"/>
+    <containedEdges identifier="E102" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E103" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E104" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+    <containedEdges identifier="E105" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.7/@ports.1"/>
+    <containedEdges identifier="E106" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E107" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.7/@ports.3"/>
+    <containedEdges identifier="E108" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E109" sources="//@children.4/@children.5/@ports.1" targets="//@children.4/@ports.6"/>
+    <containedEdges identifier="E110" sources="//@children.4/@children.5/@ports.0" targets="//@children.4/@children.5/@ports.1"/>
+    <containedEdges identifier="E111" sources="//@children.4/@children.6/@ports.1" targets="//@children.4/@children.7/@ports.2"/>
+    <containedEdges identifier="E112" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@children.6/@ports.1"/>
+    <containedEdges identifier="E113" sources="//@children.4/@children.7/@ports.6" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E114" sources="//@children.4/@children.7/@ports.5" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E115" sources="//@children.4/@children.7/@ports.4" targets="//@children.4/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N74" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L74" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P195" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N75">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L75" height="15.0" width="89.0" text="topDeadCEnter"/>
+    <ports identifier="P196" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P197" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17" incomingEdges="//@children.6/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P198" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.6/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N76" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P199" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P201" height="8.0" width="8.0" x="9.333333015441895" y="46.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P203" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P204" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N78" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L78" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P206" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N79" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L79" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+      <ports identifier="P207" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.5 //@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N80" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L80" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P210" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P211" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N81" height="46.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L81" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+      <ports identifier="P212" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E142" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.3/@ports.1"/>
+    <containedEdges identifier="E145" sources="//@children.6/@children.1/@ports.2" targets="//@children.6/@children.5/@ports.1"/>
+    <containedEdges identifier="E146" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E147" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+    <containedEdges identifier="E148" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E149" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E150" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  </children>
+  <children identifier="N82">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L82" height="15.0" width="128.0" text="contactControlMonitor"/>
+    <ports identifier="P214" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P215" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P216" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.2" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P217" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.3" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N83">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L83" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P218" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P219" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.1" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P220" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.2" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P221" height="8.0" width="8.0" outgoingEdges="//@children.7/@children.0/@containedEdges.3" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N84" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="128.0" text="contactControlMonitor"/>
+        <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@children.0/@containedEdges.0 //@children.7/@children.0/@containedEdges.1 //@children.7/@children.0/@containedEdges.2 //@children.7/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E159" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E160" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E161" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E162" sources="//@children.7/@children.0/@ports.3" targets="//@children.7/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N85" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L85" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P224" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N86" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L86" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P226" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N87" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L87" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P228" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N88" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L88" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P230" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E151" sources="//@children.7/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E152" sources="//@children.7/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E153" sources="//@children.7/@ports.2" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E154" sources="//@children.7/@ports.3" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E155" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E156" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.0/@ports.1"/>
+    <containedEdges identifier="E157" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.0/@ports.2"/>
+    <containedEdges identifier="E158" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N89" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L89" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N90" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L90" height="15.0" width="73.0" text="WaitingTime"/>
+    <ports identifier="P233" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P234" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N91" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L91" height="15.0" width="68.0" text="ModelDelay"/>
+    <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N92">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L92" height="15.0" width="121.0" text="reserveFeedMonitor2"/>
+    <ports identifier="P237" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N93">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L93" height="15.0" width="101.0" text="CompositeActor2"/>
+      <ports identifier="P240" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.0" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P241" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.3" incomingEdges="//@children.11/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N94" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L94" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P243" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P244" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.11/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N95" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L95" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P245" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P246" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P248" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P249" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E169" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E170" sources="//@children.11/@children.0/@children.0/@ports.1" targets="//@children.11/@children.0/@ports.1"/>
+      <containedEdges identifier="E171" sources="//@children.11/@children.0/@children.1/@ports.0" targets="//@children.11/@children.0/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N96" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L96" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P250" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.5" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P251" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.4" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N97">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L97" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P252" height="8.0" width="8.0" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P253" height="8.0" width="8.0" incomingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P254" height="8.0" width="8.0" incomingEdges="//@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N98">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L98" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P255" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P256" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P257" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <children identifier="N99" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L99" height="15.0" width="150.0" text="reserveFeedPaperVelocity"/>
+          <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@children.2/@children.0/@containedEdges.0 //@children.11/@children.2/@children.0/@containedEdges.1 //@children.11/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E172" sources="//@children.11/@children.2/@children.0/@ports.0" targets="//@children.11/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E173" sources="//@children.11/@children.2/@children.0/@ports.1" targets="//@children.11/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E174" sources="//@children.11/@children.2/@children.0/@ports.2" targets="//@children.11/@children.2/@children.0/@children.0/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E163" sources="//@children.11/@ports.2" targets="//@children.11/@children.1/@ports.0"/>
+    <containedEdges identifier="E164" sources="//@children.11/@ports.0" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E165" sources="//@children.11/@ports.1" targets="//@children.11/@children.2/@ports.1"/>
+    <containedEdges identifier="E166" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E167" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@children.2/@ports.2"/>
+    <containedEdges identifier="E168" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N100">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L100" height="15.0" width="125.0" text="ReserveTargetProfile2"/>
+    <ports identifier="P259" height="8.0" width="8.0" outgoingEdges="//@containedEdges.20 //@containedEdges.21" incomingEdges="//@children.12/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P260" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N101" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L101" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.2" incomingEdges="//@children.12/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P262" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.1" incomingEdges="//@children.12/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N102">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L102" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P263" height="8.0" width="8.0" incomingEdges="//@children.12/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P264" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N103">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L103" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P265" height="8.0" width="8.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.0 //@children.12/@children.1/@children.0/@containedEdges.1 //@children.12/@children.1/@children.0/@containedEdges.2 //@children.12/@children.1/@children.0/@containedEdges.3 //@children.12/@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P266" height="8.0" width="8.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.27">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N104" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L104" height="15.0" width="81.0" text="DiscreteClock"/>
+          <ports identifier="P267" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P269" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P270" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-3"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P271" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+            <properties key="org.eclipse.elk.port.index" value="-4"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N105" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L105" height="15.0" width="71.0" text="CurrentTime"/>
+          <ports identifier="P272" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.6 //@children.12/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N106" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L106" height="15.0" width="34.0" text="Scale"/>
+          <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P275" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.8 //@children.12/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N107" height="25.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L107" height="15.0" width="72.0" text="TrigFunction"/>
+          <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P277" height="8.0" width="8.0" x="31.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N108" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L108" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P278" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N109" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L109" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P280" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P282" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N110" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L110" height="15.0" width="41.0" text="Scale2"/>
+          <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P284" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N111" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L111" height="15.0" width="41.0" text="Scale3"/>
+          <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P286" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.14 //@children.12/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N112" height="25.0" width="28.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="79.0" text="TrigFunction2"/>
+          <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P288" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="25.0" width="59.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P289" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N114" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L114" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.16 //@children.12/@children.1/@children.0/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P293" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N115" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L115" height="15.0" width="41.0" text="Scale4"/>
+          <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.18">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P295" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N116" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L116" height="15.0" width="41.0" text="Scale5"/>
+          <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P297" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N117" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="87.0" text="BooleanSwitch"/>
+          <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P299" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P300" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P301" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N118" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L118" height="15.0" width="37.0" text="Merge"/>
+          <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.0 //@children.12/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P303" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N119" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="94.0" text="BooleanSwitch2"/>
+          <ports identifier="P304" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P305" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P306" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P307" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N120" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L120" height="15.0" width="44.0" text="Merge2"/>
+          <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.1 //@children.12/@children.1/@children.0/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P309" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.26">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N121" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L121" height="15.0" width="44.0" text="Merge3"/>
+          <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.13 //@children.12/@children.1/@children.0/@containedEdges.19 //@children.12/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P311" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N122" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L122" height="15.0" width="80.0" text="AddSubtract3"/>
+          <ports identifier="P312" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P314" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N123" height="46.0" width="39.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L123" height="15.0" width="94.0" text="BooleanSwitch3"/>
+          <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P316" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+          <ports identifier="P317" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P318" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="3"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N124" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L124" height="15.0" width="44.0" text="Merge4"/>
+          <ports identifier="P319" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.20 //@children.12/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P320" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N125" height="25.0" width="29.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L125" height="15.0" width="42.0" text="Const3"/>
+          <ports identifier="P321" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N126" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L126" height="15.0" width="61.0" text="LogicalNot"/>
+          <ports identifier="P323" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P324" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N127" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L127" height="15.0" width="78.0" text="CurrentTime2"/>
+          <ports identifier="P325" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N128" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L128" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.34">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P328" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P329" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N129" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L129" height="15.0" width="61.0" text="TimeDelay"/>
+          <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P331" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P332" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N130" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L130" height="15.0" width="69.0" text="TimeDelay2"/>
+          <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P334" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P335" height="8.0" width="8.0" x="29.0" y="46.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N131" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L131" height="15.0" width="69.0" text="LogicalNot2"/>
+          <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P337" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.38 //@children.12/@children.1/@children.0/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N132" height="31.0" width="31.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L132" height="15.0" width="69.0" text="LogicalNot3"/>
+          <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@children.1/@children.0/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P339" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@children.1/@children.0/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E179" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.14/@ports.0"/>
+        <containedEdges identifier="E180" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E181" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.26/@ports.0"/>
+        <containedEdges identifier="E182" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.23/@ports.1"/>
+        <containedEdges identifier="E183" sources="//@children.12/@children.1/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.25/@ports.0"/>
+        <containedEdges identifier="E184" sources="//@children.12/@children.1/@children.0/@children.0/@ports.0" targets="//@children.12/@children.1/@children.0/@children.15/@ports.0"/>
+        <containedEdges identifier="E185" sources="//@children.12/@children.1/@children.0/@children.1/@ports.0" targets="//@children.12/@children.1/@children.0/@children.18/@ports.0"/>
+        <containedEdges identifier="E186" sources="//@children.12/@children.1/@children.0/@children.1/@ports.0" targets="//@children.12/@children.1/@children.0/@children.24/@ports.2"/>
+        <containedEdges identifier="E187" sources="//@children.12/@children.1/@children.0/@children.2/@ports.1" targets="//@children.12/@children.1/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E188" sources="//@children.12/@children.1/@children.0/@children.2/@ports.1" targets="//@children.12/@children.1/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E189" sources="//@children.12/@children.1/@children.0/@children.3/@ports.1" targets="//@children.12/@children.1/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E190" sources="//@children.12/@children.1/@children.0/@children.4/@ports.0" targets="//@children.12/@children.1/@children.0/@children.5/@ports.0"/>
+        <containedEdges identifier="E191" sources="//@children.12/@children.1/@children.0/@children.5/@ports.2" targets="//@children.12/@children.1/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E192" sources="//@children.12/@children.1/@children.0/@children.6/@ports.1" targets="//@children.12/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E193" sources="//@children.12/@children.1/@children.0/@children.7/@ports.1" targets="//@children.12/@children.1/@children.0/@children.8/@ports.0"/>
+        <containedEdges identifier="E194" sources="//@children.12/@children.1/@children.0/@children.7/@ports.1" targets="//@children.12/@children.1/@children.0/@children.9/@ports.1"/>
+        <containedEdges identifier="E195" sources="//@children.12/@children.1/@children.0/@children.8/@ports.1" targets="//@children.12/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E196" sources="//@children.12/@children.1/@children.0/@children.9/@ports.0" targets="//@children.12/@children.1/@children.0/@children.10/@ports.0"/>
+        <containedEdges identifier="E197" sources="//@children.12/@children.1/@children.0/@children.10/@ports.2" targets="//@children.12/@children.1/@children.0/@children.11/@ports.0"/>
+        <containedEdges identifier="E198" sources="//@children.12/@children.1/@children.0/@children.11/@ports.1" targets="//@children.12/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E199" sources="//@children.12/@children.1/@children.0/@children.12/@ports.1" targets="//@children.12/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E200" sources="//@children.12/@children.1/@children.0/@children.13/@ports.2" targets="//@children.12/@children.1/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E201" sources="//@children.12/@children.1/@children.0/@children.13/@ports.3" targets="//@children.12/@children.1/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E202" sources="//@children.12/@children.1/@children.0/@children.14/@ports.1" targets="//@children.12/@children.1/@children.0/@children.13/@ports.1"/>
+        <containedEdges identifier="E203" sources="//@children.12/@children.1/@children.0/@children.15/@ports.2" targets="//@children.12/@children.1/@children.0/@children.1/@ports.1"/>
+        <containedEdges identifier="E204" sources="//@children.12/@children.1/@children.0/@children.15/@ports.3" targets="//@children.12/@children.1/@children.0/@children.19/@ports.0"/>
+        <containedEdges identifier="E205" sources="//@children.12/@children.1/@children.0/@children.16/@ports.1" targets="//@children.12/@children.1/@children.0/@children.15/@ports.1"/>
+        <containedEdges identifier="E206" sources="//@children.12/@children.1/@children.0/@children.17/@ports.1" targets="//@children.12/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E207" sources="//@children.12/@children.1/@children.0/@children.18/@ports.2" targets="//@children.12/@children.1/@children.0/@children.13/@ports.0"/>
+        <containedEdges identifier="E208" sources="//@children.12/@children.1/@children.0/@children.19/@ports.2" targets="//@children.12/@children.1/@children.0/@children.12/@ports.0"/>
+        <containedEdges identifier="E209" sources="//@children.12/@children.1/@children.0/@children.19/@ports.3" targets="//@children.12/@children.1/@children.0/@children.21/@ports.1"/>
+        <containedEdges identifier="E210" sources="//@children.12/@children.1/@children.0/@children.20/@ports.1" targets="//@children.12/@children.1/@children.0/@children.17/@ports.0"/>
+        <containedEdges identifier="E211" sources="//@children.12/@children.1/@children.0/@children.21/@ports.0" targets="//@children.12/@children.1/@children.0/@children.20/@ports.0"/>
+        <containedEdges identifier="E212" sources="//@children.12/@children.1/@children.0/@children.22/@ports.1" targets="//@children.12/@children.1/@children.0/@children.19/@ports.1"/>
+        <containedEdges identifier="E213" sources="//@children.12/@children.1/@children.0/@children.23/@ports.0" targets="//@children.12/@children.1/@children.0/@children.24/@ports.0"/>
+        <containedEdges identifier="E214" sources="//@children.12/@children.1/@children.0/@children.24/@ports.1" targets="//@children.12/@children.1/@children.0/@children.18/@ports.1"/>
+        <containedEdges identifier="E215" sources="//@children.12/@children.1/@children.0/@children.25/@ports.1" targets="//@children.12/@children.1/@children.0/@children.27/@ports.0"/>
+        <containedEdges identifier="E216" sources="//@children.12/@children.1/@children.0/@children.26/@ports.1" targets="//@children.12/@children.1/@children.0/@children.28/@ports.0"/>
+        <containedEdges identifier="E217" sources="//@children.12/@children.1/@children.0/@children.27/@ports.1" targets="//@children.12/@children.1/@children.0/@children.16/@ports.0"/>
+        <containedEdges identifier="E218" sources="//@children.12/@children.1/@children.0/@children.27/@ports.1" targets="//@children.12/@children.1/@children.0/@children.22/@ports.0"/>
+        <containedEdges identifier="E219" sources="//@children.12/@children.1/@children.0/@children.28/@ports.1" targets="//@children.12/@children.1/@children.0/@children.14/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E175" sources="//@children.12/@ports.1" targets="//@children.12/@children.1/@ports.0"/>
+    <containedEdges identifier="E176" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@ports.0"/>
+    <containedEdges identifier="E177" sources="//@children.12/@children.0/@ports.0" targets="//@children.12/@children.0/@ports.1"/>
+    <containedEdges identifier="E178" sources="//@children.12/@children.1/@ports.1" targets="//@children.12/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N133">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L133" height="15.0" width="109.0" text="ReserveController2"/>
+    <ports identifier="P340" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P341" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.1" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P342" height="8.0" width="8.0" outgoingEdges="//@containedEdges.23" incomingEdges="//@children.13/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P343" height="8.0" width="8.0" outgoingEdges="//@containedEdges.22" incomingEdges="//@children.13/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P344" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N134" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L134" height="15.0" width="101.0" text="CompositeActor3"/>
+      <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.4" incomingEdges="//@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P346" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.3" incomingEdges="//@children.13/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N135">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L135" height="15.0" width="101.0" text="CompositeActor4"/>
+      <ports identifier="P347" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.1/@containedEdges.0" incomingEdges="//@children.13/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P348" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.5" incomingEdges="//@children.13/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N136" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L136" height="15.0" width="49.0" text="Sampler"/>
+        <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P350" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P351" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.13/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N137" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L137" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P352" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P354" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P355" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P356" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E232" sources="//@children.13/@children.1/@ports.0" targets="//@children.13/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E233" sources="//@children.13/@children.1/@children.0/@ports.1" targets="//@children.13/@children.1/@ports.1"/>
+      <containedEdges identifier="E234" sources="//@children.13/@children.1/@children.1/@ports.0" targets="//@children.13/@children.1/@children.0/@ports.2"/>
+    </children>
+    <children identifier="N138" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L138" height="15.0" width="101.0" text="CompositeActor5"/>
+      <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.7" incomingEdges="//@children.13/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P358" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.6" incomingEdges="//@children.13/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N139" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L139" height="15.0" width="101.0" text="CompositeActor6"/>
+      <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.9" incomingEdges="//@children.13/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P360" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@containedEdges.8" incomingEdges="//@children.13/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N140">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L140" height="15.0" width="85.0" text="PtidesPlatform"/>
+      <ports identifier="P361" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P362" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P363" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P364" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P365" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N141">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L141" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+        <ports identifier="P366" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.0 //@children.13/@children.4/@children.0/@containedEdges.1 //@children.13/@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P367" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P368" height="8.0" width="8.0" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P369" height="8.0" width="8.0" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P370" height="8.0" width="8.0" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N142" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L142" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P372" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.5 //@children.13/@children.4/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N143" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L143" height="15.0" width="68.0" text="TimedDelay"/>
+          <ports identifier="P374" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P375" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N144" height="41.0" width="21.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L144" height="15.0" width="49.0" text="Register"/>
+          <ports identifier="P376" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P377" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.8 //@children.13/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P378" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <children identifier="N145" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L145" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P379" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P380" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P381" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N146" height="25.0" width="18.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L146" height="15.0" width="34.0" text="Const"/>
+          <ports identifier="P382" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P383" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N147" height="25.0" width="70.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L147" height="15.0" width="42.0" text="Const2"/>
+          <ports identifier="P384" height="8.0" width="8.0" x="70.0" y="8.5" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P385" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N148" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L148" height="15.0" width="80.0" text="AddSubtract2"/>
+          <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P388" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N149" height="47.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L149" height="15.0" width="37.0" text="Select"/>
+          <ports identifier="P389" height="8.0" width="8.0" x="-8.0" y="19.5" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.6 //@children.13/@children.4/@children.0/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P390" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@children.13/@children.4/@children.0/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P391" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@children.13/@children.4/@children.0/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E235" sources="//@children.13/@children.4/@children.0/@ports.0" targets="//@children.13/@children.4/@children.0/@children.2/@ports.2"/>
+        <containedEdges identifier="E236" sources="//@children.13/@children.4/@children.0/@ports.0" targets="//@children.13/@children.4/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E237" sources="//@children.13/@children.4/@children.0/@ports.0" targets="//@children.13/@children.4/@children.0/@children.6/@ports.1"/>
+        <containedEdges identifier="E238" sources="//@children.13/@children.4/@children.0/@ports.1" targets="//@children.13/@children.4/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E239" sources="//@children.13/@children.4/@children.0/@ports.2" targets="//@children.13/@children.4/@children.0/@children.5/@ports.1"/>
+        <containedEdges identifier="E240" sources="//@children.13/@children.4/@children.0/@children.0/@ports.1" targets="//@children.13/@children.4/@children.0/@children.4/@ports.1"/>
+        <containedEdges identifier="E241" sources="//@children.13/@children.4/@children.0/@children.0/@ports.1" targets="//@children.13/@children.4/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E242" sources="//@children.13/@children.4/@children.0/@children.1/@ports.1" targets="//@children.13/@children.4/@children.0/@ports.3"/>
+        <containedEdges identifier="E243" sources="//@children.13/@children.4/@children.0/@children.2/@ports.1" targets="//@children.13/@children.4/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E244" sources="//@children.13/@children.4/@children.0/@children.2/@ports.1" targets="//@children.13/@children.4/@children.0/@children.6/@ports.0"/>
+        <containedEdges identifier="E245" sources="//@children.13/@children.4/@children.0/@children.3/@ports.2" targets="//@children.13/@children.4/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E246" sources="//@children.13/@children.4/@children.0/@children.4/@ports.0" targets="//@children.13/@children.4/@children.0/@children.7/@ports.0"/>
+        <containedEdges identifier="E247" sources="//@children.13/@children.4/@children.0/@children.5/@ports.0" targets="//@children.13/@children.4/@children.0/@children.7/@ports.2"/>
+        <containedEdges identifier="E248" sources="//@children.13/@children.4/@children.0/@children.6/@ports.2" targets="//@children.13/@children.4/@children.0/@ports.4"/>
+        <containedEdges identifier="E249" sources="//@children.13/@children.4/@children.0/@children.7/@ports.1" targets="//@children.13/@children.4/@children.0/@children.1/@ports.0"/>
+      </children>
+    </children>
+    <containedEdges identifier="E220" sources="//@children.13/@ports.0" targets="//@children.13/@children.1/@ports.0"/>
+    <containedEdges identifier="E221" sources="//@children.13/@ports.1" targets="//@children.13/@children.0/@ports.0"/>
+    <containedEdges identifier="E222" sources="//@children.13/@ports.4" targets="//@children.13/@children.2/@ports.0"/>
+    <containedEdges identifier="E223" sources="//@children.13/@children.0/@ports.1" targets="//@children.13/@children.4/@ports.0"/>
+    <containedEdges identifier="E224" sources="//@children.13/@children.0/@ports.0" targets="//@children.13/@children.0/@ports.1"/>
+    <containedEdges identifier="E225" sources="//@children.13/@children.1/@ports.1" targets="//@children.13/@children.4/@ports.1"/>
+    <containedEdges identifier="E226" sources="//@children.13/@children.2/@ports.1" targets="//@children.13/@children.4/@ports.2"/>
+    <containedEdges identifier="E227" sources="//@children.13/@children.2/@ports.0" targets="//@children.13/@children.2/@ports.1"/>
+    <containedEdges identifier="E228" sources="//@children.13/@children.3/@ports.1" targets="//@children.13/@ports.2"/>
+    <containedEdges identifier="E229" sources="//@children.13/@children.3/@ports.0" targets="//@children.13/@children.3/@ports.1"/>
+    <containedEdges identifier="E230" sources="//@children.13/@children.4/@ports.4" targets="//@children.13/@ports.3"/>
+    <containedEdges identifier="E231" sources="//@children.13/@children.4/@ports.3" targets="//@children.13/@children.3/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.6" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.3" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.3" targets="//@children.13/@ports.4"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.2" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.6" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.5/@ports.0" targets="//@children.7/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.6/@ports.2" targets="//@children.4/@ports.5"/>
+  <containedEdges identifier="E16" sources="//@children.6/@ports.1" targets="//@children.4/@ports.4"/>
+  <containedEdges identifier="E17" sources="//@children.6/@ports.1" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E18" sources="//@children.6/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E19" sources="//@children.8/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.9/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.12/@ports.0" targets="//@children.13/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E24" sources="//@children.13/@ports.2" targets="//@children.0/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_trex_TREXPtidesMulticoreDirector.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_trex_TREXPtidesMulticoreDirector.elkg
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="89.0" text="DiscreteClock3"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="89.0" text="DiscreteClock4"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="133.0" text="ContactControllerMicro"/>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.4/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.4/@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="38.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="136.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="136.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="53.0" text="TimeGap"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.9 //@children.4/@containedEdges.10 //@children.4/@containedEdges.11 //@children.4/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.13 //@children.4/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="49.0" text="Register"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.1 //@children.4/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.13 //@children.4/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="69.0" text="TimeDelay2"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="56.0" text="Register2"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="6.5" y="41.0" incomingEdges="//@children.4/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.2 //@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="87.0" text="MultiplyDivide3"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.7 //@children.4/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="54.0" text="TrueGate"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="41.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.22 //@children.4/@containedEdges.23 //@children.4/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="69.0" text="TimeDelay3"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.4/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.4/@ports.1" targets="//@children.4/@children.6/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.4/@ports.1" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.4/@ports.0" targets="//@children.4/@children.11/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@ports.2" targets="//@children.4/@children.10/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@ports.3" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.11/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.12/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@ports.4"/>
+    <containedEdges identifier="E23" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.2/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.5/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.12/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.4/@children.5/@ports.2" targets="//@children.4/@children.8/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.4/@children.5/@ports.2" targets="//@children.4/@children.10/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.4/@children.6/@ports.1" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.4/@children.7/@ports.1" targets="//@children.4/@children.13/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.4/@children.8/@ports.2" targets="//@children.4/@children.9/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.4/@children.9/@ports.1" targets="//@children.4/@ports.6"/>
+    <containedEdges identifier="E33" sources="//@children.4/@children.10/@ports.1" targets="//@children.4/@children.8/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.4/@children.11/@ports.1" targets="//@children.4/@children.6/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.4/@children.12/@ports.2" targets="//@children.4/@children.14/@ports.2"/>
+    <containedEdges identifier="E36" sources="//@children.4/@children.13/@ports.1" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.4/@children.13/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.4/@children.13/@ports.1" targets="//@children.4/@children.14/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.4/@children.14/@ports.1" targets="//@children.4/@ports.5"/>
+  </children>
+  <children identifier="N21" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P69" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="78.0" text="CurrentTime2"/>
+    <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="78.0" text="CurrentTime3"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="24.0" text="Test"/>
+    <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="32.0" text="Test2"/>
+    <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="32.0" text="Test3"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.4" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.5" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.6" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.0" targets="//@children.13/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_tte_TTE.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_tte_TTE.elkg
@@ -1,0 +1,2137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="63.0" text="Controller1"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.0/@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="111.0" text="RecordAssembler2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="111.0" text="RecordAssembler3"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="111.0" text="RecordAssembler4"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="55.0" text="TriggerLP"/>
+      <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.10/@containedEdges.0 //@children.0/@children.10/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.17" incomingEdges="//@children.0/@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="40.0" text="Equals"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.10/@containedEdges.0 //@children.0/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@children.10/@containedEdges.2 //@children.0/@children.10/@containedEdges.3 //@children.0/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@children.10/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.10/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.0/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.0/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.0/@children.10/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.0/@children.10/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@children.10/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.10/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="47.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.0/@children.10/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.10/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E52" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.10/@children.1/@ports.1"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.10/@children.0/@ports.1" targets="//@children.0/@children.10/@children.2/@ports.2"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.10/@children.0/@ports.1" targets="//@children.0/@children.10/@children.3/@ports.1"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.10/@children.0/@ports.1" targets="//@children.0/@children.10/@children.4/@ports.1"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.10/@children.1/@ports.0" targets="//@children.0/@children.10/@children.0/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.10/@children.2/@ports.3" targets="//@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.10/@children.3/@ports.0" targets="//@children.0/@children.10/@children.2/@ports.0"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.10/@children.4/@ports.0" targets="//@children.0/@children.10/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N18" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="44.0" text="Merge3"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.20 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="110.0" text="PreemptableServer"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="117.0" text="PreemptableServer2"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.22 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="56.0" text="Sampler2"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.25 //@children.0/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.0/@ports.2" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.0/@ports.2" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.0/@ports.3" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.0/@ports.3" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.0/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.0/@ports.1" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.0/@ports.1" targets="//@children.0/@children.17/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.2"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.5/@ports.2"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.7/@ports.2"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.13/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.11/@ports.1" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.12/@ports.2" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.15/@ports.0" targets="//@children.0/@children.14/@ports.2"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.16/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.16/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.0/@children.17/@ports.0" targets="//@children.0/@children.16/@ports.2"/>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="40.0" text="Switch"/>
+    <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.1/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.1/@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.1/@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N26" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="47.0" text="Switch3"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="128.0" text="RecordDisassembler3"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="47.0" text="Switch4"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.13 //@children.1/@containedEdges.14 //@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="128.0" text="RecordDisassembler4"/>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.8 //@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="44.0" text="Merge5"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.9 //@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="44.0" text="Merge6"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.10 //@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="117.0" text="PreemptableServer2"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="117.0" text="PreemptableServer4"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="117.0" text="PreemptableServer5"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E61" sources="//@children.1/@ports.3" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.1/@ports.4" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.1/@ports.5" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.0/@ports.2"/>
+    <containedEdges identifier="E69" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E71" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E72" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E73" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E74" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E75" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E76" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E77" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E78" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.4/@ports.2"/>
+    <containedEdges identifier="E79" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E80" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E81" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E82" sources="//@children.1/@children.9/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E83" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E84" sources="//@children.1/@children.11/@ports.1" targets="//@children.1/@ports.2"/>
+  </children>
+  <children identifier="N38">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L38" height="15.0" width="63.0" text="Controller3"/>
+    <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P107" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P108" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P109" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P110" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.2/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N39" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P114" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="111.0" text="RecordAssembler2"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P119" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="111.0" text="RecordAssembler4"/>
+      <ports identifier="P123" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P126" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N47">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L47" height="15.0" width="55.0" text="TriggerLP"/>
+      <ports identifier="P130" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.8/@containedEdges.0 //@children.2/@children.8/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.13" incomingEdges="//@children.2/@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N48" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="40.0" text="Equals"/>
+        <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.8/@containedEdges.0 //@children.2/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P133" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@children.8/@containedEdges.2 //@children.2/@children.8/@containedEdges.3 //@children.2/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P134" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@children.8/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.8/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N50" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L50" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.2/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.2/@children.8/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.2/@children.8/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.2/@children.8/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N51" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L51" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P140" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.8/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.8/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N52" height="25.0" width="47.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P142" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.2/@children.8/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.8/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E109" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E110" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.8/@children.1/@ports.1"/>
+      <containedEdges identifier="E111" sources="//@children.2/@children.8/@children.0/@ports.1" targets="//@children.2/@children.8/@children.2/@ports.2"/>
+      <containedEdges identifier="E112" sources="//@children.2/@children.8/@children.0/@ports.1" targets="//@children.2/@children.8/@children.3/@ports.1"/>
+      <containedEdges identifier="E113" sources="//@children.2/@children.8/@children.0/@ports.1" targets="//@children.2/@children.8/@children.4/@ports.1"/>
+      <containedEdges identifier="E114" sources="//@children.2/@children.8/@children.1/@ports.0" targets="//@children.2/@children.8/@children.0/@ports.0"/>
+      <containedEdges identifier="E115" sources="//@children.2/@children.8/@children.2/@ports.3" targets="//@children.2/@children.8/@ports.1"/>
+      <containedEdges identifier="E116" sources="//@children.2/@children.8/@children.3/@ports.0" targets="//@children.2/@children.8/@children.2/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.2/@children.8/@children.4/@ports.0" targets="//@children.2/@children.8/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N53" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="44.0" text="Merge3"/>
+      <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.16 //@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="110.0" text="PreemptableServer"/>
+      <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="117.0" text="PreemptableServer2"/>
+      <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P153" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.18 //@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P155" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P158" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P159" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="56.0" text="Sampler2"/>
+      <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P161" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.21 //@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P162" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="89.0" text="DiscreteClock2"/>
+      <ports identifier="P163" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P166" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P167" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E85" sources="//@children.2/@ports.2" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E86" sources="//@children.2/@ports.2" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E87" sources="//@children.2/@ports.0" targets="//@children.2/@children.12/@ports.0"/>
+    <containedEdges identifier="E88" sources="//@children.2/@ports.1" targets="//@children.2/@children.14/@ports.0"/>
+    <containedEdges identifier="E89" sources="//@children.2/@ports.1" targets="//@children.2/@children.15/@ports.1"/>
+    <containedEdges identifier="E90" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E91" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.0/@ports.2"/>
+    <containedEdges identifier="E92" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E93" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.2/@ports.2"/>
+    <containedEdges identifier="E94" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E95" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E96" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.5/@ports.2"/>
+    <containedEdges identifier="E97" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.11/@ports.0"/>
+    <containedEdges identifier="E98" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.11/@ports.2"/>
+    <containedEdges identifier="E99" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@ports.4"/>
+    <containedEdges identifier="E100" sources="//@children.2/@children.10/@ports.2" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E101" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E102" sources="//@children.2/@children.11/@ports.1" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E103" sources="//@children.2/@children.12/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E104" sources="//@children.2/@children.12/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E105" sources="//@children.2/@children.13/@ports.0" targets="//@children.2/@children.12/@ports.2"/>
+    <containedEdges identifier="E106" sources="//@children.2/@children.14/@ports.1" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E107" sources="//@children.2/@children.14/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E108" sources="//@children.2/@children.15/@ports.0" targets="//@children.2/@children.14/@ports.2"/>
+  </children>
+  <children identifier="N60">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L60" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P168" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.3/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N61" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P172" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P173" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P174" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P175" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N63" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P178" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N64" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="111.0" text="RecordAssembler4"/>
+      <ports identifier="P179" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P181" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P182" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N66" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P185" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N67">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L67" height="15.0" width="55.0" text="TriggerLP"/>
+      <ports identifier="P186" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.6/@containedEdges.0 //@children.3/@children.6/@containedEdges.1" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P187" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.9" incomingEdges="//@children.3/@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N68" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="40.0" text="Equals"/>
+        <ports identifier="P188" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@children.6/@containedEdges.0 //@children.3/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P189" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@children.6/@containedEdges.2 //@children.3/@children.6/@containedEdges.3 //@children.3/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="25.0" width="18.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P190" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N70" height="47.0" width="49.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L70" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+        <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.3/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.3/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P194" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.3/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P195" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.3/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N71" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L71" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P196" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N72" height="25.0" width="47.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P198" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.3/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E135" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.6/@children.1/@ports.1"/>
+      <containedEdges identifier="E137" sources="//@children.3/@children.6/@children.0/@ports.1" targets="//@children.3/@children.6/@children.2/@ports.2"/>
+      <containedEdges identifier="E138" sources="//@children.3/@children.6/@children.0/@ports.1" targets="//@children.3/@children.6/@children.3/@ports.1"/>
+      <containedEdges identifier="E139" sources="//@children.3/@children.6/@children.0/@ports.1" targets="//@children.3/@children.6/@children.4/@ports.1"/>
+      <containedEdges identifier="E140" sources="//@children.3/@children.6/@children.1/@ports.0" targets="//@children.3/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E141" sources="//@children.3/@children.6/@children.2/@ports.3" targets="//@children.3/@children.6/@ports.1"/>
+      <containedEdges identifier="E142" sources="//@children.3/@children.6/@children.3/@ports.0" targets="//@children.3/@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E143" sources="//@children.3/@children.6/@children.4/@ports.0" targets="//@children.3/@children.6/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N73" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="44.0" text="Merge3"/>
+      <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.12 //@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P201" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="110.0" text="PreemptableServer"/>
+      <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P203" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P204" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="117.0" text="PreemptableServer2"/>
+      <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P206" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N76" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L76" height="15.0" width="49.0" text="Sampler"/>
+      <ports identifier="P208" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P209" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.14 //@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P210" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N77" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L77" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P211" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P214" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P215" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E118" sources="//@children.3/@ports.1" targets="//@children.3/@children.3/@ports.1"/>
+    <containedEdges identifier="E119" sources="//@children.3/@ports.1" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E120" sources="//@children.3/@ports.0" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E121" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E122" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E123" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E124" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E125" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.3/@ports.2"/>
+    <containedEdges identifier="E126" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E127" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.9/@ports.2"/>
+    <containedEdges identifier="E128" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@ports.3"/>
+    <containedEdges identifier="E129" sources="//@children.3/@children.8/@ports.2" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E130" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E131" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E132" sources="//@children.3/@children.10/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E133" sources="//@children.3/@children.10/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E134" sources="//@children.3/@children.11/@ports.0" targets="//@children.3/@children.10/@ports.2"/>
+  </children>
+  <children identifier="N78" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L78" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N79" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L79" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P217" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P220" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P221" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N80" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L80" height="15.0" width="89.0" text="DiscreteClock2"/>
+    <ports identifier="P222" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N81" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L81" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P227" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P228" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N82" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L82" height="15.0" width="88.0" text="PoissonClock2"/>
+    <ports identifier="P229" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N83" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L83" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N84" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L84" height="15.0" width="51.0" text="Display3"/>
+    <ports identifier="P232" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N85">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L85" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P233" height="8.0" width="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P234" height="8.0" width="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P235" height="8.0" width="8.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P236" height="8.0" width="8.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P237" height="8.0" width="8.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P238" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P239" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P240" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N86">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L86" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P241" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P242" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P243" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P244" height="8.0" width="8.0" outgoingEdges="//@children.11/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P245" height="8.0" width="8.0" incomingEdges="//@children.11/@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P246" height="8.0" width="8.0" incomingEdges="//@children.11/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P247" height="8.0" width="8.0" incomingEdges="//@children.11/@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P248" height="8.0" width="8.0" incomingEdges="//@children.11/@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N87" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L87" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P250" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N88" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L88" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P252" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N89" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L89" height="15.0" width="41.0" text="Scale3"/>
+        <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P254" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N90" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L90" height="15.0" width="41.0" text="Scale4"/>
+        <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P256" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N91" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L91" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P258" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P259" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N92" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L92" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P260" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P261" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P262" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N93" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L93" height="15.0" width="69.0" text="TimeDelay3"/>
+        <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P264" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P265" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N94" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L94" height="15.0" width="69.0" text="TimeDelay4"/>
+        <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P267" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P268" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E144" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E145" sources="//@children.11/@children.0/@ports.1" targets="//@children.11/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E146" sources="//@children.11/@children.0/@ports.2" targets="//@children.11/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E147" sources="//@children.11/@children.0/@ports.3" targets="//@children.11/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E148" sources="//@children.11/@children.0/@children.0/@ports.1" targets="//@children.11/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E149" sources="//@children.11/@children.0/@children.1/@ports.1" targets="//@children.11/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E150" sources="//@children.11/@children.0/@children.2/@ports.1" targets="//@children.11/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E151" sources="//@children.11/@children.0/@children.3/@ports.1" targets="//@children.11/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E152" sources="//@children.11/@children.0/@children.4/@ports.1" targets="//@children.11/@children.0/@ports.4"/>
+      <containedEdges identifier="E153" sources="//@children.11/@children.0/@children.5/@ports.1" targets="//@children.11/@children.0/@ports.5"/>
+      <containedEdges identifier="E154" sources="//@children.11/@children.0/@children.6/@ports.1" targets="//@children.11/@children.0/@ports.6"/>
+      <containedEdges identifier="E155" sources="//@children.11/@children.0/@children.7/@ports.1" targets="//@children.11/@children.0/@ports.7"/>
+    </children>
+  </children>
+  <children identifier="N95">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L95" height="15.0" width="93.0" text="PtidesPlatform2"/>
+    <ports identifier="P269" height="8.0" width="8.0" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P270" height="8.0" width="8.0" outgoingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P271" height="8.0" width="8.0" outgoingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N96">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L96" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P272" height="8.0" width="8.0" incomingEdges="//@children.12/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P273" height="8.0" width="8.0" incomingEdges="//@children.12/@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P274" height="8.0" width="8.0" incomingEdges="//@children.12/@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N97" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L97" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P275" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P278" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P279" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N98" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L98" height="15.0" width="89.0" text="DiscreteClock2"/>
+        <ports identifier="P280" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P282" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P283" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P284" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N99" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="89.0" text="DiscreteClock3"/>
+        <ports identifier="P285" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P286" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P288" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P289" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N100" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L100" height="15.0" width="86.0" text="SensorHandler"/>
+        <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P291" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N101" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L101" height="15.0" width="93.0" text="SensorHandler2"/>
+        <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P293" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N102" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L102" height="15.0" width="93.0" text="SensorHandler3"/>
+        <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.12/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P295" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N103" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L103" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P296" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P297" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N104" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L104" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P299" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N105" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L105" height="15.0" width="41.0" text="Scale3"/>
+        <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P301" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N106" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L106" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P303" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P304" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N107" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P305" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P306" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P307" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="69.0" text="TimeDelay3"/>
+        <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.12/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P309" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.12/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E156" sources="//@children.12/@children.0/@children.0/@ports.0" targets="//@children.12/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E157" sources="//@children.12/@children.0/@children.1/@ports.0" targets="//@children.12/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E158" sources="//@children.12/@children.0/@children.2/@ports.0" targets="//@children.12/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E159" sources="//@children.12/@children.0/@children.3/@ports.1" targets="//@children.12/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E160" sources="//@children.12/@children.0/@children.4/@ports.1" targets="//@children.12/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E161" sources="//@children.12/@children.0/@children.5/@ports.1" targets="//@children.12/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E162" sources="//@children.12/@children.0/@children.6/@ports.1" targets="//@children.12/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E163" sources="//@children.12/@children.0/@children.7/@ports.1" targets="//@children.12/@children.0/@children.11/@ports.0"/>
+      <containedEdges identifier="E164" sources="//@children.12/@children.0/@children.8/@ports.1" targets="//@children.12/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E165" sources="//@children.12/@children.0/@children.9/@ports.1" targets="//@children.12/@children.0/@ports.0"/>
+      <containedEdges identifier="E166" sources="//@children.12/@children.0/@children.10/@ports.1" targets="//@children.12/@children.0/@ports.1"/>
+      <containedEdges identifier="E167" sources="//@children.12/@children.0/@children.11/@ports.1" targets="//@children.12/@children.0/@ports.2"/>
+    </children>
+  </children>
+  <children identifier="N109">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L109" height="15.0" width="93.0" text="PtidesPlatform3"/>
+    <ports identifier="P311" height="8.0" width="8.0" outgoingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P312" height="8.0" width="8.0" outgoingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N110">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L110" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P313" height="8.0" width="8.0" incomingEdges="//@children.13/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P314" height="8.0" width="8.0" incomingEdges="//@children.13/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N111" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L111" height="15.0" width="81.0" text="DiscreteClock"/>
+        <ports identifier="P315" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P316" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P318" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P319" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N112" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L112" height="15.0" width="89.0" text="DiscreteClock2"/>
+        <ports identifier="P320" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.13/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P323" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P324" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N113" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L113" height="15.0" width="68.0" text="TimedDelay"/>
+        <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P326" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N114" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L114" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P328" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N115" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L115" height="15.0" width="86.0" text="SensorHandler"/>
+        <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P330" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N116" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L116" height="15.0" width="76.0" text="TimedDelay2"/>
+        <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P332" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N117" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L117" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.13/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P334" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.13/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N118" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L118" height="15.0" width="93.0" text="SensorHandler2"/>
+        <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P336" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.13/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E168" sources="//@children.13/@children.0/@children.0/@ports.0" targets="//@children.13/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E169" sources="//@children.13/@children.0/@children.1/@ports.0" targets="//@children.13/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E170" sources="//@children.13/@children.0/@children.2/@ports.1" targets="//@children.13/@children.0/@ports.0"/>
+      <containedEdges identifier="E171" sources="//@children.13/@children.0/@children.3/@ports.1" targets="//@children.13/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E172" sources="//@children.13/@children.0/@children.4/@ports.1" targets="//@children.13/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E173" sources="//@children.13/@children.0/@children.5/@ports.1" targets="//@children.13/@children.0/@ports.1"/>
+      <containedEdges identifier="E174" sources="//@children.13/@children.0/@children.6/@ports.1" targets="//@children.13/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E175" sources="//@children.13/@children.0/@children.7/@ports.1" targets="//@children.13/@children.0/@children.6/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.4" targets="//@children.0/@ports.6"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.1" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.2" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.4" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.4" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.3" targets="//@children.1/@ports.5"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.11/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.0" targets="//@children.11/@ports.2"/>
+  <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.11/@ports.3"/>
+  <containedEdges identifier="E15" sources="//@children.11/@ports.7" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E16" sources="//@children.11/@ports.6" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.5" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.11/@ports.4" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.12/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.12/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.3/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptides_vertxdemo_Subscriber.elkg
+++ b/realworld/ptolemy/hierarchical/ptides_vertxdemo_Subscriber.elkg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="98.0" text="VertxBusHandler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="105.0" text="VertxBusHandler2"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="82.0" text="JSONToToken"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P5" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E8" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E9" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="114.0" text="ConverStringToDate"/>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.6/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="75.0" text="StringToDate"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.6/@children.0/@ports.3" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.1/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.3"/>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_brewery_Brewery.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_brewery_Brewery.elkg
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="78.0" text="MES System"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="84.0" text="ActuatorSetup"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="91.0" text="ActuatorSetup2"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="86.0" text="SensorHandler"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="69.0" text="TimeDelay2"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.0/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="46.0" text="Reactor"/>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.3" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.3/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.3/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="35.0" text="Tank2"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="1.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="37.0">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="46.0" text="Reactor"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="1.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="37.0">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.5 //@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="91.0" text="ZeroOrderHold3"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="91.0" text="ZeroOrderHold4"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="35.0" text="Tank1"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="1.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.14 //@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="66.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="66.0" y="37.0">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.3/@ports.0" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@ports.2" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.3/@ports.3" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.0/@ports.6"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@ports.5"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.1/@ports.4" targets="//@children.3/@children.1/@ports.6"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.1/@ports.3" targets="//@children.3/@ports.6"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.2/@ports.2" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.3/@children.4/@ports.1" targets="//@children.3/@children.7/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.3/@children.7/@ports.4" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.3/@children.7/@ports.4" targets="//@children.3/@children.7/@ports.6"/>
+    <containedEdges identifier="E40" sources="//@children.3/@children.7/@ports.3" targets="//@children.3/@ports.4"/>
+    <containedEdges identifier="E41" sources="//@children.3/@children.8/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N24" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.3/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.4" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.6" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_brewery_BreweryWireless.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_brewery_BreweryWireless.elkg
@@ -1,0 +1,453 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="29.0" text="MES"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="84.0" text="ActuatorSetup"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="91.0" text="ActuatorSetup2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="86.0" text="SensorHandler"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6 //@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.6 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="69.0" text="TimeDelay2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.9/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.9/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="46.0" text="Reactor"/>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.3/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="27.0" text="Tank"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="1.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="66.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="37.0">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="46.0" text="Reactor"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="1.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="37.0">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="35.0" text="Tank2"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="1.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.9 //@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="66.0" y="37.0">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.3/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.3/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.0/@ports.6"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.0/@ports.3" targets="//@children.3/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.1/@ports.4" targets="//@children.3/@children.1/@ports.6"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.1/@ports.3" targets="//@children.3/@ports.4"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.2/@ports.2" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.4/@ports.4" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.4/@ports.4" targets="//@children.3/@children.4/@ports.6"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.4/@ports.3" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.4/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.4" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorPtides.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorPtides.elkg
@@ -1,0 +1,473 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="96.0" width="82.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="85.0" text="PtidesPlatform"/>
+    <ports identifier="P8" height="8.0" width="8.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L6" height="15.0" width="137.0" text="PtidesPlatformContents"/>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N7" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="61.0" text="Supervisor"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L8" height="15.0" width="56.0" text="Controller"/>
+        <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.1/@containedEdges.0 //@children.4/@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.4" incomingEdges="//@children.4/@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N9" height="25.0" width="42.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L9" height="15.0" width="88.0" text="DesiredVoltage"/>
+          <ports identifier="P23" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@children.4/@children.0/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@children.1/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <children identifier="N10" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L10" height="15.0" width="72.0" text="AddSubtract"/>
+          <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N11" height="41.0" width="61.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L11" height="15.0" width="22.0" text="PID"/>
+          <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-2"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E17" sources="//@children.4/@children.0/@children.1/@ports.0" targets="//@children.4/@children.0/@children.1/@children.0/@ports.1"/>
+        <containedEdges identifier="E18" sources="//@children.4/@children.0/@children.1/@ports.0" targets="//@children.4/@children.0/@children.1/@children.1/@ports.1"/>
+        <containedEdges identifier="E19" sources="//@children.4/@children.0/@children.1/@children.0/@ports.0" targets="//@children.4/@children.0/@children.1/@children.1/@ports.0"/>
+        <containedEdges identifier="E20" sources="//@children.4/@children.0/@children.1/@children.1/@ports.2" targets="//@children.4/@children.0/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E21" sources="//@children.4/@children.0/@children.1/@children.2/@ports.1" targets="//@children.4/@children.0/@children.1/@ports.1"/>
+      </children>
+      <children identifier="N12" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="69.0" text="TimeDelay2"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="29.0" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E12" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.4/@children.0/@children.0/@ports.2" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.4/@children.0/@children.1/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@ports.2"/>
+      <containedEdges identifier="E16" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@ports.4"/>
+    </children>
+  </children>
+  <children identifier="N14" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.4 //@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E22" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.5/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.7/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.6/@children.5/@ports.1" targets="//@children.6/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N24">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L24" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N25" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.4 //@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E30" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.4" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.4" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.1/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXFMU.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXFMU.elkg
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="200.0" text="GeneratorContactorLoadSimXFMU"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="151.0" text="InstanceOfInitialPlusDelay"/>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="159.0" text="InstanceOfInitialPlusDelay2"/>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10" incomingEdges="//@children.7/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1 //@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.7/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.6/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMU.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMU.elkg
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="200.0" text="GeneratorContactorLoadSimXFMU"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="151.0" text="InstanceOfInitialPlusDelay"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.5/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.5/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="159.0" text="InstanceOfInitialPlusDelay2"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="91.0" text="onOffSupervisor"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMUMetronomy.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorSimXRhapsodyFMUMetronomy.elkg
@@ -1,0 +1,449 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="10.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="10.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="200.0" text="GeneratorContactorLoadSimXFMU"/>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="151.0" text="InstanceOfInitialPlusDelay"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.5/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.5/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="159.0" text="InstanceOfInitialPlusDelay2"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="91.0" text="onOffSupervisor"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L16" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.4 //@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.9/@children.0/@ports.0" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.5/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.1/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.9/@children.3/@ports.0" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.9/@children.4/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.9/@children.4/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N23">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L23" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N24" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@containedEdges.0 //@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.10/@containedEdges.4 //@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.6/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.10/@children.2/@ports.1" targets="//@children.10/@children.1/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.10/@children.3/@ports.0" targets="//@children.10/@children.4/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.10/@children.3/@ports.0" targets="//@children.10/@children.5/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.10/@children.4/@ports.1" targets="//@children.10/@children.7/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.10/@children.5/@ports.1" targets="//@children.10/@children.4/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.8/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="96.0" width="82.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="10.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P13" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.2 //@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.4/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.4 //@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.5/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.5/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.8/@children.4/@ports.1" targets="//@children.8/@children.3/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.8/@children.5/@ports.1" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.8/@children.5/@ports.1" targets="//@children.8/@children.4/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.1/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithLogging.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithLogging.elkg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="96.0" width="82.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="10.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P13" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="86.0" text="LogExecutions"/>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="130.0" text="ExecutionRequestPort"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="138.0" text="ExecutionRequestPort2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.2 //@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="81.0" text="LogMessages"/>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.2 //@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="18.0" text="in3"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.4 //@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.2 //@children.8/@containedEdges.4 //@children.8/@containedEdges.6 //@children.8/@containedEdges.7 //@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="101.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="68.0" text="StringConst"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="101.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="129.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="76.0" text="StringConst2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="129.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="83.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="76.0" text="StringConst3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="83.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.4/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.5/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.6/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.4/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.8/@children.5/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.8/@children.6/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithProcessor.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithProcessor.elkg
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="96.0" width="82.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.0 //@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.4 //@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.1/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.5/@children.3/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.4 //@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.6/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.5/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.7/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.6/@children.5/@ports.1" targets="//@children.6/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N22" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="10.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L23" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P40" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.1/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithSpecificationAsAspect.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_GeneratorRegulatorProtectorWithSpecificationAsAspect.elkg
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="118.0" text="SpecificationMonitor"/>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="contactor"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="118.0" text="SpecificationMonitor"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="98.0" text="ThrowModelError"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="24.0" text="fault"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="31.0" text="onOff"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="128.0" text="RecordDisassembler3"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.7/@children.1/@ports.3" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.1/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.1/@ports.2"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="125.0" text="SpecificationMonitor3"/>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="41.0" text="voltage"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="24.0" text="fault"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="118.0" text="SpecificationMonitor"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@children.4/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_generatorregulatorprotectormetro_GeneratorRegulatorProtectorWithMapping.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_electricpowersystem_generatorregulatorprotectormetro_GeneratorRegulatorProtectorWithMapping.elkg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="85.0" text="FunctionModel"/>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="197.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="28.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="90.0" text="MicrostepDelay"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="56.0" text="Controller"/>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7" incomingEdges="//@children.0/@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.5/@containedEdges.0 //@children.0/@children.5/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N8" height="25.0" width="42.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="88.0" text="DesiredVoltage"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="42.0" y="8.5" outgoingEdges="//@children.0/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="22.0" text="PID"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E11" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.5/@children.1/@ports.1"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.5/@children.0/@ports.0" targets="//@children.0/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.5/@children.1/@ports.2" targets="//@children.0/@children.5/@children.2/@ports.0"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.5/@children.2/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="61.0" text="Supervisor"/>
+      <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.6/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.6/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.8" incomingEdges="//@children.0/@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="55.0" text="contactor"/>
+        <ports identifier="P23" y="13.666666984558105" incomingEdges="//@children.0/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" y="27.33333396911621" incomingEdges="//@children.0/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" x="30.5" y="41.0" outgoingEdges="//@children.0/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.6/@children.0/@ports.2" targets="//@children.0/@children.6/@ports.2"/>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_BouncingBall.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_BouncingBall.elkg
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="Animate Ball"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="70.0" text="ViewScreen"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="58.0" text="Sphere3D"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="40.0" text="Box3D"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="84.0" text="Translate3D10"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="75.0" text="Copy1:Const"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="61.0" text="Ball Model"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_Collisions.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_Collisions.elkg
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="73.0" text="Transmitter0"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="17.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="99.0" text="CollisionDetector"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.13 //@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="81.0" text="TimedPlotter2"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.23 //@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="75.0" text="SquarePulse"/>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@containedEdges.0 //@children.1/@children.5/@containedEdges.1 //@children.1/@children.5/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.13" incomingEdges="//@children.1/@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N12" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.5/@containedEdges.1 //@children.1/@children.5/@containedEdges.4 //@children.1/@children.5/@containedEdges.6 //@children.1/@children.5/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.5/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.5/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.5/@containedEdges.7 //@children.1/@children.5/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E29" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.5/@children.3/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.5/@children.3/@ports.2"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.5/@children.0/@ports.0" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.5/@children.1/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.5/@children.2/@ports.0" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.5/@children.3/@ports.1" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.5/@children.3/@ports.1" targets="//@children.1/@children.5/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="82.0" text="SquarePulse2"/>
+      <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0 //@children.1/@children.6/@containedEdges.1 //@children.1/@children.6/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.14" incomingEdges="//@children.1/@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N17" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.1 //@children.1/@children.6/@containedEdges.4 //@children.1/@children.6/@containedEdges.6 //@children.1/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="79.0" text="VariableDelay"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.6/@containedEdges.6 //@children.1/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.1/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E38" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.6/@children.2/@ports.2"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.6/@children.0/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.6/@children.1/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.6/@children.2/@ports.1" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.1/@children.6/@children.2/@ports.1" targets="//@children.1/@children.6/@children.3/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.1/@children.6/@children.3/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N21" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.16 //@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="94.0" text="BooleanSwitch3"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.1/@children.12/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.1/@ports.4" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.1/@ports.4" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.12/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.13/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.13/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.11/@ports.2" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.11/@ports.3" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.12/@ports.2" targets="//@children.1/@children.5/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.12/@ports.3" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.13/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.13/@ports.3" targets="//@children.1/@children.4/@ports.0"/>
+  </children>
+  <children identifier="N28">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L28" height="15.0" width="73.0" text="Transmitter1"/>
+    <ports identifier="P67" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N29" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="17.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E47" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E54" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.7/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_Controllers.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_Controllers.elkg
@@ -1,0 +1,554 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Sampler1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="38.0" text="Plant1"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.1/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="63.0" text="InputAdder"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.6 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="74.0" text="OutputAdder"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="62.0" text="Integrator0"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="65.0" text="Feedback0"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="78.0" text="Feedforward0"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="65.0" text="Feedback1"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="78.0" text="Feedforward1"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="TimedPlotter1"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L18" height="15.0" width="38.0" text="Plant2"/>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10" incomingEdges="//@children.9/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="63.0" text="InputAdder"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.6 //@children.9/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="74.0" text="OutputAdder"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.7 //@children.9/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="62.0" text="Integrator0"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4 //@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="65.0" text="Feedback0"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="78.0" text="Feedforward0"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.8 //@children.9/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="65.0" text="Feedback1"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="78.0" text="Feedforward1"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@children.2/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.9/@children.1/@ports.2" targets="//@children.9/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.5/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.9/@children.3/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.9/@children.4/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.9/@children.5/@ports.2" targets="//@children.9/@children.6/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.9/@children.5/@ports.2" targets="//@children.9/@children.7/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.9/@children.6/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.9/@children.7/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="82.0" text="TM controllers"/>
+    <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.10/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.10/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.1" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.2" incomingEdges="//@children.10/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.3" incomingEdges="//@children.10/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N29" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="63.0" text="Controller1"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="63.0" text="Controller2"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E43" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.10/@children.0/@children.0/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.10/@children.0/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.3"/>
+    </children>
+    <containedEdges identifier="E39" sources="//@children.10/@ports.1" targets="//@children.10/@children.0/@ports.2"/>
+    <containedEdges identifier="E40" sources="//@children.10/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@ports.3"/>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.10/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_EvaderAndPursuer.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_EvaderAndPursuer.elkg
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="40.0" text="Evader"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="25.0" width="94.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="48.0" text="Random"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="modal model"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="81.0" text="Accumulator2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="70.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="70.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="48.0" text="Poisson"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="78.0" text="MostRecent2"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.11/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.12/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.11/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="46.0" text="Pursuer"/>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="68.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="46.0" text="Pursuer"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.2/@ports.3" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_GuardedCount.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_GuardedCount.elkg
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="DisplayCount"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="67.0" text="CountDown"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.1/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="40.0" text="Default"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="48.0" text="Default2"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Sequence2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="10.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="35.0" text="When"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.8/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.9/@ports.1"/>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="84.0" text="DisplayEnable"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="110.0" text="EnabledComposite"/>
+    <ports identifier="P34" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="10.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="132.0" text="DisplayCountRequests"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_Inspection.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_Inspection.elkg
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="119.0" text="Poisson Bus Arrivals"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="107.0" text="Passenger Arrivals"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="128.0" text="Poisson Waiting Time"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="78.0" text="Timed Plotter"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="59.0" text="Histogram"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="116.0" text="Regular Bus Arrivals"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="125.0" text="Regular Waiting Time"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="139.0" text="Report Poisson Average"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1 //@children.7/@containedEdges.2" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.7/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="47.0" text="Average"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.4 //@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.7/@ports.1" targets="//@children.7/@children.1/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.7/@ports.1" targets="//@children.7/@children.3/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.7/@children.2/@ports.2" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="179.0" text="Display Average Waiting Times"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.12 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="76.0" text="SingleEvent0"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="136.0" text="Report Regular Average"/>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1 //@children.10/@containedEdges.2" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.10/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="47.0" text="Average"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.4 //@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="53.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="53.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.10/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.10/@ports.1" targets="//@children.10/@children.1/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.10/@ports.1" targets="//@children.10/@children.3/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.10/@children.1/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.10/@children.2/@ports.2" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.10/@children.3/@ports.0" targets="//@children.10/@children.2/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.2" targets="//@children.8/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_SigmaDelta.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_SigmaDelta.elkg
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="131.0" text="ContinuousSubsystem"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="75.0" text="Current Time"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="20.0" text="Sin"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="31.0" text="Add1"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="41.0" text="Scale0"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="41.0" text="Scale1"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="41.0" text="Scale3"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="88.0" text="ContinuousPlot"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.5 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="31.0" text="delay"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="54.0" text="FIR Filter"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="57.0" text="Quantizer"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="41.0" text="DEPlot"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="90.0" text="Moving Average"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="117.0" text="Average 50 samples"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_TerrainModel.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_TerrainModel.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="264.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="264.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P24" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_TimingParadox.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_TimingParadox.elkg
@@ -1,0 +1,673 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="41.0" text="Clock2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="98.0" text="HistogramPlotter"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="37.0" text="Rician"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="44.0" text="Rician2"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="111.0" text="InstanceOfSampler"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3 //@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E26" sources="//@children.6/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.6/@ports.0" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.3/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="118.0" text="InstanceOfSampler2"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.7/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E33" sources="//@children.7/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.7/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E36" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.3/@ports.2"/>
+    <containedEdges identifier="E38" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="118.0" text="InstanceOfSampler3"/>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.1" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0" incomingEdges="//@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.8/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3 //@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E40" sources="//@children.8/@ports.1" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.8/@ports.0" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.8/@children.0/@ports.2" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.8/@children.1/@ports.0" targets="//@children.8/@children.3/@ports.2"/>
+    <containedEdges identifier="E45" sources="//@children.8/@children.2/@ports.1" targets="//@children.8/@children.1/@ports.1"/>
+    <containedEdges identifier="E46" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N22">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L22" height="15.0" width="118.0" text="InstanceOfSampler4"/>
+    <ports identifier="P53" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.22">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.9/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N23" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E47" sources="//@children.9/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.9/@ports.0" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@ports.2"/>
+    <containedEdges identifier="E50" sources="//@children.9/@children.1/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.9/@children.1/@ports.0" targets="//@children.9/@children.3/@ports.2"/>
+    <containedEdges identifier="E52" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.1/@ports.1"/>
+    <containedEdges identifier="E53" sources="//@children.9/@children.3/@ports.1" targets="//@children.9/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="118.0" text="InstanceOfSampler5"/>
+    <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.23">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.10/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.3 //@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E54" sources="//@children.10/@ports.1" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.10/@ports.0" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E57" sources="//@children.10/@children.1/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.10/@children.1/@ports.0" targets="//@children.10/@children.3/@ports.2"/>
+    <containedEdges identifier="E59" sources="//@children.10/@children.2/@ports.1" targets="//@children.10/@children.1/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.10/@children.3/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N32">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L32" height="15.0" width="118.0" text="InstanceOfSampler6"/>
+    <ports identifier="P79" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.1" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.11/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N33" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.11/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.3 //@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.11/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.11/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.11/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E61" sources="//@children.11/@ports.1" targets="//@children.11/@children.2/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.11/@ports.0" targets="//@children.11/@children.3/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.11/@children.0/@ports.2" targets="//@children.11/@ports.2"/>
+    <containedEdges identifier="E64" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.0/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.11/@children.1/@ports.0" targets="//@children.11/@children.3/@ports.2"/>
+    <containedEdges identifier="E66" sources="//@children.11/@children.2/@ports.1" targets="//@children.11/@children.1/@ports.1"/>
+    <containedEdges identifier="E67" sources="//@children.11/@children.3/@ports.1" targets="//@children.11/@children.0/@ports.1"/>
+  </children>
+  <children identifier="N37" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="61.0" text="TimeDelay"/>
+    <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14 //@containedEdges.15 //@containedEdges.16 //@containedEdges.17 //@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P94" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="69.0" text="TimeDelay2"/>
+    <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.19 //@containedEdges.20 //@containedEdges.21 //@containedEdges.22 //@containedEdges.23 //@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.12/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.13/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.12/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.12/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E20" sources="//@children.13/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E21" sources="//@children.13/@ports.1" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E22" sources="//@children.13/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E23" sources="//@children.13/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E24" sources="//@children.13/@ports.1" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E25" sources="//@children.13/@ports.1" targets="//@children.11/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_TransmitAntennaPattern.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_TransmitAntennaPattern.elkg
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.6/@ports.2"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.8/@ports.3" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P28" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L14" height="15.0" width="168.0" text="TransmitPropertyTransformer"/>
+      <ports identifier="P32" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N15" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="99.0" text="CartesianToPolar"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="5.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="81.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="104.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.2 //@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="99.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.4 //@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="81.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.9 //@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="83.0" text="AntennaModel"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.1/@children.1/@children.1/@ports.3" targets="//@children.1/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.1/@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.2"/>
+      <containedEdges identifier="E18" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.5/@ports.2"/>
+      <containedEdges identifier="E19" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E21" sources="//@children.1/@children.1/@children.5/@ports.0" targets="//@children.1/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.1/@children.1/@children.6/@ports.0" targets="//@children.1/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.1/@children.1/@children.7/@ports.2" targets="//@children.1/@children.1/@children.6/@ports.2"/>
+      <containedEdges identifier="E24" sources="//@children.1/@children.1/@children.7/@ports.1" targets="//@children.1/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.1/@children.1/@children.8/@ports.0" targets="//@children.1/@children.1/@children.7/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.1/@children.1/@children.9/@ports.2" targets="//@children.1/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.1/@children.1/@children.10/@ports.1" targets="//@children.1/@children.1/@children.9/@ports.0"/>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_ViterbiDecoder.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_ViterbiDecoder.elkg
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1 //@children.9/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.9/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.9/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.9/@ports.0" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.9/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.9/@ports.1" targets="//@children.9/@children.3/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.9/@children.3/@ports.0" targets="//@children.9/@children.4/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.9/@children.4/@ports.2" targets="//@children.9/@ports.3"/>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="Count Errors2"/>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.1 //@children.12/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.12/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.12/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.3 //@children.12/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@containedEdges.0 //@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E29" sources="//@children.12/@ports.0" targets="//@children.12/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.12/@ports.1" targets="//@children.12/@children.2/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.12/@ports.1" targets="//@children.12/@children.3/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@children.4/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.12/@children.1/@ports.1" targets="//@children.12/@children.0/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.12/@children.2/@ports.1" targets="//@children.12/@children.1/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.12/@children.3/@ports.0" targets="//@children.12/@children.4/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.12/@children.4/@ports.2" targets="//@children.12/@ports.3"/>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="93.0" text="ViterbiDecoder2"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.3" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_WirelessSoundDetection.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_WirelessSoundDetection.elkg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="79.0" text="SoundSource"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="41.0" text="Clock2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="119.0" text="WirelessTriangulator"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="68.0" text="Triangulator"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="79.0" text="ArrayElement"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="87.0" text="ArrayElement2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_hyvisualdemos_BouncingBall.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_hyvisualdemos_BouncingBall.elkg
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="74.0" text="Animate Ball"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="70.0" text="ViewScreen"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="58.0" text="Sphere3D"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="40.0" text="Box3D"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="84.0" text="Translate3D10"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="75.0" text="Copy1:Const"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="96.0" text="PeriodicSampler"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="61.0" text="Ball Model"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.4/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_hyvisualdemos_Pendulum3D.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_hyvisualdemos_Pendulum3D.elkg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="70.0" text="ModalModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="-1.875" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="10.375" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="22.625" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="34.875" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="79.0" text="Displacement"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="40.0" text="Angles"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="104.0" text="Angular Velocities"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="57.0" text="animation"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L6" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N7" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="33.0" text="string"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="58.0" text="Sphere3D"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="77.0" text="Translate3D3"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="70.0" text="Translate3D"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="30.399999618530273">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="55.0" text="Rotate3D"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.3 //@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E19" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.4/@ports.2"/>
+      <containedEdges identifier="E20" sources="//@children.4/@children.0/@children.0/@ports.0" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.4/@children.0/@children.1/@ports.0" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.4/@children.0/@children.4/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="86.0" text="ViewScreen3D"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.3 //@children.4/@containedEdges.6 //@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="50.0" text="Scale3D"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="55.0" text="Rotate3D"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="33.0" text="stage"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="70.0" text="Translate3D"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="47.0" text="Cone3D"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="77.0" text="Translate3D2"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.4/@ports.1" targets="//@children.4/@children.3/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.4/@children.5/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.7/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.6" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.3" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.5" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.5" targets="//@children.4/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_hyvisualdemos_SigmaDelta.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_execdemos_demos_hyvisualdemos_SigmaDelta.elkg
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="82.0" text="CTSubsystem"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="75.0" text="Current Time"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="20.0" text="Sin"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="84.0" text="ZeroOrderHold"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="31.0" text="Add1"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="62.0" text="Integrator2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="41.0" text="Scale0"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="41.0" text="Scale1"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="41.0" text="Scale3"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="41.0" text="Scale4"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="39.0" text="CTPlot"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.5 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N15" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="31.0" text="delay"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="54.0" text="FIR Filter"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="57.0" text="Quantizer"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="41.0" text="DEPlot"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="90.0" text="Moving Average"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="117.0" text="Average 50 samples"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_faultmodels_CommunicationAnomalyDetectionCQM.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_faultmodels_CommunicationAnomalyDetectionCQM.elkg
@@ -1,0 +1,742 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="66.0" text="Transmitter"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="93.0" text="OutgoingPacket"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.1/@ports.3"/>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="99.0" text="LatencyEstimate"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="109.0" text="Learning/Detection"/>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N10" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="103.0" text="ArrayToSequence"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.2/@containedEdges.3 //@children.1/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="97.0" text="SequencePlotter"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.3 //@children.1/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="110.0" text="ArrayToSequence2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.2/@containedEdges.5 //@children.1/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="31.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="90.0" text="CompareLabels"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="66.0" text="CountTrues"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.8 //@children.1/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="43.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="40.0" text="priors2"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="47.0" text="Average"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.12 //@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="54.0" text="Average2"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.14 //@children.1/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="54.0" text="Average3"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.16 //@children.1/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="104.0" text="SequencePlotter2"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="33.0" text="Mean"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="77.0" text="Std Deviation"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="92.0" text="TransitionMatrix"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="172.0" text="ParameterEstimatorGaussian"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="1.600000023841858" outgoingEdges="//@children.1/@children.2/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="60.0" y="11.199999809265137" outgoingEdges="//@children.1/@children.2/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="20.799999237060547" outgoingEdges="//@children.1/@children.2/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="60.0" y="30.399999618530273" outgoingEdges="//@children.1/@children.2/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="140.0" text="HMMGaussianClassifier"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" incomingEdges="//@children.1/@children.2/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@children.2/@containedEdges.22">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@children.1/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E26" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E27" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.14/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.2/@children.15/@ports.2"/>
+      <containedEdges identifier="E29" sources="//@children.1/@children.2/@children.0/@ports.1" targets="//@children.1/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.2/@children.0/@ports.1" targets="//@children.1/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E31" sources="//@children.1/@children.2/@children.2/@ports.1" targets="//@children.1/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.2/@children.2/@ports.1" targets="//@children.1/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.2/@children.3/@ports.2" targets="//@children.1/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.2/@children.4/@ports.1" targets="//@children.1/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.2/@children.4/@ports.1" targets="//@children.1/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.2/@children.5/@ports.2" targets="//@children.1/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.2/@children.6/@ports.0" targets="//@children.1/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E38" sources="//@children.1/@children.2/@children.7/@ports.1" targets="//@children.1/@children.2/@children.11/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.2/@children.7/@ports.1" targets="//@children.1/@children.2/@children.15/@ports.4"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.2/@children.8/@ports.1" targets="//@children.1/@children.2/@children.12/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.2/@children.8/@ports.1" targets="//@children.1/@children.2/@children.15/@ports.5"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.2/@children.9/@ports.1" targets="//@children.1/@children.2/@children.13/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.2/@children.9/@ports.1" targets="//@children.1/@children.2/@children.15/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.2/@children.14/@ports.2" targets="//@children.1/@children.2/@children.15/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.1/@children.2/@children.14/@ports.3" targets="//@children.1/@children.2/@children.7/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.1/@children.2/@children.14/@ports.4" targets="//@children.1/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.1/@children.2/@children.14/@ports.1" targets="//@children.1/@children.2/@children.9/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.1/@children.2/@children.15/@ports.3" targets="//@children.1/@children.2/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N26" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="81.0" text="TrainOrTest?2"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="74.0" text="TrainOrTest?"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="110.0" text="SequenceToArray2"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="93.0" text="IncomingPacket"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.10 //@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="10.0" y="28.75">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="25.0" width="87.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P87" height="8.0" width="8.0" x="87.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.16 //@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.4/@ports.3" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.5/@ports.3" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.10/@ports.2" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.11/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.11/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+  </children>
+  <children identifier="N35">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L35" height="15.0" width="89.0" text="ServiceChannel"/>
+    <children identifier="N36" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="11.0" text="in"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="18.0" text="out"/>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="123.0" text="CommunicationDelay"/>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="79.0" text="UpdateLabels"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="25.0" width="75.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="106.0" text="UpdateCQMToken"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="112.0" text="LatencyDistribution"/>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E49" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E55" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.8/@ports.2"/>
+    <containedEdges identifier="E56" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E58" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E59" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.7/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_faultmodels_GMMConvergenceAnalysis.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_faultmodels_GMMConvergenceAnalysis.elkg
@@ -1,0 +1,876 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="GMMSamples"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="64.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="75.0" text="ChooseIndex"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="54.0" text="ChooseN"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="147.0" text="ExpectationMaximization"/>
+    <ports identifier="P23" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="55.0" text="EM_Core"/>
+      <ports identifier="P31" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2 //@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.6 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="55.0" width="153.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="19.0" text="tau"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="153.0" y="23.5" outgoingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@children.3/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.3 //@children.3/@children.0/@containedEdges.4 //@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="51.0" text="sum_tau"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="59.0" text="tau_n*x_n"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="33.0" text="tau_n"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="87.0" text="MovingAverage"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="51.0" text="next_mu"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.9 //@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="70.0" text="tau_average"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.11 //@children.3/@children.0/@containedEdges.12 //@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="122.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="122.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.3/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="94.0" text="MovingAverage3"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="66.0" text="tau_n*x_n2"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="78.0" text="samplesigma"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="74.0" text="SetVariable2"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="74.0" text="SetVariable5"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="74.0" text="SetVariable6"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="103.0" text="ArrayToSequence"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.18 //@children.3/@children.0/@containedEdges.19 //@children.3/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="25.0" width="19.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="96.0" text="observationArray"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E33" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.8/@ports.3"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.0/@children.3/@ports.2" targets="//@children.3/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.3/@children.0/@children.5/@ports.1" targets="//@children.3/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.3/@children.0/@children.6/@ports.2" targets="//@children.3/@children.0/@children.8/@ports.2"/>
+      <containedEdges identifier="E43" sources="//@children.3/@children.0/@children.6/@ports.2" targets="//@children.3/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E45" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.3/@children.0/@children.8/@ports.0" targets="//@children.3/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.3/@children.0/@children.9/@ports.1" targets="//@children.3/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.3/@children.0/@children.10/@ports.2" targets="//@children.3/@children.0/@children.11/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.3/@children.0/@children.11/@ports.0" targets="//@children.3/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E52" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E54" sources="//@children.3/@children.0/@children.16/@ports.0" targets="//@children.3/@children.0/@children.15/@ports.0"/>
+    </children>
+    <children identifier="N29" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="19.0" text="mu"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="25.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="36.0" text="sigma"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="10.0" text="pi"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="25.0" width="19.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="25.0" width="127.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="29.0" text="MSE"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P90" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="25.0" width="127.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="37.0" text="MSE2"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="110.0" text="SequenceToArray2"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.3/@children.0/@ports.6" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.5/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.7/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.11/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.0/@ports.5" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.5" targets="//@children.3/@children.12/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.5/@ports.2" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.11/@ports.0" targets="//@children.3/@children.12/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.12/@ports.2" targets="//@children.3/@children.13/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.13/@ports.0" targets="//@children.3/@children.14/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.14/@ports.1" targets="//@children.3/@children.15/@ports.0"/>
+  </children>
+  <children identifier="N44" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="61.0" text="ChooseN3"/>
+    <ports identifier="P111" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N45">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L45" height="15.0" width="103.0" text="PlotsAndAnalysis"/>
+    <ports identifier="P113" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P114" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N46" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="111.0" text="Mean Convergence"/>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="10.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="60.0" text="Distributor"/>
+      <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="67.0" text="Distributor2"/>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.5 //@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="110.0" text="ArrayToSequence2"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="67.0" text="Distributor3"/>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="116.0" text="Sigma Convergence"/>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E55" sources="//@children.5/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.5/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.6/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.5/@children.6/@ports.1" targets="//@children.5/@children.7/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.4"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.5" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.7" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.3/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_fuelsystem_FuelSystemErrorHandling.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_fuelsystem_FuelSystemErrorHandling.elkg
@@ -1,0 +1,994 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="30.0" text="Plant"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.1/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.1/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.1/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.6" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L3" height="15.0" width="86.0" text="emptyIndicator"/>
+      <ports identifier="P13" outgoingEdges="//@children.1/@children.0/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" outgoingEdges="//@children.1/@children.0/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" incomingEdges="//@children.1/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" outgoingEdges="//@children.1/@containedEdges.7" incomingEdges="//@children.1/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" incomingEdges="//@children.1/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" incomingEdges="//@children.1/@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" incomingEdges="//@children.1/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N4" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.3 //@children.1/@children.0/@containedEdges.4 //@children.1/@children.0/@containedEdges.5 //@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@children.0/@containedEdges.7 //@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.1/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.1/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.10 //@children.1/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+        <ports identifier="P35" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.1/@children.0/@containedEdges.12 //@children.1/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.0/@ports.7" targets="//@children.1/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.0/@children.0/@ports.2" targets="//@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.0/@children.0/@ports.2" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.0/@children.0/@ports.2" targets="//@children.1/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.0/@children.0/@ports.2" targets="//@children.1/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E38" sources="//@children.1/@children.0/@children.2/@ports.2" targets="//@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.0/@children.2/@ports.2" targets="//@children.1/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.0/@children.2/@ports.3" targets="//@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.0/@children.3/@ports.0" targets="//@children.1/@children.0/@ports.5"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.0/@children.3/@ports.0" targets="//@children.1/@children.0/@children.2/@ports.4"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.0/@children.4/@ports.0" targets="//@children.1/@children.0/@ports.6"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.0/@children.4/@ports.0" targets="//@children.1/@children.0/@children.2/@ports.5"/>
+      <containedEdges identifier="E45" sources="//@children.1/@children.0/@children.5/@ports.2" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="86.0" text="emptyIndicator"/>
+      <ports identifier="P40" outgoingEdges="//@children.1/@children.1/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" outgoingEdges="//@children.1/@children.1/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" outgoingEdges="//@children.1/@containedEdges.8" incomingEdges="//@children.1/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" outgoingEdges="//@children.1/@containedEdges.9" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" incomingEdges="//@children.1/@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" incomingEdges="//@children.1/@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" incomingEdges="//@children.1/@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N11" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.3 //@children.1/@children.1/@containedEdges.4 //@children.1/@children.1/@containedEdges.5 //@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@children.1/@containedEdges.7 //@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.10 //@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.12 //@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E46" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.1/@children.1/@ports.7" targets="//@children.1/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E49" sources="//@children.1/@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@ports.3"/>
+      <containedEdges identifier="E50" sources="//@children.1/@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.1/@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E52" sources="//@children.1/@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.1/@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.2"/>
+      <containedEdges identifier="E54" sources="//@children.1/@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.1/@children.1/@children.2/@ports.3" targets="//@children.1/@children.1/@ports.4"/>
+      <containedEdges identifier="E56" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@ports.5"/>
+      <containedEdges identifier="E57" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.4"/>
+      <containedEdges identifier="E58" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@ports.6"/>
+      <containedEdges identifier="E59" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.5"/>
+      <containedEdges identifier="E60" sources="//@children.1/@children.1/@children.5/@ports.2" targets="//@children.1/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N17">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L17" height="15.0" width="86.0" text="emptyIndicator"/>
+      <ports identifier="P67" outgoingEdges="//@children.1/@children.2/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" outgoingEdges="//@children.1/@children.2/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P69" incomingEdges="//@children.1/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P70" outgoingEdges="//@children.1/@containedEdges.10" incomingEdges="//@children.1/@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P71" outgoingEdges="//@children.1/@containedEdges.11" incomingEdges="//@children.1/@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" incomingEdges="//@children.1/@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" incomingEdges="//@children.1/@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N18" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@children.2/@containedEdges.3 //@children.1/@children.2/@containedEdges.4 //@children.1/@children.2/@containedEdges.5 //@children.1/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.1/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.1/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@children.2/@containedEdges.7 //@children.1/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.1/@children.2/@containedEdges.10 //@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+        <ports identifier="P89" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.1/@children.2/@containedEdges.12 //@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P93" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E61" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E63" sources="//@children.1/@children.2/@ports.7" targets="//@children.1/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E64" sources="//@children.1/@children.2/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.3"/>
+      <containedEdges identifier="E65" sources="//@children.1/@children.2/@children.0/@ports.2" targets="//@children.1/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.1/@children.2/@children.0/@ports.2" targets="//@children.1/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E67" sources="//@children.1/@children.2/@children.0/@ports.2" targets="//@children.1/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E68" sources="//@children.1/@children.2/@children.2/@ports.2" targets="//@children.1/@children.2/@ports.2"/>
+      <containedEdges identifier="E69" sources="//@children.1/@children.2/@children.2/@ports.2" targets="//@children.1/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E70" sources="//@children.1/@children.2/@children.2/@ports.3" targets="//@children.1/@children.2/@ports.4"/>
+      <containedEdges identifier="E71" sources="//@children.1/@children.2/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.5"/>
+      <containedEdges identifier="E72" sources="//@children.1/@children.2/@children.3/@ports.0" targets="//@children.1/@children.2/@children.2/@ports.4"/>
+      <containedEdges identifier="E73" sources="//@children.1/@children.2/@children.4/@ports.0" targets="//@children.1/@children.2/@ports.6"/>
+      <containedEdges identifier="E74" sources="//@children.1/@children.2/@children.4/@ports.0" targets="//@children.1/@children.2/@children.2/@ports.5"/>
+      <containedEdges identifier="E75" sources="//@children.1/@children.2/@children.5/@ports.2" targets="//@children.1/@children.2/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N24" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="76.0" text="LMT_inConst"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.1" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.3" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.4" targets="//@children.1/@children.0/@ports.7"/>
+    <containedEdges identifier="E22" sources="//@children.1/@ports.6" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@ports.7" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.1/@ports.10" targets="//@children.1/@children.1/@ports.7"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.0/@ports.3" targets="//@children.1/@ports.5"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.9"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@ports.8"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.2/@ports.3" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.2/@ports.4" targets="//@children.1/@children.2/@ports.7"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P96" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.4" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.2/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.2/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.2/@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.2/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.2/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.2/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.2/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="102.0" text="FuelConsumption"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="78.0" text="AltitudeConst"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.8 //@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="98.0" text="actualOutFlowTT"/>
+      <ports identifier="P115" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="136.0" text="LMT2LFT_plus_TT2LFT"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.15 //@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L31" height="15.0" width="74.0" text="WatchdogTT"/>
+      <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.5/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.5/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.12" incomingEdges="//@children.2/@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N32" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="58.0" text="HeartBeat"/>
+        <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P126" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="68.0" text="ErrorTrigger"/>
+        <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E98" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E100" sources="//@children.2/@children.5/@children.0/@ports.2" targets="//@children.2/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.2/@children.5/@children.1/@ports.1" targets="//@children.2/@children.5/@ports.2"/>
+    </children>
+    <children identifier="N34">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L34" height="15.0" width="72.0" text="FuelTransfer"/>
+      <ports identifier="P129" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.6/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P130" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.6/@containedEdges.1" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.6/@containedEdges.2" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P132" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.6/@containedEdges.3" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.6/@containedEdges.4" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P134" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.16 //@children.2/@containedEdges.17 //@children.2/@containedEdges.18" incomingEdges="//@children.2/@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.19" incomingEdges="//@children.2/@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P136" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.13 //@children.2/@containedEdges.14 //@children.2/@containedEdges.15" incomingEdges="//@children.2/@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N35" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="93.0" text="LeftFuelTransfer"/>
+        <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.2/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@children.2/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@children.2/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-6"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.2/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-7"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E102" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E104" sources="//@children.2/@children.6/@ports.2" targets="//@children.2/@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E105" sources="//@children.2/@children.6/@ports.3" targets="//@children.2/@children.6/@children.0/@ports.6"/>
+      <containedEdges identifier="E106" sources="//@children.2/@children.6/@ports.4" targets="//@children.2/@children.6/@children.0/@ports.7"/>
+      <containedEdges identifier="E107" sources="//@children.2/@children.6/@children.0/@ports.3" targets="//@children.2/@children.6/@ports.5"/>
+      <containedEdges identifier="E108" sources="//@children.2/@children.6/@children.0/@ports.4" targets="//@children.2/@children.6/@ports.6"/>
+      <containedEdges identifier="E109" sources="//@children.2/@children.6/@children.0/@ports.5" targets="//@children.2/@children.6/@ports.7"/>
+    </children>
+    <children identifier="N36" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="92.0" text="WatchdogClock"/>
+      <ports identifier="P145" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P149" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="139.0" text="LMT2LFT_plus_LMT2TT"/>
+      <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E76" sources="//@children.2/@ports.1" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E77" sources="//@children.2/@ports.1" targets="//@children.2/@children.6/@ports.3"/>
+    <containedEdges identifier="E78" sources="//@children.2/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E79" sources="//@children.2/@ports.2" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E80" sources="//@children.2/@ports.3" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E81" sources="//@children.2/@ports.0" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E82" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.9"/>
+    <containedEdges identifier="E83" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E84" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E85" sources="//@children.2/@children.2/@ports.2" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E86" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@ports.4"/>
+    <containedEdges identifier="E87" sources="//@children.2/@children.4/@ports.2" targets="//@children.2/@ports.10"/>
+    <containedEdges identifier="E88" sources="//@children.2/@children.5/@ports.2" targets="//@children.2/@children.6/@ports.4"/>
+    <containedEdges identifier="E89" sources="//@children.2/@children.6/@ports.7" targets="//@children.2/@ports.5"/>
+    <containedEdges identifier="E90" sources="//@children.2/@children.6/@ports.7" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E91" sources="//@children.2/@children.6/@ports.7" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E92" sources="//@children.2/@children.6/@ports.5" targets="//@children.2/@ports.8"/>
+    <containedEdges identifier="E93" sources="//@children.2/@children.6/@ports.5" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E94" sources="//@children.2/@children.6/@ports.5" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E95" sources="//@children.2/@children.6/@ports.6" targets="//@children.2/@ports.6"/>
+    <containedEdges identifier="E96" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E97" sources="//@children.2/@children.8/@ports.2" targets="//@children.2/@ports.7"/>
+  </children>
+  <children identifier="N38" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P155" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="87.0" text="FaultGenerator"/>
+    <ports identifier="P157" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P161" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P163" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.9" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.5" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.5" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.2" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.8" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.4" targets="//@children.1/@ports.10"/>
+  <containedEdges identifier="E8" sources="//@children.2/@ports.5" targets="//@children.1/@ports.7"/>
+  <containedEdges identifier="E9" sources="//@children.2/@ports.6" targets="//@children.1/@ports.6"/>
+  <containedEdges identifier="E10" sources="//@children.2/@ports.7" targets="//@children.1/@ports.4"/>
+  <containedEdges identifier="E11" sources="//@children.2/@ports.8" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.2/@ports.9" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.2/@ports.10" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.3/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_probabilisticmodels_ChannelFaultModel.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_probabilisticmodels_ChannelFaultModel.elkg
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5 //@containedEdges.7 //@containedEdges.9 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="57.0" text="Receiver2"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="57.0" text="Receiver3"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.8" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="57.0" text="Receiver4"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.10" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="73.0" text="Packet Drop"/>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="11.0" text="i1"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="15.0" text="o1"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="69.0" text="PacketDrop"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="11.0" text="i2"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="51.0" text="Stuck-At"/>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="11.0" text="i1"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="15.0" text="o1"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="76.0" text="StuckAtFault"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="84.0" text="StuckAtFault3"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="15.0" text="o2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="11.0" text="i2"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.7/@children.5/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="57.0" text="Receiver1"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.12" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.5/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.8/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_probabilisticmodels_GMMConvergenceAnalysis.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_probabilisticmodels_GMMConvergenceAnalysis.elkg
@@ -1,0 +1,886 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="GMMSamples"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="64.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="98.0" text="HistogramPlotter"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="75.0" text="ChooseIndex"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="54.0" text="ChooseN"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="147.0" text="ExpectationMaximization"/>
+    <ports identifier="P24" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="55.0" text="EM_Core"/>
+      <ports identifier="P32" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2 //@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.6 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="55.0" width="153.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="19.0" text="tau"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="153.0" y="23.5" outgoingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@children.3/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.3 //@children.3/@children.0/@containedEdges.4 //@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="51.0" text="sum_tau"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="59.0" text="tau_n*x_n"/>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="33.0" text="tau_n"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="87.0" text="MovingAverage"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="51.0" text="next_mu"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.9 //@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="70.0" text="tau_average"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.11 //@children.3/@children.0/@containedEdges.12 //@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="122.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="122.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.3/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="94.0" text="MovingAverage3"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="66.0" text="tau_n*x_n2"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="25.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="78.0" text="samplesigma"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="74.0" text="SetVariable2"/>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="74.0" text="SetVariable5"/>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="74.0" text="SetVariable6"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="103.0" text="ArrayToSequence"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.18 //@children.3/@children.0/@containedEdges.19 //@children.3/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="25.0" width="19.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="96.0" text="observationArray"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.8/@ports.3"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E41" sources="//@children.3/@children.0/@children.3/@ports.2" targets="//@children.3/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.3/@children.0/@children.5/@ports.1" targets="//@children.3/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.3/@children.0/@children.6/@ports.2" targets="//@children.3/@children.0/@children.8/@ports.2"/>
+      <containedEdges identifier="E44" sources="//@children.3/@children.0/@children.6/@ports.2" targets="//@children.3/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E47" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.3/@children.0/@children.8/@ports.0" targets="//@children.3/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.3/@children.0/@children.9/@ports.1" targets="//@children.3/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.3/@children.0/@children.10/@ports.2" targets="//@children.3/@children.0/@children.11/@ports.1"/>
+      <containedEdges identifier="E51" sources="//@children.3/@children.0/@children.11/@ports.0" targets="//@children.3/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E55" sources="//@children.3/@children.0/@children.16/@ports.0" targets="//@children.3/@children.0/@children.15/@ports.0"/>
+    </children>
+    <children identifier="N30" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="19.0" text="mu"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="25.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="36.0" text="sigma"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="10.0" text="pi"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="25.0" width="19.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="127.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="29.0" text="MSE"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P91" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="25.0" width="127.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="37.0" text="MSE2"/>
+      <ports identifier="P105" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="110.0" text="SequenceToArray2"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.3/@children.0/@ports.6" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.5/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.7/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.11/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.5" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.0/@ports.5" targets="//@children.3/@children.12/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.5/@ports.2" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.11/@ports.0" targets="//@children.3/@children.12/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.12/@ports.2" targets="//@children.3/@children.13/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.13/@ports.0" targets="//@children.3/@children.14/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.14/@ports.1" targets="//@children.3/@children.15/@ports.0"/>
+  </children>
+  <children identifier="N45" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="61.0" text="ChooseN3"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L46" height="15.0" width="103.0" text="PlotsAndAnalysis"/>
+    <ports identifier="P114" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N47" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="111.0" text="Mean Convergence"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="10.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="60.0" text="Distributor"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="67.0" text="Distributor2"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.5 //@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="110.0" text="ArrayToSequence2"/>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="67.0" text="Distributor3"/>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="116.0" text="Sigma Convergence"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E56" sources="//@children.5/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.5/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E61" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E63" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.6/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.5/@children.6/@ports.1" targets="//@children.5/@children.7/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.4"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.5" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.7" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.3/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_robot_RandomWalkIntruder.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_robot_RandomWalkIntruder.elkg
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="44.0" text="Intruder"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="56.0" text="Controller"/>
+      <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="46.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="44.0" text="Uniform"/>
+        <ports identifier="P4" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="25.0" width="175.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P8" height="8.0" width="8.0" x="175.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E11" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="82.0" text="TokenToJSON"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="94.0" text="KeyValueStore2"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.199999809265137">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="8.0">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="35.0" text="Errors"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.5" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_test_auto32_GeneratorRegulatorProtectorSimXFMU.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_test_auto32_GeneratorRegulatorProtectorSimXFMU.elkg
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="200.0" text="GeneratorContactorLoadSimXFMU"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="151.0" text="InstanceOfInitialPlusDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.5/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.5/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="159.0" text="InstanceOfInitialPlusDelay2"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11 //@containedEdges.12" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1 //@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="76.0" text="SingleEvent2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="70.0" text="MostRecent"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="86.0" text="NonStrictTest2"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.0" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.6/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.7/@ports.1" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_test_auto_ChannelFaultModel.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_test_auto_ChannelFaultModel.elkg
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="57.0" text="Receiver2"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="57.0" text="Receiver3"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.8" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="57.0" text="Receiver4"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.10" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="73.0" text="Packet Drop"/>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="11.0" text="i1"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="15.0" text="o1"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="69.0" text="PacketDrop"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="11.0" text="i2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.0 //@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.5/@children.3/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="51.0" text="Stuck-At"/>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="11.0" text="i1"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="15.0" text="o1"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="76.0" text="StuckAtFault"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="84.0" text="StuckAtFault3"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="15.0" text="o2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="11.0" text="i2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N19" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="57.0" text="Receiver1"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.11" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="24.0" text="Test"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="32.0" text="Test2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="32.0" text="Test3"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.7/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_test_auto_FuelSystemErrorHandling.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_test_auto_FuelSystemErrorHandling.elkg
@@ -1,0 +1,1012 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="30.0" text="Plant"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.0/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.0/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.6" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="86.0" text="emptyIndicator"/>
+      <ports identifier="P12" outgoingEdges="//@children.0/@children.0/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" outgoingEdges="//@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" outgoingEdges="//@children.0/@containedEdges.7" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" incomingEdges="//@children.0/@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" incomingEdges="//@children.0/@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.4 //@children.0/@children.0/@containedEdges.5 //@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.0/@containedEdges.7 //@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.10 //@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.12 //@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.0/@ports.7" targets="//@children.0/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.0/@children.2/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.0/@children.2/@ports.2" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.0/@children.2/@ports.3" targets="//@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.5"/>
+      <containedEdges identifier="E42" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.4"/>
+      <containedEdges identifier="E43" sources="//@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@ports.6"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.5"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.0/@children.5/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="86.0" text="emptyIndicator"/>
+      <ports identifier="P39" outgoingEdges="//@children.0/@children.1/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" outgoingEdges="//@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" outgoingEdges="//@children.0/@containedEdges.8" incomingEdges="//@children.0/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" outgoingEdges="//@children.0/@containedEdges.9" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" incomingEdges="//@children.0/@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" incomingEdges="//@children.0/@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" incomingEdges="//@children.0/@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N10" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.3 //@children.0/@children.1/@containedEdges.4 //@children.0/@children.1/@containedEdges.5 //@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.1/@containedEdges.7 //@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.0/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+        <ports identifier="P59" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.10 //@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.12 //@children.0/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E46" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.1/@ports.7" targets="//@children.0/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.1/@children.0/@ports.2" targets="//@children.0/@children.1/@ports.3"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.1/@children.0/@ports.2" targets="//@children.0/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.1/@children.0/@ports.2" targets="//@children.0/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.1/@children.0/@ports.2" targets="//@children.0/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.1/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.2"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.1/@children.2/@ports.2" targets="//@children.0/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.0/@children.1/@children.2/@ports.3" targets="//@children.0/@children.1/@ports.4"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.1/@children.3/@ports.0" targets="//@children.0/@children.1/@ports.5"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.1/@children.3/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.4"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.1/@children.4/@ports.0" targets="//@children.0/@children.1/@ports.6"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.1/@children.4/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.5"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.1/@children.5/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="86.0" text="emptyIndicator"/>
+      <ports identifier="P66" outgoingEdges="//@children.0/@children.2/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" outgoingEdges="//@children.0/@children.2/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" incomingEdges="//@children.0/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" outgoingEdges="//@children.0/@containedEdges.10" incomingEdges="//@children.0/@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P70" outgoingEdges="//@children.0/@containedEdges.11" incomingEdges="//@children.0/@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P71" incomingEdges="//@children.0/@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" incomingEdges="//@children.0/@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.2/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N17" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.0/@children.2/@containedEdges.3 //@children.0/@children.2/@containedEdges.4 //@children.0/@children.2/@containedEdges.5 //@children.0/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.2/@containedEdges.7 //@children.0/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P83" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.0/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.0/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-5"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@children.2/@containedEdges.10 //@children.0/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="46.0" width="73.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+        <ports identifier="P88" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@children.0/@children.2/@containedEdges.12 //@children.0/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E61" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.2/@ports.7" targets="//@children.0/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.2/@children.0/@ports.2" targets="//@children.0/@children.2/@ports.3"/>
+      <containedEdges identifier="E65" sources="//@children.0/@children.2/@children.0/@ports.2" targets="//@children.0/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.2/@children.0/@ports.2" targets="//@children.0/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.2/@children.0/@ports.2" targets="//@children.0/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.2/@children.2/@ports.2" targets="//@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E69" sources="//@children.0/@children.2/@children.2/@ports.2" targets="//@children.0/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.2/@children.2/@ports.3" targets="//@children.0/@children.2/@ports.4"/>
+      <containedEdges identifier="E71" sources="//@children.0/@children.2/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.5"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.2/@children.3/@ports.0" targets="//@children.0/@children.2/@children.2/@ports.4"/>
+      <containedEdges identifier="E73" sources="//@children.0/@children.2/@children.4/@ports.0" targets="//@children.0/@children.2/@ports.6"/>
+      <containedEdges identifier="E74" sources="//@children.0/@children.2/@children.4/@ports.0" targets="//@children.0/@children.2/@children.2/@ports.5"/>
+      <containedEdges identifier="E75" sources="//@children.0/@children.2/@children.5/@ports.2" targets="//@children.0/@children.2/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N23" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="76.0" text="LMT_inConst"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.0/@ports.3" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.0/@ports.4" targets="//@children.0/@children.0/@ports.7"/>
+    <containedEdges identifier="E22" sources="//@children.0/@ports.6" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@ports.7" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.0/@ports.10" targets="//@children.0/@children.1/@ports.7"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.9"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@ports.8"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@children.2/@ports.7"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N24">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L24" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P95" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P96" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1 //@children.1/@containedEdges.2" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P97" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P98" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P99" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.1/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P100" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.1/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P101" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.1/@containedEdges.19">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P102" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.1/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P103" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.1/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.1/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.1/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N25" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="102.0" text="FuelConsumption"/>
+      <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="78.0" text="AltitudeConst"/>
+      <ports identifier="P108" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P110" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="98.0" text="actualOutFlowTT"/>
+      <ports identifier="P114" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="136.0" text="LMT2LFT_plus_TT2LFT"/>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.15 //@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="74.0" text="WatchdogTT"/>
+      <ports identifier="P120" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.12" incomingEdges="//@children.1/@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="58.0" text="HeartBeat"/>
+        <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="68.0" text="ErrorTrigger"/>
+        <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P127" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E98" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E100" sources="//@children.1/@children.5/@children.0/@ports.2" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.1/@children.5/@children.1/@ports.1" targets="//@children.1/@children.5/@ports.2"/>
+    </children>
+    <children identifier="N33">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L33" height="15.0" width="72.0" text="FuelTransfer"/>
+      <ports identifier="P128" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P130" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P132" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.4" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.16 //@children.1/@containedEdges.17 //@children.1/@containedEdges.18" incomingEdges="//@children.1/@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P134" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.19" incomingEdges="//@children.1/@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.13 //@children.1/@containedEdges.14 //@children.1/@containedEdges.15" incomingEdges="//@children.1/@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N34" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="93.0" text="LeftFuelTransfer"/>
+        <ports identifier="P136" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P139" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@children.1/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P141" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@children.1/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-6"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.1/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-7"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E102" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E103" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E104" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E105" sources="//@children.1/@children.6/@ports.3" targets="//@children.1/@children.6/@children.0/@ports.6"/>
+      <containedEdges identifier="E106" sources="//@children.1/@children.6/@ports.4" targets="//@children.1/@children.6/@children.0/@ports.7"/>
+      <containedEdges identifier="E107" sources="//@children.1/@children.6/@children.0/@ports.3" targets="//@children.1/@children.6/@ports.5"/>
+      <containedEdges identifier="E108" sources="//@children.1/@children.6/@children.0/@ports.4" targets="//@children.1/@children.6/@ports.6"/>
+      <containedEdges identifier="E109" sources="//@children.1/@children.6/@children.0/@ports.5" targets="//@children.1/@children.6/@ports.7"/>
+    </children>
+    <children identifier="N35" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="92.0" text="WatchdogClock"/>
+      <ports identifier="P144" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P148" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="139.0" text="LMT2LFT_plus_LMT2TT"/>
+      <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P151" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E76" sources="//@children.1/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E77" sources="//@children.1/@ports.1" targets="//@children.1/@children.6/@ports.3"/>
+    <containedEdges identifier="E78" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E79" sources="//@children.1/@ports.2" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E80" sources="//@children.1/@ports.3" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E81" sources="//@children.1/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E82" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.9"/>
+    <containedEdges identifier="E83" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E84" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E85" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E86" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@ports.4"/>
+    <containedEdges identifier="E87" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@ports.10"/>
+    <containedEdges identifier="E88" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.6/@ports.4"/>
+    <containedEdges identifier="E89" sources="//@children.1/@children.6/@ports.7" targets="//@children.1/@ports.5"/>
+    <containedEdges identifier="E90" sources="//@children.1/@children.6/@ports.7" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E91" sources="//@children.1/@children.6/@ports.7" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E92" sources="//@children.1/@children.6/@ports.5" targets="//@children.1/@ports.8"/>
+    <containedEdges identifier="E93" sources="//@children.1/@children.6/@ports.5" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E94" sources="//@children.1/@children.6/@ports.5" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E95" sources="//@children.1/@children.6/@ports.6" targets="//@children.1/@ports.6"/>
+    <containedEdges identifier="E96" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E97" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@ports.7"/>
+  </children>
+  <children identifier="N37" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="115.0" text="ConfigurationSwitch"/>
+    <ports identifier="P152" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P153" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P154" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="42.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="45.0" text="Discard"/>
+    <ports identifier="P155" height="8.0" width="8.0" x="19.0" y="-8.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+    </ports>
+  </children>
+  <children identifier="N39" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L39" height="15.0" width="87.0" text="FaultGenerator"/>
+    <ports identifier="P156" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P157" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P159" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P160" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N40" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L40" height="15.0" width="67.0" text="SetVariable"/>
+    <ports identifier="P161" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P162" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N41" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L41" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P163" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N42" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="86.0" text="NonStrictTest2"/>
+    <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N43" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L43" height="15.0" width="86.0" text="NonStrictTest3"/>
+    <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.9" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.5" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.5" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.2" targets="//@children.1/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.8" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.1/@ports.4" targets="//@children.0/@ports.10"/>
+  <containedEdges identifier="E8" sources="//@children.1/@ports.5" targets="//@children.0/@ports.7"/>
+  <containedEdges identifier="E9" sources="//@children.1/@ports.6" targets="//@children.0/@ports.6"/>
+  <containedEdges identifier="E10" sources="//@children.1/@ports.7" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E11" sources="//@children.1/@ports.8" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E12" sources="//@children.1/@ports.9" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.1/@ports.10" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.2/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.2/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_test_auto_GMMConvergenceAnalysis.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_test_auto_GMMConvergenceAnalysis.elkg
@@ -1,0 +1,906 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="83.0" text="GMMSamples"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="32.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="64.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="98.0" text="HistogramPlotter"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="75.0" text="ChooseIndex"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="54.0" text="ChooseN"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="147.0" text="ExpectationMaximization"/>
+    <ports identifier="P24" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L12" height="15.0" width="55.0" text="EM_Core"/>
+      <ports identifier="P32" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2 //@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.6 //@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N13" height="55.0" width="153.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="19.0" text="tau"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="153.0" y="23.5" outgoingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="23.5" incomingEdges="//@children.3/@children.0/@containedEdges.18">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.3 //@children.3/@children.0/@containedEdges.4 //@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="51.0" text="sum_tau"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="59.0" text="tau_n*x_n"/>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.19">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="33.0" text="tau_n"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="87.0" text="MovingAverage"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="51.0" text="next_mu"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.9 //@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="70.0" text="tau_average"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.11 //@children.3/@children.0/@containedEdges.12 //@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="122.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="122.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.3/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="94.0" text="MovingAverage3"/>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="66.0" text="tau_n*x_n2"/>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="25.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="78.0" text="samplesigma"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="51.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="74.0" text="SetVariable2"/>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="74.0" text="SetVariable5"/>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="74.0" text="SetVariable6"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="103.0" text="ArrayToSequence"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.18 //@children.3/@children.0/@containedEdges.19 //@children.3/@children.0/@containedEdges.20">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="25.0" width="19.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="96.0" text="observationArray"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.21">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E36" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.0/@children.0/@ports.0" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.3/@children.0/@children.1/@ports.2" targets="//@children.3/@children.0/@children.8/@ports.3"/>
+      <containedEdges identifier="E42" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E43" sources="//@children.3/@children.0/@children.3/@ports.2" targets="//@children.3/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.3/@children.0/@children.5/@ports.1" targets="//@children.3/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.3/@children.0/@children.6/@ports.2" targets="//@children.3/@children.0/@children.8/@ports.2"/>
+      <containedEdges identifier="E46" sources="//@children.3/@children.0/@children.6/@ports.2" targets="//@children.3/@children.0/@children.13/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E49" sources="//@children.3/@children.0/@children.7/@ports.1" targets="//@children.3/@children.0/@children.12/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.3/@children.0/@children.8/@ports.0" targets="//@children.3/@children.0/@children.9/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.3/@children.0/@children.9/@ports.1" targets="//@children.3/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.3/@children.0/@children.10/@ports.2" targets="//@children.3/@children.0/@children.11/@ports.1"/>
+      <containedEdges identifier="E53" sources="//@children.3/@children.0/@children.11/@ports.0" targets="//@children.3/@children.0/@children.14/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E55" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E56" sources="//@children.3/@children.0/@children.15/@ports.1" targets="//@children.3/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E57" sources="//@children.3/@children.0/@children.16/@ports.0" targets="//@children.3/@children.0/@children.15/@ports.0"/>
+    </children>
+    <children identifier="N30" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="19.0" text="mu"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="25.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="36.0" text="sigma"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="10.0" text="pi"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="25.0" width="19.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="19.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="127.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="29.0" text="MSE"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P91" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P104" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="25.0" width="127.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="37.0" text="MSE2"/>
+      <ports identifier="P105" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="110.0" text="SequenceToArray2"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.3/@children.0/@ports.6" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.5/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.7/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.11/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.0/@ports.4" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.0/@ports.5" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.0/@ports.5" targets="//@children.3/@children.12/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.5/@ports.2" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.11/@ports.0" targets="//@children.3/@children.12/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.12/@ports.2" targets="//@children.3/@children.13/@ports.1"/>
+    <containedEdges identifier="E34" sources="//@children.3/@children.13/@ports.0" targets="//@children.3/@children.14/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.3/@children.14/@ports.1" targets="//@children.3/@children.15/@ports.0"/>
+  </children>
+  <children identifier="N45" height="25.0" width="83.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L45" height="15.0" width="61.0" text="ChooseN3"/>
+    <ports identifier="P112" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N46">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L46" height="15.0" width="103.0" text="PlotsAndAnalysis"/>
+    <ports identifier="P114" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P115" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N47" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="111.0" text="Mean Convergence"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="10.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="60.0" text="Distributor"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="67.0" text="Distributor2"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.5 //@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="110.0" text="ArrayToSequence2"/>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="46.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="67.0" text="Distributor3"/>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="116.0" text="Sigma Convergence"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E58" sources="//@children.5/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E59" sources="//@children.5/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E60" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E61" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E62" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E63" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.6/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.5/@children.6/@ports.1" targets="//@children.5/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N55" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L55" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N56" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L56" height="15.0" width="86.0" text="NonStrictTest2"/>
+    <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.4"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.5" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.5" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.7" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.7" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.3/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_test_auto_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_test_auto_GeneratorRegulatorProtectorWithConstraintMonitor.elkg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="96.0" width="82.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="10.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P13" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.2 //@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.7/@children.0/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.7/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.7/@children.4/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.4/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.7/@children.6/@ports.1" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.7/@children.7/@ports.1" targets="//@children.7/@children.6/@ports.2"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.4 //@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.8/@children.0/@ports.0" targets="//@children.8/@children.5/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.5/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.8/@children.3/@ports.1" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.8/@children.4/@ports.1" targets="//@children.8/@children.3/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.8/@children.5/@ports.1" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.8/@children.5/@ports.1" targets="//@children.8/@children.4/@ports.0"/>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.5/@ports.1" targets="//@children.1/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/ptolemy_test_auto_GeneratorRegulatorProtectorWithProcessor.elkg
+++ b/realworld/ptolemy/hierarchical/ptolemy_test_auto_GeneratorRegulatorProtectorWithProcessor.elkg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="96.0" width="82.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="142.0" text="GeneratorContactorLoad"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="197.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="197.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="61.0" text="Supervisor"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="1Processor"/>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.0 //@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.4 //@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.1/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.5/@children.3/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="73.0" text="2Processors"/>
+    <children identifier="N14" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="18.0" text="in1"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="18.0" text="in2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.4 //@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="44.0" text="Server2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="17.0" y="36.0" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="128.0" text="RecordDisassembler2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="140.0" text="ExecutionResponsePort"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="148.0" text="ExecutionResponsePort2"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.1/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.6/@children.3/@ports.0" targets="//@children.6/@children.5/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.7/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.6/@children.5/@ports.1" targets="//@children.6/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N22" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="31.0" y="10.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="10.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L23" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P40" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="78.0" text="NonStrictTest"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.1/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/qm_tcppackettxrx_TCPPacketTXRX.elkg
+++ b/realworld/ptolemy/hierarchical/qm_tcppackettxrx_TCPPacketTXRX.elkg
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="58.0" text="LocalClk2"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="60.0" text="Processor"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="81.0" text="TimedPlotter2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="116.0" text="TCPPacketReceiver"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="123.0" text="TCPPacketReceiver2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="17.0" text="P1"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.2/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.2/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="58.0" text="LocalClk1"/>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="81.0" text="DiscreteClock"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="17.0" text="P2"/>
+    <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.4/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N18" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.3 //@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="132.0" text="TCPPacketTransmitter"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.4/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.3/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/rendezvous_trialmodule_TrialModule.elkg
+++ b/realworld/ptolemy/hierarchical/rendezvous_trialmodule_TrialModule.elkg
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="106.0" text="BooleanSelect (B)"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="67.0" text="TrialModule"/>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1 //@children.7/@containedEdges.2" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9" incomingEdges="//@children.7/@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.7/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="97.0" text="StringSubstring1"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const1"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="97.0" text="StringSubstring2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="74.0" text="StringLength"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.6 //@children.7/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="62.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.7/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.7/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.7/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.7/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="56.0" text="Ramp (B)"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="73.0" text="EmptyString"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="31.0" width="81.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="85.0" text="StringFunction"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.7/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.7/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.16 //@children.7/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.7/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.7/@ports.0" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.12/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.7/@children.1/@ports.0" targets="//@children.7/@children.0/@ports.2"/>
+    <containedEdges identifier="E18" sources="//@children.7/@children.2/@ports.0" targets="//@children.7/@children.0/@ports.3"/>
+    <containedEdges identifier="E19" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.3/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.7/@children.5/@ports.1" targets="//@children.7/@children.3/@ports.3"/>
+    <containedEdges identifier="E22" sources="//@children.7/@children.6/@ports.2" targets="//@children.7/@children.9/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.7/@children.7/@ports.0" targets="//@children.7/@children.13/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.7/@children.8/@ports.1" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E25" sources="//@children.7/@children.9/@ports.3" targets="//@children.7/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.7/@children.10/@ports.0" targets="//@children.7/@children.13/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.7/@children.11/@ports.0" targets="//@children.7/@children.9/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.7/@children.12/@ports.1" targets="//@children.7/@children.6/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.7/@children.13/@ports.2" targets="//@children.7/@children.8/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.7/@children.13/@ports.2" targets="//@children.7/@children.9/@ports.2"/>
+  </children>
+  <children identifier="N23" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.5 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.9/@ports.0" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/rendezvous_trialmodule_TrialModuleNonBacktrack.elkg
+++ b/realworld/ptolemy/hierarchical/rendezvous_trialmodule_TrialModuleNonBacktrack.elkg
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="59.0" text="Backtrack"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="68.0" text="StringConst"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="84.0" text="BooleanSelect"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="22.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="74.0" text="Not Rollback"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="25.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="37.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="ResourcePool"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="103.0" y="14.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="14.5" incomingEdges="//@containedEdges.0 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="67.0" text="TrialModule"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1 //@children.8/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10" incomingEdges="//@children.8/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.8/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10" height="31.0" width="81.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="85.0" text="StringFunction"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="97.0" text="StringSubstring1"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const1"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="97.0" text="StringSubstring2"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="74.0" text="StringLength"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.8/@containedEdges.3 //@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="62.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="62.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.8/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.8/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.8/@containedEdges.12 //@children.8/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.8/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="38.0" text="Empty"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="47.0" width="49.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="111.0" text="BooleanMultiplexor"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@children.8/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@children.8/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="20.5" y="47.0" incomingEdges="//@children.8/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="49.0" y="19.5" outgoingEdges="//@children.8/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.8/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.8/@ports.0" targets="//@children.8/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.8/@ports.0" targets="//@children.8/@children.6/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.7/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.8/@children.2/@ports.0" targets="//@children.8/@children.1/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.8/@children.3/@ports.0" targets="//@children.8/@children.1/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.8/@children.4/@ports.1" targets="//@children.8/@children.7/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.8/@children.5/@ports.0" targets="//@children.8/@children.4/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.8/@children.6/@ports.1" targets="//@children.8/@children.4/@ports.3"/>
+    <containedEdges identifier="E23" sources="//@children.8/@children.7/@ports.2" targets="//@children.8/@children.12/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.8/@children.8/@ports.0" targets="//@children.8/@children.9/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.8/@children.9/@ports.2" targets="//@children.8/@children.10/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.8/@children.9/@ports.2" targets="//@children.8/@children.12/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.8/@children.10/@ports.1" targets="//@children.8/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.8/@children.11/@ports.0" targets="//@children.8/@children.12/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.8/@children.12/@ports.3" targets="//@children.8/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.8/@children.13/@ports.0" targets="//@children.8/@children.9/@ports.1"/>
+  </children>
+  <children identifier="N24" height="66.0" width="36.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="39.0" text="Barrier"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="29.0" incomingEdges="//@containedEdges.6 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.3" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.8/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.2" targets="//@children.3/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/scr_safetyinjection_SafetyInjection.elkg
+++ b/realworld/ptolemy/hierarchical/scr_safetyinjection_SafetyInjection.elkg
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="62.0" text="SCRModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.9 //@children.0/@containedEdges.10 //@children.0/@containedEdges.11" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.20 //@children.0/@containedEdges.22 //@children.0/@containedEdges.24">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14 //@children.0/@containedEdges.15" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.17 //@children.0/@containedEdges.18 //@children.0/@containedEdges.19" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="71.0" text="Reset_event"/>
+      <ports identifier="P7" y="6.833333492279053" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" y="13.666666984558105" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" y="20.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" x="30.5" y="41.0" incomingEdges="//@children.0/@containedEdges.21 //@children.0/@containedEdges.23 //@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P11" y="27.33333396911621" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" y="34.16666793823242" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="71.0" text="Reset_event"/>
+      <ports identifier="P13" y="6.833333492279053" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" y="13.666666984558105" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" y="20.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.20 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" y="27.33333396911621" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" y="34.16666793823242" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="71.0" text="Reset_event"/>
+      <ports identifier="P19" y="6.833333492279053" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" y="13.666666984558105" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" y="20.5" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.22 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" y="27.33333396911621" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" y="34.16666793823242" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="71.0" text="Reset_event"/>
+      <ports identifier="P25" y="6.833333492279053" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" y="13.666666984558105" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" y="20.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.24 //@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" y="27.33333396911621" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" y="34.16666793823242" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.0/@ports.1" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.0/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.0/@ports.1" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.0/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.0/@ports.2" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.0/@ports.2" targets="//@children.0/@children.2/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.0/@ports.2" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.0/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E31" sources="//@children.0/@ports.4" targets="//@children.0/@children.1/@ports.4"/>
+    <containedEdges identifier="E32" sources="//@children.0/@ports.4" targets="//@children.0/@children.2/@ports.4"/>
+    <containedEdges identifier="E33" sources="//@children.0/@ports.4" targets="//@children.0/@children.3/@ports.4"/>
+    <containedEdges identifier="E34" sources="//@children.0/@ports.5" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E35" sources="//@children.0/@ports.5" targets="//@children.0/@children.1/@ports.5"/>
+    <containedEdges identifier="E36" sources="//@children.0/@ports.5" targets="//@children.0/@children.2/@ports.5"/>
+    <containedEdges identifier="E37" sources="//@children.0/@ports.5" targets="//@children.0/@children.3/@ports.5"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.3/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.3/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1 //@containedEdges.3 //@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="120.0" text="ContinuousSinewave"/>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="40.0" text="Limiter"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="33.0" text="Block"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Reset"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="130.0" text="LevelCrossingDetector"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="73.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="137.0" text="LevelCrossingDetector2"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="73.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="104.0" text="ConvertToBoolean"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.7 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.14 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="111.0" text="ConvertToBoolean2"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.10 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.3" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.6/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.0" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.0/@ports.5"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.1" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.0" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.1" targets="//@children.0/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/scr_trafficlight_TrafficLight.elkg
+++ b/realworld/ptolemy/hierarchical/scr_trafficlight_TrafficLight.elkg
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="62.0" text="SCRModel"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4 //@children.0/@containedEdges.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.16 //@children.0/@containedEdges.26 //@children.0/@containedEdges.36 //@children.0/@containedEdges.46">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.18 //@children.0/@containedEdges.28 //@children.0/@containedEdges.38 //@children.0/@containedEdges.48">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.20 //@children.0/@containedEdges.30 //@children.0/@containedEdges.40 //@children.0/@containedEdges.50">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.22 //@children.0/@containedEdges.32 //@children.0/@containedEdges.42 //@children.0/@containedEdges.52">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.0/@containedEdges.14 //@children.0/@containedEdges.24 //@children.0/@containedEdges.34 //@children.0/@containedEdges.44 //@children.0/@containedEdges.54">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="28.0" text="Cgrn"/>
+      <ports identifier="P7" y="20.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" x="10.166666984558105" y="41.0" incomingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.17 //@children.0/@containedEdges.27 //@children.0/@containedEdges.37 //@children.0/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" x="20.33333396911621" y="41.0" incomingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.19 //@children.0/@containedEdges.29 //@children.0/@containedEdges.39 //@children.0/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P10" x="30.5" y="41.0" incomingEdges="//@children.0/@containedEdges.11 //@children.0/@containedEdges.21 //@children.0/@containedEdges.31 //@children.0/@containedEdges.41 //@children.0/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P11" x="40.66666793823242" y="41.0" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.23 //@children.0/@containedEdges.33 //@children.0/@containedEdges.43 //@children.0/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" x="50.83333206176758" y="41.0" incomingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.25 //@children.0/@containedEdges.35 //@children.0/@containedEdges.45 //@children.0/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="28.0" text="Cgrn"/>
+      <ports identifier="P13" y="20.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" x="61.0" y="6.833333492279053" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" x="61.0" y="13.666666984558105" outgoingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" x="61.0" y="27.33333396911621" outgoingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" x="61.0" y="34.16666793823242" outgoingEdges="//@children.0/@containedEdges.14 //@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="28.0" text="Cgrn"/>
+      <ports identifier="P19" y="20.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" x="61.0" y="6.833333492279053" outgoingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" x="61.0" y="13.666666984558105" outgoingEdges="//@children.0/@containedEdges.18 //@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.20 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" x="61.0" y="27.33333396911621" outgoingEdges="//@children.0/@containedEdges.22 //@children.0/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" x="61.0" y="34.16666793823242" outgoingEdges="//@children.0/@containedEdges.24 //@children.0/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="28.0" text="Cgrn"/>
+      <ports identifier="P25" y="20.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" x="61.0" y="6.833333492279053" outgoingEdges="//@children.0/@containedEdges.26 //@children.0/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" x="61.0" y="13.666666984558105" outgoingEdges="//@children.0/@containedEdges.28 //@children.0/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.30 //@children.0/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" x="61.0" y="27.33333396911621" outgoingEdges="//@children.0/@containedEdges.32 //@children.0/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" x="61.0" y="34.16666793823242" outgoingEdges="//@children.0/@containedEdges.34 //@children.0/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="28.0" text="Cgrn"/>
+      <ports identifier="P31" y="20.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" x="61.0" y="6.833333492279053" outgoingEdges="//@children.0/@containedEdges.36 //@children.0/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" x="61.0" y="13.666666984558105" outgoingEdges="//@children.0/@containedEdges.38 //@children.0/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.40 //@children.0/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" x="61.0" y="27.33333396911621" outgoingEdges="//@children.0/@containedEdges.42 //@children.0/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" x="61.0" y="34.16666793823242" outgoingEdges="//@children.0/@containedEdges.44 //@children.0/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="28.0" text="Cgrn"/>
+      <ports identifier="P37" y="20.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" x="61.0" y="6.833333492279053" outgoingEdges="//@children.0/@containedEdges.46 //@children.0/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" x="61.0" y="13.666666984558105" outgoingEdges="//@children.0/@containedEdges.48 //@children.0/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" x="61.0" y="20.5" outgoingEdges="//@children.0/@containedEdges.50 //@children.0/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" x="61.0" y="27.33333396911621" outgoingEdges="//@children.0/@containedEdges.52 //@children.0/@containedEdges.53">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" x="61.0" y="34.16666793823242" outgoingEdges="//@children.0/@containedEdges.54 //@children.0/@containedEdges.55">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.1/@ports.5" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.1/@ports.5" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E31" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E32" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E33" sources="//@children.0/@children.2/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E34" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E35" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E36" sources="//@children.0/@children.2/@ports.5" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E37" sources="//@children.0/@children.2/@ports.5" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E38" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E40" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E41" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.0/@children.3/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E43" sources="//@children.0/@children.3/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E44" sources="//@children.0/@children.3/@ports.4" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E45" sources="//@children.0/@children.3/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E46" sources="//@children.0/@children.3/@ports.5" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E47" sources="//@children.0/@children.3/@ports.5" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E48" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E51" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E52" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E53" sources="//@children.0/@children.4/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E54" sources="//@children.0/@children.4/@ports.4" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E55" sources="//@children.0/@children.4/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E56" sources="//@children.0/@children.4/@ports.5" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E57" sources="//@children.0/@children.4/@ports.5" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E58" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E59" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E61" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E62" sources="//@children.0/@children.5/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E63" sources="//@children.0/@children.5/@ports.3" targets="//@children.0/@children.0/@ports.3"/>
+    <containedEdges identifier="E64" sources="//@children.0/@children.5/@ports.4" targets="//@children.0/@ports.4"/>
+    <containedEdges identifier="E65" sources="//@children.0/@children.5/@ports.4" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E66" sources="//@children.0/@children.5/@ports.5" targets="//@children.0/@ports.5"/>
+    <containedEdges identifier="E67" sources="//@children.0/@children.5/@ports.5" targets="//@children.0/@children.0/@ports.5"/>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="81.0" text="DiscreteClock"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="8.333333015441895" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="24.66666603088379" y="41.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8 //@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="41.0" text="Scale2"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="41.0" text="Scale3"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="41.0" text="Scale4"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="41.0" text="Scale5"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.4" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.5" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_CameraDetectView.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_CameraDetectView.elkg
@@ -1,0 +1,645 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="65.0" text="ImageCopy"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="87.0" text="CameraReader"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="IplImageView"/>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="105.0" text="DetectPossibleTilt"/>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2 //@children.3/@containedEdges.3 //@children.3/@containedEdges.4" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.3/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.3/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="67.0" text="FaceDetect"/>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.5" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N8" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="109.0" text="ImageConvertColor"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="76.0" text="ObjectDetect"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E34" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="75.0" text="FaceDetect2"/>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.1/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.6" incomingEdges="//@children.3/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="109.0" text="ImageConvertColor"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="76.0" text="ObjectDetect"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E38" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.3/@children.1/@children.0/@ports.1" targets="//@children.3/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.3/@children.1/@children.1/@ports.1" targets="//@children.3/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.3/@children.1/@children.2/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    </children>
+    <children identifier="N15">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L15" height="15.0" width="75.0" text="FaceDetect3"/>
+      <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.2/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.7" incomingEdges="//@children.3/@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N16" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="109.0" text="ImageConvertColor"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="76.0" text="ObjectDetect"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E42" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.3/@children.2/@children.0/@ports.1" targets="//@children.3/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.3/@children.2/@children.1/@ports.1" targets="//@children.3/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.3/@children.2/@children.2/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N19">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L19" height="15.0" width="75.0" text="FaceDetect4"/>
+      <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.3/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.8" incomingEdges="//@children.3/@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N20" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="109.0" text="ImageConvertColor"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="76.0" text="ObjectDetect"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E46" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.3/@children.0/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.3/@children.3/@children.0/@ports.1" targets="//@children.3/@children.3/@children.1/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.3/@children.3/@children.1/@ports.1" targets="//@children.3/@children.3/@children.2/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.3/@children.3/@children.2/@ports.1" targets="//@children.3/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N23" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="68.0" text="ChooseSeq"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="32.0" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L24" height="15.0" width="75.0" text="FaceDetect5"/>
+      <ports identifier="P50" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.5/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.11" incomingEdges="//@children.3/@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N25" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="109.0" text="ImageConvertColor"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.5/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="76.0" text="ObjectDetect"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E50" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.5/@children.0/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.3/@children.5/@children.0/@ports.1" targets="//@children.3/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.3/@children.5/@children.1/@ports.1" targets="//@children.3/@children.5/@children.2/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.3/@children.5/@children.2/@ports.1" targets="//@children.3/@children.5/@ports.1"/>
+    </children>
+    <children identifier="N28" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="74.0" text="ImageRotate"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="81.0" text="ImageRotate2"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="81.0" text="ImageRotate3"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="81.0" text="ImageRotate4"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="65.0" text="ImageCopy"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="73.0" text="ImageCopy2"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="73.0" text="ImageCopy3"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="73.0" text="ImageCopy4"/>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="73.0" text="ImageCopy5"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.3/@ports.0" targets="//@children.3/@children.11/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.3/@ports.0" targets="//@children.3/@children.12/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.3/@ports.0" targets="//@children.3/@children.13/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.3/@ports.0" targets="//@children.3/@children.14/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.3/@ports.0" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.4/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.4/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.4/@ports.4"/>
+    <containedEdges identifier="E21" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.4/@ports.5"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.4/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.4/@ports.6"/>
+    <containedEdges identifier="E25" sources="//@children.3/@children.6/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.3/@children.10/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.3/@children.11/@ports.1" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.3/@children.12/@ports.1" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.3/@children.13/@ports.1" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.3/@children.14/@ports.1" targets="//@children.3/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N37" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L37" height="15.0" width="90.0" text="DrawResultSeq"/>
+    <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="4.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P77" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N38" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L38" height="15.0" width="73.0" text="ImageCopy2"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N39">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L39" height="15.0" width="84.0" text="IplImageView2"/>
+    <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N40" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E54" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N42" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L42" height="15.0" width="122.0" text="ImageRotateOpenCV"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.2" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.7/@ports.2"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_CameraDetectView_3win.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_CameraDetectView_3win.elkg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="90.0" text="DrawResultSeq"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="65.0" text="ImageCopy"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="CameraReader"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="FaceDetect"/>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.3/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="109.0" text="ImageConvertColor"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="76.0" text="ObjectDetect"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="77.0" text="IplImageView"/>
+      <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.3/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="106.0" text="ImageDisplayGray"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.3/@children.1/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.3/@children.3/@children.1/@ports.1" targets="//@children.3/@children.3/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="84.0" text="IplImageView2"/>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.4/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="129.0" text="ImageDisplayEqualize"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.3/@children.4/@children.1/@ports.1" targets="//@children.3/@children.4/@children.0/@ports.0"/>
+    </children>
+    <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="IplImageView"/>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="115.0" text="ImageDisplayResult"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.0/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_ImageDetectView_3.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_ImageDetectView_3.elkg
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="84.0" text="IplImageView2"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="104.0" text="ImageDisplayRaw"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="DrawResultSeq"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="65.0" text="ImageCopy"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="67.0" text="FaceDetect"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="109.0" text="ImageConvertColor"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="108.0" text="ImageEqualizeHist"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="76.0" text="ObjectDetect"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="135.0" text="IplImageViewConvColor"/>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.3/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N11" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="164.0" text="ImageDisplayAfterConvColor"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.3/@children.1/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.3/@children.3/@children.1/@ports.1" targets="//@children.3/@children.3/@children.0/@ports.0"/>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="77.0" text="IplImageView"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="115.0" text="ImageDisplayResult"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="77.0" text="ImageReader"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="84.0" text="IplImageView3"/>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="135.0" text="ImageDisplayAfterCopy"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="126.0" text="IplImageToAWTImage"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_case_Case.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_case_Case.elkg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="31.0" text="Case"/>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L5" height="15.0" width="8.0" text="1"/>
+      <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.3" incomingEdges="//@children.3/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N6" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="72.0" text="TrigFunction"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E10" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.3/@children.0/@children.0/@ports.1" targets="//@children.3/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.3/@children.0/@children.1/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+      <containedEdges identifier="E13" sources="//@children.3/@children.0/@children.2/@ports.1" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N9">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L9" height="15.0" width="8.0" text="0"/>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.1/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.4" incomingEdges="//@children.3/@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N10" height="25.0" width="50.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.3/@children.1/@children.0/@ports.1" targets="//@children.3/@children.1/@ports.1"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="38.0" text="default"/>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.2/@containedEdges.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.5" incomingEdges="//@children.3/@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="25.0" width="14.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="114.0" text="UnaryMathFunction"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.3/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E16" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.3/@children.2/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_convolutionalcoder_ConvolutionalCoder.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_convolutionalcoder_ConvolutionalCoder.elkg
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.1/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="46.0" text="Counter"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.1" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.0" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.8/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="81.0" text="Count Errors2"/>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.1 //@children.2/@containedEdges.2" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.2/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E33" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.2/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.2/@ports.1" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E37" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.2/@children.4/@ports.2" targets="//@children.2/@ports.3"/>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="60.0" text="Scrambler"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="82.0" text="LogicFunction"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P57" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="76.0" text="DeScrambler"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="89.0" text="LogicFunction2"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N29" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L29" height="15.0" width="58.0" text="Bernoulli2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N30" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L30" height="15.0" width="83.0" text="DeScrambler2"/>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N31" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="86.0" text="ViterbiDecoder"/>
+    <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.7/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.11/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.12/@ports.1" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.13/@ports.0" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.14/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.15/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E16" sources="//@children.16/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.17/@ports.1" targets="//@children.10/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_croom_CRoom.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_croom_CRoom.elkg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="39.0" text="Plotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="54.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="27.0" text="TSet"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Room"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.7 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="52.0" text="RunTime"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="90.0" text="SimulationTime"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.11/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13" incomingEdges="//@children.11/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="25.0" width="131.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="40.0" text="Limiter"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.11/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="59.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="25.0" text="gain"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.11/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.11/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.11/@ports.0" targets="//@children.11/@children.2/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.11/@children.0/@ports.0" targets="//@children.11/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.11/@children.1/@ports.1" targets="//@children.11/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.11/@children.2/@ports.0" targets="//@children.11/@children.0/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.0" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.11/@ports.1" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_dftsubset_DFTSubSet.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_dftsubset_DFTSubSet.elkg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="112.0" text="ComputeCoefficient"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="25.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="73.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="180.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="94.0" text="InputBlockDelay"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="180.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N7" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="55.0" text="Sinewave"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="10.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="72.0" text="Commutator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="19.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="84.0" text="AbsoluteValue"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="96.0" text="SequenceScope"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="MultiplyDivide"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="107.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="107.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.0" targets="//@children.5/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_gravitation_Gravitation.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_gravitation_Gravitation.elkg
@@ -1,0 +1,406 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="BodyModels"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="99.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="158.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="158.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="21.0" text="FIR"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="162.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="162.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="160.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="160.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.13 //@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="79.0" text="ArrayElement"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@ports.0" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N16" height="25.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="103.0" y="8.5" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L17" height="15.0" width="49.0" text="Animate"/>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="86.0" text="ViewScreen3D"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="99.0" text="ArrayToElements"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L20" height="15.0" width="140.0" text="MultiInstanceComposite"/>
+      <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.2/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@children.2/@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N21" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="58.0" text="Sphere3D"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="70.0" text="Translate3D"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@children.2/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@children.2/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="20.799999237060547" incomingEdges="//@children.2/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.2/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="99.0" text="ArrayToElements"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@children.2/@containedEdges.4 //@children.2/@children.2/@containedEdges.5 //@children.2/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E27" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.2/@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.2/@children.2/@children.1/@ports.1" targets="//@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.2/@children.2/@children.2/@ports.1" targets="//@children.2/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.2/@children.2/@children.3/@ports.1" targets="//@children.2/@children.2/@children.1/@ports.4"/>
+      <containedEdges identifier="E32" sources="//@children.2/@children.2/@children.3/@ports.1" targets="//@children.2/@children.2/@children.1/@ports.3"/>
+      <containedEdges identifier="E33" sources="//@children.2/@children.2/@children.3/@ports.1" targets="//@children.2/@children.2/@children.1/@ports.2"/>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_gravitation_GravitationWithCollisionDetection.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_gravitation_GravitationWithCollisionDetection.elkg
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="BodyModels"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="99.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="158.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="158.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="21.0" text="FIR"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="162.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="162.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.18 //@children.0/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="160.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="85.0" text="SampleDelay2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="160.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.14 //@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.16 //@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="41.0" text="Scale2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="79.0" text="ArrayElement"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="105.0" text="CollisionDetection"/>
+      <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.20 //@children.0/@containedEdges.21 //@children.0/@containedEdges.22" incomingEdges="//@children.0/@children.14/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.14/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N17" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="70.0" text="ModalModel"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.0/@children.14/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.0/@children.14/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="281.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.14/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="102.0" text="SequenceToArray"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.14/@containedEdges.5 //@children.0/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="82.0" text="ArrayContains"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.14/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.14/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="88.0" text="ArrayMaximum"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.14/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.14/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="112.0" text="BooleanToAnything"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.14/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@children.14/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.0/@children.14/@ports.0" targets="//@children.0/@children.14/@children.1/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.14/@children.0/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.14/@ports.3" targets="//@children.0/@children.14/@children.0/@ports.3"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.14/@children.0/@ports.2" targets="//@children.0/@children.14/@ports.2"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.14/@children.1/@ports.0" targets="//@children.0/@children.14/@children.5/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.3/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.14/@children.2/@ports.1" targets="//@children.0/@children.14/@children.4/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.14/@children.3/@ports.1" targets="//@children.0/@children.14/@children.0/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.14/@children.4/@ports.2" targets="//@children.0/@children.14/@children.0/@ports.4"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.14/@children.5/@ports.1" targets="//@children.0/@children.14/@children.2/@ports.0"/>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@ports.3" targets="//@children.0/@children.14/@ports.3"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.14/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.0/@children.13/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.0/@children.14/@ports.2" targets="//@children.0/@children.9/@ports.0"/>
+  </children>
+  <children identifier="N23" height="25.0" width="103.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="103.0" y="8.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L24" height="15.0" width="49.0" text="Animate"/>
+    <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N25" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="86.0" text="ViewScreen3D"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="99.0" text="ArrayToElements"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L27" height="15.0" width="140.0" text="MultiInstanceComposite"/>
+      <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.2/@containedEdges.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2" incomingEdges="//@children.2/@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N28" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="58.0" text="Sphere3D"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="40.0" width="60.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="70.0" text="Translate3D"/>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="1.600000023841858" incomingEdges="//@children.2/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@children.2/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="20.799999237060547" incomingEdges="//@children.2/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.2/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="99.0" text="ArrayToElements"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@children.2/@containedEdges.3 //@children.2/@children.2/@containedEdges.4 //@children.2/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E44" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.2/@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.2/@children.2/@children.1/@ports.1" targets="//@children.2/@children.2/@ports.1"/>
+      <containedEdges identifier="E47" sources="//@children.2/@children.2/@children.2/@ports.1" targets="//@children.2/@children.2/@children.1/@ports.2"/>
+      <containedEdges identifier="E48" sources="//@children.2/@children.2/@children.2/@ports.1" targets="//@children.2/@children.2/@children.1/@ports.3"/>
+      <containedEdges identifier="E49" sources="//@children.2/@children.2/@children.2/@ports.1" targets="//@children.2/@children.2/@children.1/@ports.4"/>
+      <containedEdges identifier="E50" sources="//@children.2/@children.2/@children.3/@ports.1" targets="//@children.2/@children.2/@children.2/@ports.0"/>
+    </children>
+    <containedEdges identifier="E41" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N32" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="99.0" text="ElementsToArray"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P79" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N33" height="25.0" width="105.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P81" height="8.0" width="8.0" x="105.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N34" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L34" height="15.0" width="107.0" text="ElementsToArray2"/>
+    <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P83" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_htvq_HTVQ2.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_htvq_HTVQ2.elkg
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="40.0" text="sender"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="60.0" text="1:Encoder"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="53.0" text="1:Source"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="99.0" text="1:Partition Image"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="45.0" text="receiver"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="1:Unpartition"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="85.0" text="1:Compressed"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="60.0" text="1:Decoder"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="92.0" text="DatagramWriter"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="98.0" text="DatagramReader"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_htvq_HTVQ4.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_htvq_HTVQ4.elkg
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="42.0" text="Source"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="37.0" text="PSNR"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="74.0" text="Compressed"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="44.0" text="Original"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="130.0" text="typed composite actor"/>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="49.0" text="Encoder"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="63.0" text="Unpartition"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="88.0" text="Partition Image"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="49.0" text="Decoder"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
@@ -1,0 +1,650 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="180.0" text="iRobotSensorSignalProcessing"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="48.0" text="Sensors"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="63.0" y="-5.5625">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="63.0" y="-3.125">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="63.0" y="-0.6875">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="63.0" y="1.75">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="63.0" y="4.1875">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="63.0" y="6.625">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="63.0" y="9.0625" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="63.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="63.0" y="13.9375" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="8"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="63.0" y="16.375" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="9"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="63.0" y="18.8125">
+        <properties key="org.eclipse.elk.port.index" value="10"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="63.0" y="21.25">
+        <properties key="org.eclipse.elk.port.index" value="11"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="63.0" y="23.6875">
+        <properties key="org.eclipse.elk.port.index" value="12"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="63.0" y="26.125">
+        <properties key="org.eclipse.elk.port.index" value="13"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="63.0" y="28.5625">
+        <properties key="org.eclipse.elk.port.index" value="14"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-15"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.8" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.9" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.7" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.6" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.15"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="iRobotActuator"/>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N9" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="38.0" text="Speed"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="36.0" text="Drive2"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="63.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="36.0" text="Drive3"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="63.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="36.0" text="Drive4"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="63.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="72.0" text="RotateAngle"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="75.0" text="UnitDistance"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.3"/>
+    <containedEdges identifier="E22" sources="//@children.1/@ports.1" targets="//@children.1/@children.5/@ports.3"/>
+    <containedEdges identifier="E23" sources="//@children.1/@ports.2" targets="//@children.1/@children.6/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.5/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.3/@ports.4"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.5/@ports.4"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.6/@ports.4"/>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="1.8571428060531616" y="41.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="11.714285850524902" y="41.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="21.571428298950195" y="41.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="31.428571701049805" y="41.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="41.28571319580078" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="51.14285659790039" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L19" height="15.0" width="186.0" text="AccelerometerSignalProcessing"/>
+    <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.3/@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.3/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.3/@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.3/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N20" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="28.0" text="ADC"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="63.0" y="5.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="63.0" y="18.0" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="224.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="212.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="457.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="73.0" text="Expression5"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="473.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="73.0" text="Expression6"/>
+      <ports identifier="P90" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="119.0" text="BooleanToAnything5"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="119.0" text="BooleanToAnything6"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E33" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E34" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.3/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.5/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.12/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.11/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@ports.4"/>
+    <containedEdges identifier="E47" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@ports.5"/>
+    <containedEdges identifier="E48" sources="//@children.3/@children.10/@ports.1" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.3/@children.11/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E50" sources="//@children.3/@children.12/@ports.1" targets="//@children.3/@ports.3"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.9"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.10"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.6" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.7" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.8" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.4" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.5" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.2" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.3" targets="//@children.2/@ports.5"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_iterateoverarray_IterateOverArray.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_iterateoverarray_IterateOverArray.elkg
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="103.0" text="AntennaElements"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="94.0" text="composite actor"/>
+      <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="87.0" text="MultiplyDivide2"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.1 //@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="25.0" width="323.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="31.0" text="expjx"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="323.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.1/@ports.1"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N5" height="25.0" width="281.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="102.0" text="HammingWindow"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="113.0" text="SumArrayElements"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="59.0" text="Normalize"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="69.0" text="CreateArray"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="49.0" text="Steering"/>
+    <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="94.0" text="composite actor"/>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.1 //@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="25.0" width="430.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="430.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E20" sources="//@children.6/@children.0/@children.0/@ports.2" targets="//@children.6/@children.0/@ports.2"/>
+      <containedEdges identifier="E21" sources="//@children.6/@children.0/@children.1/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N14" height="25.0" width="274.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="107.0" text="PlaneWavePhasor"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="274.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Ramp2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="55.0" text="XYPlotter"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="99.0" text="PolarToCartesian"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.9/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_matlabroom_MatlabRoom.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_matlabroom_MatlabRoom.elkg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="51.0" text="MATLAB"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="52.0" text="RunTime"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="88.0" text="WallClockTime"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="90.0" text="SimulationTime"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="71.0" text="CurrentTime"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="25.0" width="78.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="78.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="39.0" text="Plotter"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9 //@containedEdges.10 //@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="25.0" width="54.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="27.0" text="TSet"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="54.0" y="8.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="117.0" text="VectorDisassembler"/>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.9 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="124.0" text="VectorDisassembler2"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@containedEdges.11 //@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="56.0" text="Controller"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14" incomingEdges="//@children.12/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N14" height="25.0" width="131.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="40.0" text="Limiter"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="131.0" y="8.5" outgoingEdges="//@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.12/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="59.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="25.0" text="gain"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="59.0" y="8.5" outgoingEdges="//@children.12/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.12/@ports.1" targets="//@children.12/@children.2/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.12/@children.0/@ports.0" targets="//@children.12/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.12/@children.1/@ports.1" targets="//@children.12/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.12/@children.2/@ports.0" targets="//@children.12/@children.0/@ports.1"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.0" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.8/@ports.2" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.9/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.10/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.11/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.0" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_opencvreader_OpenCVReader.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_opencvreader_OpenCVReader.elkg
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="OpenCVReader"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="30.0" text="Copy"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="128.0" text="DisplayCurrentImage3"/>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@containedEdges.4" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="121.0" text="DisplayCurrentImage"/>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@containedEdges.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.3/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N9" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="22.0" text="Flip"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="24.0" text="Blur"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="128.0" text="DisplayCurrentImage2"/>
+    <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@containedEdges.9" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="29.0" text="Flip2"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="128.0" text="DisplayCurrentImage4"/>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0 //@containedEdges.11" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="78.0" text="ImageDisplay"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="127.0" text="OpenCVToAWTImage"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.8/@ports.0" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.8/@children.1/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N18" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="30.0" text="Invert"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.0" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.1" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_rijndaelencryption_RijndaelEncryption.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_rijndaelencryption_RijndaelEncryption.elkg
@@ -1,0 +1,563 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="41.0" text="rijndael"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="118.0" text="RoundKeyGenerator"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="25.0" width="32.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P4" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="102.0" text="SequenceToArray"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="25.0" width="508.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="508.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="203.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="85.0" text="SampleDelay2"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="203.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="103.0" text="ArrayToSequence"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.6 //@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="74.0" text="modal model"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E18" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E20" sources="//@children.0/@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.0/@children.0/@children.3/@ports.1" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.0/@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="96.0" text="RoundSequence"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="61.0" text="UpSample"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="77.0" text="DownSample"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="89.0" text="convertToString"/>
+      <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.7/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.9" incomingEdges="//@children.0/@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N17" height="25.0" width="115.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.0/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.7/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="77.0" text="DownSample"/>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.7/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.7/@containedEdges.3 //@children.0/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.0/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.0/@children.7/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.7/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="61.0" text="UpSample"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.7/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.7/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="227.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="92.0" text="PadToTwoChars"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@children.0/@children.7/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.7/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E26" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.7/@children.0/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.7/@children.0/@ports.0" targets="//@children.0/@children.7/@children.6/@ports.1"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.7/@children.1/@ports.1" targets="//@children.0/@children.7/@children.2/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.7/@children.2/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.7/@children.2/@ports.1" targets="//@children.0/@children.7/@children.4/@ports.1"/>
+      <containedEdges identifier="E31" sources="//@children.0/@children.7/@children.3/@ports.1" targets="//@children.0/@children.7/@children.5/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.7/@children.4/@ports.0" targets="//@children.0/@children.7/@children.3/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.7/@children.5/@ports.1" targets="//@children.0/@children.7/@children.1/@ports.2"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.7/@children.6/@ports.0" targets="//@children.0/@children.7/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N24" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="110.0" text="ArrayToSequence3"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="110.0" text="SequenceToArray3"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="94.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.10/@ports.1" targets="//@children.0/@children.1/@ports.3"/>
+  </children>
+  <children identifier="N27" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N29">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L29" height="15.0" width="89.0" text="convertToString"/>
+    <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N30" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="77.0" text="DownSample"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="77.0" text="SampleDelay"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="61.0" text="UpSample"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="227.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="92.0" text="PadToTwoChars"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="227.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E35" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E40" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.3/@children.5/@ports.1" targets="//@children.3/@children.1/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_robot_robotWebService.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_robot_robotWebService.elkg
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="55.0" text="Run Tulip"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="104.0" text="ConfigureInputFile"/>
+      <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="57.0" text="FileWriter"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="63.0" text="FileReader"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="25.0" width="33.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.6 //@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="25.0" width="306.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="93.0" text="AssumptionText"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="306.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="25.0" width="459.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="84.0" text="GuaranteeText"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="459.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E18" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E19" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.2"/>
+      <containedEdges identifier="E21" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.0/@children.3/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.0"/>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="30.0" text="Exec"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.75">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="28.75">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="63.0" text="FileReader"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="91.0" text="XSLTransformer"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="73.0" text="StringToXML"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@ports.1" targets="//@children.0/@children.0/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N14" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="56.0" text="HttpActor"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="60.0" y="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5 //@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="90.0" text="MicrostepDelay"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="10.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="121.0" text="RecordDisassembler"/>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N18" height="28.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="98.0" text="MicrostepDelay2"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="31.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="10.0" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N19" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.1" targets="//@children.1/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_scrambler_Scrambler.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_scrambler_Scrambler.elkg
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="60.0" text="Scrambler"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="38.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="76.0" text="DeScrambler"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="94.0" text="Scrambled Data"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="131.0" text="Measure Rate of Trues"/>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.4/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.4/@children.3/@ports.2" targets="//@children.4/@ports.1"/>
+  </children>
+  <children identifier="N10" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="77.0" text="Rate of Trues"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="108.0" text="Descrambled Data"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_signature_Signature.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_signature_Signature.elkg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="104.0" text="PrivateKeyReader"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="101.0" text="PublicKeyReader"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="93.0" text="SignatureSigner"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="95.0" text="SignatureVerifier"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="104.0" text="Man in the middle"/>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.7/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.4 //@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="50.0" text="Bernoulli"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.7/@children.2/@ports.2" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.2/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N15" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="77.0" text="Ramp Output"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.3" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_speech_Speech.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_speech_Speech.elkg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="138.0" text="DiscreteRandomSource"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="88.0" text="process blocks"/>
+    <ports identifier="P3" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="64.0" text="Quantizer2"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L6" height="15.0" width="49.0" text="Decoder"/>
+      <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@children.1/@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.3/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N7" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="96.0" text="RecursiveLattice"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.3/@children.0/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.1/@children.3/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="88.0" text="Autocorrelation"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="88.0" text="LevinsonDurbin"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="49.0" text="Encoder"/>
+      <ports identifier="P22" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.7" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N11" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="40.0" text="Lattice"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="64.0" text="Quantizer2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E14" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.6/@children.0/@ports.0"/>
+      <containedEdges identifier="E15" sources="//@children.1/@children.6/@children.0/@ports.1" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.1/@children.6/@children.1/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="75.0" text="AudioReader"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="71.0" text="AudioPlayer"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E2" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.5/@ports.3" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_systemcommand_SystemCommand.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_systemcommand_SystemCommand.elkg
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="105.0" text="SystemCommand"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="15.0" text="x1"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="15.0" text="x2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="10.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="98.0" text="ReadOutputFile1"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6" height="31.0" width="81.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="85.0" text="StringFunction"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="105.0" text="AnythingToDouble"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="113.0" text="ExpressionToToken"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="98.0" text="ThrowModelError"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.5 //@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="63.0" text="FileReader"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.4/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.4/@children.5/@ports.1" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.4/@children.5/@ports.1" targets="//@children.4/@children.7/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.7/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="98.0" text="ReadOutputFile2"/>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.5/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="31.0" width="81.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="85.0" text="StringFunction"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="81.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="105.0" text="AnythingToDouble"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="113.0" text="ExpressionToToken"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="98.0" text="ThrowModelError"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.0 //@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.5/@containedEdges.5 //@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="63.0" text="FileReader"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.5/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.5/@children.5/@ports.1" targets="//@children.5/@children.7/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.5/@children.6/@ports.0" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.5/@children.7/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N23" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="133.0" text="StandardOutputStream"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="122.0" text="StandardErrorStream"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.0/@ports.4"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_trellisdecoder_TrellisDecoder.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_trellisdecoder_TrellisDecoder.elkg
@@ -1,0 +1,563 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.13 //@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.14 //@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1 //@children.4/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.4/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.4/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.3 //@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.4/@ports.0" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@ports.1" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.4/@children.4/@ports.2" targets="//@children.4/@ports.3"/>
+  </children>
+  <children identifier="N11" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="81.0" text="Count Errors2"/>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.1 //@children.7/@containedEdges.2" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.7/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.7/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E28" sources="//@children.7/@ports.0" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.7/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.7/@ports.1" targets="//@children.7/@children.3/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@ports.2"/>
+    <containedEdges identifier="E32" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.4/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.7/@children.2/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.7/@children.3/@ports.0" targets="//@children.7/@children.4/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.7/@children.4/@ports.2" targets="//@children.7/@ports.3"/>
+  </children>
+  <children identifier="N19" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L19" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N20" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L20" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N21" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="34.0" text="Slicer"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="59.0" text="LineCoder"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="66.0" text="LineCoder2"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="111.0" text="Complex Gaussian"/>
+    <ports identifier="P57" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.14/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.14/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="63.0" text="Gaussian2"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.14/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="25.0" width="92.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P66" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@children.14/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.14/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.14/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E37" sources="//@children.14/@children.0/@ports.0" targets="//@children.14/@children.2/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.14/@children.1/@ports.0" targets="//@children.14/@children.2/@ports.2"/>
+    <containedEdges identifier="E39" sources="//@children.14/@children.2/@ports.0" targets="//@children.14/@ports.0"/>
+  </children>
+  <children identifier="N29">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L29" height="15.0" width="118.0" text="Complex Gaussian2"/>
+    <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@containedEdges.16" incomingEdges="//@children.15/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N30" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="63.0" text="Gaussian2"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="25.0" width="92.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P78" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@children.15/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.15/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.15/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E40" sources="//@children.15/@children.0/@ports.0" targets="//@children.15/@children.2/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.15/@children.1/@ports.0" targets="//@children.15/@children.2/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.15/@children.2/@ports.0" targets="//@children.15/@ports.0"/>
+  </children>
+  <children identifier="N33" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L33" height="15.0" width="83.0" text="TrellisDecoder"/>
+    <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.16/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.1" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.2" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.7/@ports.2" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.11/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.13/@ports.1" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.14/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sdf_viterbidecoder_ViterbiDecoder.elkg
+++ b/realworld/ptolemy/hierarchical/sdf_viterbidecoder_ViterbiDecoder.elkg
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1 //@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="56.0" text="Gaussian"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="50.0" text="Bernoulli"/>
+    <ports identifier="P10" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="202.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="202.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.9 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything3"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="73.0" text="Count Errors"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.1 //@children.9/@containedEdges.2" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.9/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.9/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.9/@ports.0" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.9/@ports.1" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.9/@ports.1" targets="//@children.9/@children.3/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.9/@children.1/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.9/@children.2/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.9/@children.3/@ports.0" targets="//@children.9/@children.4/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.9/@children.4/@ports.2" targets="//@children.9/@ports.3"/>
+  </children>
+  <children identifier="N16" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="145.0" text="Errors on Coded Channel"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="169.0" text="Error Rate on Coded Channel"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L18" height="15.0" width="81.0" text="Count Errors2"/>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" outgoingEdges="//@children.12/@containedEdges.1 //@children.12/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@containedEdges.14" incomingEdges="//@children.12/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@containedEdges.15" incomingEdges="//@children.12/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.3 //@children.12/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.12/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.12/@containedEdges.0 //@children.12/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.12/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.12/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.12/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.12/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E29" sources="//@children.12/@ports.0" targets="//@children.12/@children.2/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.12/@ports.1" targets="//@children.12/@children.2/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.12/@ports.1" targets="//@children.12/@children.3/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.12/@children.0/@ports.1" targets="//@children.12/@children.4/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.12/@children.1/@ports.1" targets="//@children.12/@children.0/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.12/@children.2/@ports.1" targets="//@children.12/@children.1/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.12/@children.3/@ports.0" targets="//@children.12/@children.4/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.12/@children.4/@ports.2" targets="//@children.12/@ports.3"/>
+  </children>
+  <children identifier="N24" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="159.0" text="Errors on Uncoded Channel"/>
+    <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="40.0" width="60.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="183.0" text="Error Rate on Uncoded Channel"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="111.0" text="ConvolutionalCoder"/>
+    <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N27" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L27" height="15.0" width="63.0" text="Gaussian2"/>
+    <ports identifier="P64" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="5.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="32.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N28" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L28" height="15.0" width="93.0" text="ViterbiDecoder2"/>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.18">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.17/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.12/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.0" targets="//@children.15/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.1" targets="//@children.9/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.5/@ports.2" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.9/@ports.2" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.12/@ports.2" targets="//@children.13/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.12/@ports.3" targets="//@children.14/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.15/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.16/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E19" sources="//@children.17/@ports.1" targets="//@children.9/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/security_signature_Signature.elkg
+++ b/realworld/ptolemy/hierarchical/security_signature_Signature.elkg
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="102.0" text="SequenceToArray"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="28.0">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="104.0" text="PrivateKeyReader"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="101.0" text="PublicKeyReader"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="103.0" text="ArrayToSequence"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="93.0" text="SignatureSigner"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="95.0" text="SignatureVerifier"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="104.0" text="Man in the middle"/>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.7/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="102.0" text="SequenceToArray"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.7/@containedEdges.4 //@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="50.0" text="Bernoulli"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.7/@ports.0" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.7/@children.1/@ports.1" targets="//@children.7/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.7/@children.2/@ports.2" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.2/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.7/@children.3/@ports.1" targets="//@children.7/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N15" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="77.0" text="Ramp Output"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.6/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.3" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.1" targets="//@children.6/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_controlFlowDemo.elkg
+++ b/realworld/ptolemy/hierarchical/sr_controlFlowDemo.elkg
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="66.0" text="AccumLUB"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="36.0" text="EmitA"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="60.0" y="4.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="15.0" text="T1"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="60.0" y="4.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="36.0" text="EmitB"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="1.600000023841858">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="60.0" y="4.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="11.199999809265137" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="20.799999237060547">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="30.399999618530273" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="60.0" y="28.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="17.0" text="P1"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="60.0" y="8.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="32.0">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="17.0" text="P2"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="60.0" y="8.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="32.0">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="60.0" y="24.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@ports.0" targets="//@children.0/@children.1/@ports.5"/>
+    <containedEdges identifier="E8" sources="//@children.0/@ports.3" targets="//@children.0/@children.2/@ports.6"/>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.1" targets="//@children.0/@children.3/@ports.5"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.6" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.1/@ports.4" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.2/@ports.5" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.2/@ports.4" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.3/@ports.6" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.3/@ports.4" targets="//@children.0/@children.5/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.4/@ports.6" targets="//@children.0/@children.2/@ports.2"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.5/@ports.6" targets="//@children.0/@children.2/@ports.2"/>
+  </children>
+  <children identifier="N8" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P49" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="25.0" width="18.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P51" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.0" targets="//@children.0/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_guardedcount_GuardedCount.elkg
+++ b/realworld/ptolemy/hierarchical/sr_guardedcount_GuardedCount.elkg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="77.0" text="DisplayCount"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="67.0" text="CountDown"/>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.1/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="40.0" text="Default"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="35.0" text="When"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="84.0" text="DisplayEnable"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L13" height="15.0" width="110.0" text="EnabledComposite"/>
+    <ports identifier="P29" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N14" height="29.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="59.0" text="Sequence"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="10.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="132.0" text="DisplayCountRequests"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.1/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_guardedcount_GuardedCountTimed.elkg
+++ b/realworld/ptolemy/hierarchical/sr_guardedcount_GuardedCountTimed.elkg
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="67.0" text="CountDown"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N2" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="40.0" text="Default"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="35.0" text="When"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+  </children>
+  <children identifier="N9" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10" height="29.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L10" height="15.0" width="59.0" text="Sequence"/>
+    <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="10.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="10.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.0" targets="//@children.0/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_irobothillclimbing_iRobotCreateVerification.elkg
+++ b/realworld/ptolemy/hierarchical/sr_irobothillclimbing_iRobotCreateVerification.elkg
@@ -1,0 +1,916 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Slope"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="-1.875" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="10.375" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="22.625" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="-1.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="6.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="13.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="20.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="27.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="34.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.75" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="34.875" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="180.0" text="iRobotSensorSignalProcessing"/>
+    <ports identifier="P14" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N3" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="48.0" text="Sensors"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="63.0" y="-5.5625">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="63.0" y="-3.125">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="63.0" y="-0.6875">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="63.0" y="1.75">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="63.0" y="4.1875">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="63.0" y="6.625">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="63.0" y="9.0625" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="63.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="63.0" y="13.9375" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="8"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="63.0" y="16.375" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="9"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="63.0" y="18.8125">
+        <properties key="org.eclipse.elk.port.index" value="10"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="63.0" y="21.25">
+        <properties key="org.eclipse.elk.port.index" value="11"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="63.0" y="23.6875">
+        <properties key="org.eclipse.elk.port.index" value="12"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="63.0" y="26.125">
+        <properties key="org.eclipse.elk.port.index" value="13"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="63.0" y="28.5625">
+        <properties key="org.eclipse.elk.port.index" value="14"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="-15"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="47.0" text="Switch2"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.8" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.0/@ports.9" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.0/@ports.7" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.0/@ports.6" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="186.0" text="AccelerometerSignalProcessing"/>
+    <ports identifier="P50" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="28.0" text="ADC"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="63.0" y="5.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="63.0" y="18.0" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="224.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="212.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.10 //@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="47.0" text="Switch2"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.14 //@children.2/@containedEdges.15 //@children.2/@containedEdges.16 //@children.2/@containedEdges.17 //@children.2/@containedEdges.18 //@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@children.2/@containedEdges.10 //@children.2/@containedEdges.12 //@children.2/@containedEdges.20 //@children.2/@containedEdges.24 //@children.2/@containedEdges.26 //@children.2/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="47.0" text="Switch3"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.20 //@children.2/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="457.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="73.0" text="Expression5"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="473.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="73.0" text="Expression6"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="47.0" text="Switch5"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.24 //@children.2/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="47.0" text="Switch6"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.26 //@children.2/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="47.0" text="Switch4"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.28 //@children.2/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="119.0" text="BooleanToAnything5"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="119.0" text="BooleanToAnything6"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E28" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.10/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.11/@ports.1"/>
+    <containedEdges identifier="E34" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.15/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.18/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.17/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.20/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.12/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.13/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.14/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@ports.5"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.16/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.19/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.12/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.2/@children.12/@ports.1" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E54" sources="//@children.2/@children.13/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.2/@children.13/@ports.1" targets="//@children.2/@ports.4"/>
+    <containedEdges identifier="E56" sources="//@children.2/@children.14/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.2/@children.14/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E58" sources="//@children.2/@children.15/@ports.1" targets="//@children.2/@children.5/@ports.2"/>
+    <containedEdges identifier="E59" sources="//@children.2/@children.16/@ports.1" targets="//@children.2/@children.9/@ports.2"/>
+    <containedEdges identifier="E60" sources="//@children.2/@children.17/@ports.1" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E61" sources="//@children.2/@children.18/@ports.1" targets="//@children.2/@children.14/@ports.2"/>
+    <containedEdges identifier="E62" sources="//@children.2/@children.19/@ports.1" targets="//@children.2/@children.12/@ports.2"/>
+    <containedEdges identifier="E63" sources="//@children.2/@children.20/@ports.1" targets="//@children.2/@children.13/@ports.2"/>
+  </children>
+  <children identifier="N33">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L33" height="15.0" width="87.0" text="iRobotActuator"/>
+    <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N34" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="38.0" text="Speed"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="36.0" text="Drive2"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="63.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="36.0" text="Drive3"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="63.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="31.0" width="63.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="36.0" text="Drive4"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="63.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="72.0" text="RotateAngle"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.9 //@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="25.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="75.0" text="UnitDistance"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="105.0" text="AnythingToDouble"/>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E64" sources="//@children.3/@ports.0" targets="//@children.3/@children.3/@ports.3"/>
+    <containedEdges identifier="E65" sources="//@children.3/@ports.1" targets="//@children.3/@children.5/@ports.3"/>
+    <containedEdges identifier="E66" sources="//@children.3/@ports.2" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.6/@ports.2"/>
+    <containedEdges identifier="E71" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.5/@ports.2"/>
+    <containedEdges identifier="E72" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.3/@ports.2"/>
+    <containedEdges identifier="E73" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.3/@ports.4"/>
+    <containedEdges identifier="E74" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.5/@ports.4"/>
+    <containedEdges identifier="E75" sources="//@children.3/@children.8/@ports.0" targets="//@children.3/@children.6/@ports.4"/>
+    <containedEdges identifier="E76" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.6/@ports.3"/>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="61.0" y="-1.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="61.0" y="6.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="61.0" y="13.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="61.0" y="20.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="27.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="61.0" y="34.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="-1.875" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="4.25" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="10.375" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="22.625" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="34.875" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.6" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.7" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.8" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.9" targets="//@children.4/@ports.4"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.10" targets="//@children.4/@ports.5"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.4/@ports.9"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.4" targets="//@children.4/@ports.10"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.11" targets="//@children.4/@ports.11"/>
+  <containedEdges identifier="E10" sources="//@children.0/@ports.12" targets="//@children.4/@ports.12"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.6" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.7" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.4/@ports.8" targets="//@children.0/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_reflexgame_ReflexGame.elkg
+++ b/realworld/ptolemy/hierarchical/sr_reflexgame_ReflexGame.elkg
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="119.0" text="SR Composite Actor"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.0/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="74.0" text="modal model"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="4.25" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="28.75" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@ports.3"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.4" targets="//@children.0/@ports.4"/>
+  </children>
+  <children identifier="N3" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="65.0" text="Start Timer"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="67.0" text="ButtonTime"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="150.0" text="Display 'Ready' and 'Now!'"/>
+    <ports identifier="P15" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6" height="25.0" width="48.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="29.0" text="Now!"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="48.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="68.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="37.0" text="Ready"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.3/@ports.0" targets="//@children.3/@children.2/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="93.0" text="Display Outputs"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="88.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="88.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.4 //@children.4/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="80.0" text="AddSubtract3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.7 //@children.4/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="119.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="119.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="89.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="89.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.5 //@children.4/@containedEdges.6 //@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.1 //@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.10 //@children.4/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="76.0" text="TimedDelay2"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.12 //@children.4/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.4/@ports.0" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.4/@ports.0" targets="//@children.4/@children.6/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.4/@ports.1" targets="//@children.4/@children.7/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.4/@ports.2" targets="//@children.4/@children.8/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.4/@children.1/@ports.2" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.4/@children.2/@ports.2" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.6/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.4/@children.6/@ports.2" targets="//@children.4/@children.5/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.4/@children.7/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.4/@children.7/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.4/@children.8/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.4/@children.8/@ports.1" targets="//@children.4/@children.3/@ports.1"/>
+  </children>
+  <children identifier="N19">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L19" height="15.0" width="77.0" text="RandomTime"/>
+    <ports identifier="P45" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7" incomingEdges="//@children.5/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P46" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="33.0" text="Timer"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="44.0" text="Uniform"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="88.0" text="WallClockTime"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="41.0" y="8.333333015441895" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E32" sources="//@children.5/@ports.1" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.5/@children.0/@ports.1" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E34" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.4" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.5/@ports.0" targets="//@children.3/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_threadedcomposite_MulticoreExecution.elkg
+++ b/realworld/ptolemy/hierarchical/sr_threadedcomposite_MulticoreExecution.elkg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="116.0" text="ThreadedComposite"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="150.0" text="ThreadedCompositeInside"/>
+      <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="87.0" text="ExecutionTime"/>
+        <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E4" sources="//@children.0/@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E5" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <children identifier="N6" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="123.0" text="ThreadedComposite2"/>
+    <ports identifier="P11" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L8" height="15.0" width="150.0" text="ThreadedCompositeInside"/>
+      <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="87.0" text="ExecutionTime"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="74.0" text="Accumulator"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E6" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E7" sources="//@children.2/@children.0/@children.0/@ports.0" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E8" sources="//@children.2/@children.0/@children.2/@ports.1" targets="//@children.2/@children.0/@children.1/@ports.0"/>
+    </children>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_tokenring_TokenRing_complicated.elkg
+++ b/realworld/ptolemy/hierarchical/sr_tokenring_TokenRing_complicated.elkg
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Request1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="97.0" text="NonStrictDisplay"/>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2 //@containedEdges.5 //@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="41.0" text="Block2"/>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.4" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.3" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.2/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3" incomingEdges="//@children.2/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="20.0" text="OR"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="35.0" text="AND2"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="28.0" text="AND"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="37.0" text="NAND"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="38.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.2/@ports.4" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.2/@ports.4" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.2/@ports.1" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.2/@ports.1" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@ports.5"/>
+    <containedEdges identifier="E28" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.4/@ports.1" targets="//@children.2/@ports.3"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="41.0" text="Block3"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.4" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.3" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.3/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.3/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6" incomingEdges="//@children.3/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="20.0" text="OR"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.5 //@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="35.0" text="AND2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.5 //@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="28.0" text="AND"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="37.0" text="NAND"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="38.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="38.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E30" sources="//@children.3/@ports.4" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.3/@ports.4" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.3/@ports.1" targets="//@children.3/@children.4/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E38" sources="//@children.3/@children.2/@ports.1" targets="//@children.3/@ports.5"/>
+    <containedEdges identifier="E39" sources="//@children.3/@children.3/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.3/@children.4/@ports.1" targets="//@children.3/@ports.3"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="41.0" text="Block1"/>
+    <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2 //@children.4/@containedEdges.3" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.4/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.4/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10 //@containedEdges.11" incomingEdges="//@children.4/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="20.0" text="OR"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.2 //@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.5 //@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="35.0" text="AND2"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.5 //@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="28.0" text="AND"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="37.0" text="NAND"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="87.0" text="NonStrictDelay"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E41" sources="//@children.4/@ports.4" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.4/@ports.4" targets="//@children.4/@children.3/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.4/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.4/@ports.1" targets="//@children.4/@children.4/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E49" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@ports.5"/>
+    <containedEdges identifier="E50" sources="//@children.4/@children.3/@ports.1" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.4/@children.4/@ports.1" targets="//@children.4/@ports.3"/>
+  </children>
+  <children identifier="N21" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L21" height="15.0" width="56.0" text="Request2"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N22" height="25.0" width="33.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="56.0" text="Request3"/>
+    <ports identifier="P54" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="97.0" text="SequencePlotter"/>
+    <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15 //@containedEdges.16 //@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="112.0" text="BooleanToAnything"/>
+    <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P58" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N25" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L25" height="15.0" width="123.0" text="1:BooleanToAnything"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N26" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L26" height="15.0" width="123.0" text="2:BooleanToAnything"/>
+    <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.4/@ports.4"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.5" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.5" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.5" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.5" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.2" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.5" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.5" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.4/@ports.3" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.5/@ports.0" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E15" sources="//@children.6/@ports.0" targets="//@children.3/@ports.4"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E17" sources="//@children.9/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E18" sources="//@children.10/@ports.1" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/sr_trafficlight_WirelessDeployment.elkg
+++ b/realworld/ptolemy/hierarchical/sr_trafficlight_WirelessDeployment.elkg
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="48.0" text="CarLight"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="48.0" text="CarLight"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="0.1666666716337204" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="32.83333206176758" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-7"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="74.0" text="SetVariable3"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="74.0" text="SetVariable4"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="SetVariable5"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.12 //@children.0/@containedEdges.13 //@children.0/@containedEdges.14 //@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="64.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="64.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="75.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="75.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="69.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="69.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.4" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.7"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@ports.6"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="90.0" text="PedestrianLight"/>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5 //@children.1/@containedEdges.6 //@children.1/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="90.0" text="PedestrianLight"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-6"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="139.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="150.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="144.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="94.0" text="BooleanSwitch3"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="135.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="94.0" text="BooleanSwitch4"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@ports.0" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.0" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.1/@ports.0" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@ports.0" targets="//@children.1/@children.10/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.1/@ports.0" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.0/@ports.5"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.0/@ports.6"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.0/@ports.4"/>
+    <containedEdges identifier="E34" sources="//@children.1/@children.10/@ports.0" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.1/@children.11/@ports.2" targets="//@children.1/@children.0/@ports.3"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/syntactic_LoopSyntacticC.elkg
+++ b/realworld/ptolemy/hierarchical/syntactic_LoopSyntacticC.elkg
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="110.0" text="DDFBooleanSelect"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="46.0" width="39.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="87.0" text="BooleanSwitch"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@containedEdges.2 //@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6 //@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="77.0" text="SampleDelay"/>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.8 //@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="138.0" text="Outside-the-loop Plotter"/>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="127.0" text="Inside-the-loop Plotter"/>
+    <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="31.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="68.0" text="Comparator"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@containedEdges.10 //@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P21" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N10">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L10" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P24" height="8.0" width="8.0" incomingEdges="//@children.9/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.2 //@containedEdges.14" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P26" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13" incomingEdges="//@children.9/@containedEdges.4 //@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="87.0" text="MovingAverage"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.1 //@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.9/@ports.0" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.9/@ports.2" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.9/@children.1/@ports.2" targets="//@children.9/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.9/@children.2/@ports.0" targets="//@children.9/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N14" height="47.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="118.0" text="DDFBooleanSelect2"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="10.333333015441895" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="28.66666603088379" incomingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="16.5" y="47.0" incomingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="41.0" y="19.5" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="25.0" width="46.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="85.0" text="SampleDelay2"/>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.3" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.3" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.7/@ports.2" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E12" sources="//@children.7/@ports.2" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.8/@ports.0" targets="//@children.7/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.9/@ports.3" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.9/@ports.2" targets="//@children.9/@ports.3"/>
+  <containedEdges identifier="E16" sources="//@children.10/@ports.3" targets="//@children.9/@ports.2"/>
+  <containedEdges identifier="E17" sources="//@children.11/@ports.0" targets="//@children.10/@ports.1"/>
+  <containedEdges identifier="E18" sources="//@children.12/@ports.1" targets="//@children.10/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/tdl_activerearsteeringct_ActiveRearSteeringCT.elkg
+++ b/realworld/ptolemy/hierarchical/tdl_activerearsteeringct_ActiveRearSteeringCT.elkg
@@ -1,0 +1,2904 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="164.0" text="signalGenerator_frontgAngle"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="75.0" text="smoothJump"/>
+      <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E23" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.0/@children.6/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.0/@children.7/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="82.0" text="smoothJump2"/>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.2 //@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.0/@children.1/@children.0/@ports.2" targets="//@children.0/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.1/@children.1/@ports.1" targets="//@children.0/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.1/@children.2/@ports.1" targets="//@children.0/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.1/@children.3/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.1/@children.4/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.1/@children.5/@ports.0" targets="//@children.0/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.1/@children.6/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.1/@children.7/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N20" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L21" height="15.0" width="82.0" text="smoothJump3"/>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3" incomingEdges="//@children.0/@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.2 //@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E39" sources="//@children.0/@children.3/@children.0/@ports.2" targets="//@children.0/@children.3/@children.1/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.3/@children.1/@ports.1" targets="//@children.0/@children.3/@children.6/@ports.1"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.3/@children.2/@ports.1" targets="//@children.0/@children.3/@children.4/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.0/@children.3/@children.3/@ports.0" targets="//@children.0/@children.3/@children.0/@ports.1"/>
+      <containedEdges identifier="E43" sources="//@children.0/@children.3/@children.4/@ports.2" targets="//@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.3/@children.5/@ports.0" targets="//@children.0/@children.3/@children.4/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.3/@children.6/@ports.0" targets="//@children.0/@children.3/@children.2/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.0/@children.3/@children.7/@ports.0" targets="//@children.0/@children.3/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="82.0" text="smoothJump4"/>
+      <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@children.0/@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.2 //@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E47" sources="//@children.0/@children.4/@children.0/@ports.2" targets="//@children.0/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.4/@children.1/@ports.1" targets="//@children.0/@children.4/@children.6/@ports.1"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.4/@children.2/@ports.1" targets="//@children.0/@children.4/@children.4/@ports.0"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.4/@children.3/@ports.0" targets="//@children.0/@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.4/@children.4/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.4/@children.5/@ports.0" targets="//@children.0/@children.4/@children.4/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.4/@children.6/@ports.0" targets="//@children.0/@children.4/@children.2/@ports.0"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.4/@children.7/@ports.0" targets="//@children.0/@children.4/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N40">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L40" height="15.0" width="153.0" text="signalBuilder_speedProfile"/>
+    <ports identifier="P83" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N41" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.10 //@children.1/@containedEdges.33 //@children.1/@containedEdges.43 //@children.1/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5 //@children.1/@containedEdges.6 //@children.1/@containedEdges.7 //@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12 //@children.1/@containedEdges.13 //@children.1/@containedEdges.14 //@children.1/@containedEdges.15 //@children.1/@containedEdges.16 //@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.19 //@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.20 //@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="62.0" text="EventFilter"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="69.0" text="EventFilter2"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P115" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="75.0" text="Comparator3"/>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.28 //@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.29 //@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="75.0" text="Comparator4"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P127" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N60" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="69.0" text="EventFilter3"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="69.0" text="LogicalNot2"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="89.0" text="LogicFunction3"/>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.25 //@children.1/@containedEdges.35 //@children.1/@containedEdges.45 //@children.1/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N63" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P136" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N64" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="75.0" text="Comparator5"/>
+      <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="89.0" text="LogicFunction4"/>
+      <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.38 //@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P142" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.39 //@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N66" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="75.0" text="Comparator6"/>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N67" height="25.0" width="24.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P146" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="42.0" text="Ramp3"/>
+      <ports identifier="P148" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="69.0" text="EventFilter4"/>
+      <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="69.0" text="LogicalNot3"/>
+      <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="25.0" width="24.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="42.0" text="Const8"/>
+      <ports identifier="P155" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N72" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L72" height="15.0" width="42.0" text="Const9"/>
+      <ports identifier="P157" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N73" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="75.0" text="Comparator7"/>
+      <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P161" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.48 //@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="69.0" text="LogicalNot4"/>
+      <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P163" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="69.0" text="EventFilter5"/>
+      <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E55" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E59" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.13/@ports.1"/>
+    <containedEdges identifier="E61" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.17/@ports.1"/>
+    <containedEdges identifier="E62" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.22/@ports.1"/>
+    <containedEdges identifier="E63" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.26/@ports.1"/>
+    <containedEdges identifier="E64" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.30/@ports.1"/>
+    <containedEdges identifier="E65" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.16/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.23/@ports.0"/>
+    <containedEdges identifier="E71" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.25/@ports.0"/>
+    <containedEdges identifier="E72" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.32/@ports.0"/>
+    <containedEdges identifier="E73" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E74" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E75" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E76" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E77" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E78" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E79" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E80" sources="//@children.1/@children.11/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E81" sources="//@children.1/@children.12/@ports.1" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E82" sources="//@children.1/@children.13/@ports.0" targets="//@children.1/@children.14/@ports.1"/>
+    <containedEdges identifier="E83" sources="//@children.1/@children.14/@ports.2" targets="//@children.1/@children.15/@ports.0"/>
+    <containedEdges identifier="E84" sources="//@children.1/@children.15/@ports.1" targets="//@children.1/@children.19/@ports.0"/>
+    <containedEdges identifier="E85" sources="//@children.1/@children.15/@ports.1" targets="//@children.1/@children.20/@ports.0"/>
+    <containedEdges identifier="E86" sources="//@children.1/@children.16/@ports.2" targets="//@children.1/@children.15/@ports.0"/>
+    <containedEdges identifier="E87" sources="//@children.1/@children.17/@ports.0" targets="//@children.1/@children.16/@ports.1"/>
+    <containedEdges identifier="E88" sources="//@children.1/@children.18/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E89" sources="//@children.1/@children.19/@ports.1" targets="//@children.1/@children.18/@ports.1"/>
+    <containedEdges identifier="E90" sources="//@children.1/@children.20/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E91" sources="//@children.1/@children.21/@ports.1" targets="//@children.1/@children.12/@ports.0"/>
+    <containedEdges identifier="E92" sources="//@children.1/@children.22/@ports.0" targets="//@children.1/@children.23/@ports.1"/>
+    <containedEdges identifier="E93" sources="//@children.1/@children.23/@ports.2" targets="//@children.1/@children.24/@ports.0"/>
+    <containedEdges identifier="E94" sources="//@children.1/@children.24/@ports.1" targets="//@children.1/@children.28/@ports.0"/>
+    <containedEdges identifier="E95" sources="//@children.1/@children.24/@ports.1" targets="//@children.1/@children.29/@ports.0"/>
+    <containedEdges identifier="E96" sources="//@children.1/@children.25/@ports.2" targets="//@children.1/@children.24/@ports.0"/>
+    <containedEdges identifier="E97" sources="//@children.1/@children.26/@ports.0" targets="//@children.1/@children.25/@ports.1"/>
+    <containedEdges identifier="E98" sources="//@children.1/@children.27/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E99" sources="//@children.1/@children.28/@ports.1" targets="//@children.1/@children.27/@ports.1"/>
+    <containedEdges identifier="E100" sources="//@children.1/@children.29/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E101" sources="//@children.1/@children.30/@ports.0" targets="//@children.1/@children.32/@ports.1"/>
+    <containedEdges identifier="E102" sources="//@children.1/@children.31/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E103" sources="//@children.1/@children.32/@ports.2" targets="//@children.1/@children.33/@ports.0"/>
+    <containedEdges identifier="E104" sources="//@children.1/@children.32/@ports.2" targets="//@children.1/@children.34/@ports.0"/>
+    <containedEdges identifier="E105" sources="//@children.1/@children.33/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E106" sources="//@children.1/@children.34/@ports.1" targets="//@children.1/@children.31/@ports.1"/>
+  </children>
+  <children identifier="N76" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="42.0" text="sigGen"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="59.0" text="speedProf"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N78">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L78" height="15.0" width="43.0" text="Vehicle"/>
+    <ports identifier="P168" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8" incomingEdges="//@children.4/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.4/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.4/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N79">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L79" height="15.0" width="103.0" text="Lin Einspurmodell"/>
+      <ports identifier="P174" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P178" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P179" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N80" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P181" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="41.0" text="Scale3"/>
+        <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P185" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L83" height="15.0" width="104.0" text="LinearStateSpace"/>
+        <ports identifier="P186" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.0 //@children.4/@children.0/@children.3/@containedEdges.1 //@children.4/@children.0/@children.3/@containedEdges.2 //@children.4/@children.0/@children.3/@containedEdges.3 //@children.4/@children.0/@children.3/@containedEdges.4 //@children.4/@children.0/@children.3/@containedEdges.5 //@children.4/@children.0/@children.3/@containedEdges.6 //@children.4/@children.0/@children.3/@containedEdges.7 //@children.4/@children.0/@children.3/@containedEdges.8 //@children.4/@children.0/@children.3/@containedEdges.9 //@children.4/@children.0/@children.3/@containedEdges.10 //@children.4/@children.0/@children.3/@containedEdges.11 //@children.4/@children.0/@children.3/@containedEdges.12 //@children.4/@children.0/@children.3/@containedEdges.13 //@children.4/@children.0/@children.3/@containedEdges.14 //@children.4/@children.0/@children.3/@containedEdges.15 //@children.4/@children.0/@children.3/@containedEdges.16 //@children.4/@children.0/@children.3/@containedEdges.17" incomingEdges="//@children.4/@children.0/@containedEdges.0 //@children.4/@children.0/@containedEdges.1 //@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P187" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.6 //@children.4/@children.0/@containedEdges.7" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.78 //@children.4/@children.0/@children.3/@containedEdges.83">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P188" height="8.0" width="8.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.18 //@children.4/@children.0/@children.3/@containedEdges.26 //@children.4/@children.0/@children.3/@containedEdges.34 //@children.4/@children.0/@children.3/@containedEdges.42">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N84" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L84" height="15.0" width="44.0" text="state_0"/>
+          <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P190" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.18 //@children.4/@children.0/@children.3/@containedEdges.19 //@children.4/@children.0/@children.3/@containedEdges.20 //@children.4/@children.0/@children.3/@containedEdges.21 //@children.4/@children.0/@children.3/@containedEdges.22 //@children.4/@children.0/@children.3/@containedEdges.23 //@children.4/@children.0/@children.3/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N85" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L85" height="15.0" width="78.0" text="stateAdder_0"/>
+          <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.50 //@children.4/@children.0/@children.3/@containedEdges.51 //@children.4/@children.0/@children.3/@containedEdges.52 //@children.4/@children.0/@children.3/@containedEdges.53 //@children.4/@children.0/@children.3/@containedEdges.66 //@children.4/@children.0/@children.3/@containedEdges.70 //@children.4/@children.0/@children.3/@containedEdges.74">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P192" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P193" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.25">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N86" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L86" height="15.0" width="44.0" text="state_1"/>
+          <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P195" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.26 //@children.4/@children.0/@children.3/@containedEdges.27 //@children.4/@children.0/@children.3/@containedEdges.28 //@children.4/@children.0/@children.3/@containedEdges.29 //@children.4/@children.0/@children.3/@containedEdges.30 //@children.4/@children.0/@children.3/@containedEdges.31 //@children.4/@children.0/@children.3/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N87" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L87" height="15.0" width="78.0" text="stateAdder_1"/>
+          <ports identifier="P196" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.54 //@children.4/@children.0/@children.3/@containedEdges.55 //@children.4/@children.0/@children.3/@containedEdges.56 //@children.4/@children.0/@children.3/@containedEdges.57 //@children.4/@children.0/@children.3/@containedEdges.67 //@children.4/@children.0/@children.3/@containedEdges.71 //@children.4/@children.0/@children.3/@containedEdges.75">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P197" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P198" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.33">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N88" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L88" height="15.0" width="44.0" text="state_2"/>
+          <ports identifier="P199" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P200" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.34 //@children.4/@children.0/@children.3/@containedEdges.35 //@children.4/@children.0/@children.3/@containedEdges.36 //@children.4/@children.0/@children.3/@containedEdges.37 //@children.4/@children.0/@children.3/@containedEdges.38 //@children.4/@children.0/@children.3/@containedEdges.39 //@children.4/@children.0/@children.3/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N89" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L89" height="15.0" width="78.0" text="stateAdder_2"/>
+          <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.58 //@children.4/@children.0/@children.3/@containedEdges.59 //@children.4/@children.0/@children.3/@containedEdges.60 //@children.4/@children.0/@children.3/@containedEdges.61 //@children.4/@children.0/@children.3/@containedEdges.68 //@children.4/@children.0/@children.3/@containedEdges.72 //@children.4/@children.0/@children.3/@containedEdges.76">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P202" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P203" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.41">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N90" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L90" height="15.0" width="44.0" text="state_3"/>
+          <ports identifier="P204" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.49">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P205" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.42 //@children.4/@children.0/@children.3/@containedEdges.43 //@children.4/@children.0/@children.3/@containedEdges.44 //@children.4/@children.0/@children.3/@containedEdges.45 //@children.4/@children.0/@children.3/@containedEdges.46 //@children.4/@children.0/@children.3/@containedEdges.47 //@children.4/@children.0/@children.3/@containedEdges.48">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N91" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L91" height="15.0" width="78.0" text="stateAdder_3"/>
+          <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.62 //@children.4/@children.0/@children.3/@containedEdges.63 //@children.4/@children.0/@children.3/@containedEdges.64 //@children.4/@children.0/@children.3/@containedEdges.65 //@children.4/@children.0/@children.3/@containedEdges.69 //@children.4/@children.0/@children.3/@containedEdges.73 //@children.4/@children.0/@children.3/@containedEdges.77">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P208" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.49">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N92" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L92" height="15.0" width="81.0" text="feedback_0_0"/>
+          <ports identifier="P209" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.19">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P210" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.50">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N93" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L93" height="15.0" width="81.0" text="feedback_0_1"/>
+          <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.27">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P212" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.51">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N94" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="81.0" text="feedback_0_2"/>
+          <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.35">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P214" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.52">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N95" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L95" height="15.0" width="81.0" text="feedback_0_3"/>
+          <ports identifier="P215" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.43">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P216" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.53">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N96" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L96" height="15.0" width="81.0" text="feedback_1_0"/>
+          <ports identifier="P217" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.20">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P218" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.54">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N97" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L97" height="15.0" width="81.0" text="feedback_1_1"/>
+          <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.28">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P220" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.55">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N98" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L98" height="15.0" width="81.0" text="feedback_1_2"/>
+          <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.36">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P222" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.56">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N99" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L99" height="15.0" width="81.0" text="feedback_1_3"/>
+          <ports identifier="P223" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.44">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P224" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.57">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N100" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L100" height="15.0" width="81.0" text="feedback_2_0"/>
+          <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.21">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P226" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.58">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N101" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L101" height="15.0" width="81.0" text="feedback_2_1"/>
+          <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.29">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P228" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.59">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N102" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L102" height="15.0" width="81.0" text="feedback_2_2"/>
+          <ports identifier="P229" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.37">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P230" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.60">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N103" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L103" height="15.0" width="81.0" text="feedback_2_3"/>
+          <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.45">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P232" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.61">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N104" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L104" height="15.0" width="81.0" text="feedback_3_0"/>
+          <ports identifier="P233" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.22">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P234" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.62">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N105" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L105" height="15.0" width="81.0" text="feedback_3_1"/>
+          <ports identifier="P235" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.30">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P236" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.63">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N106" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L106" height="15.0" width="81.0" text="feedback_3_2"/>
+          <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.38">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P238" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.64">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N107" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L107" height="15.0" width="81.0" text="feedback_3_3"/>
+          <ports identifier="P239" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.46">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P240" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.65">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N108" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L108" height="15.0" width="36.0" text="b_0_0"/>
+          <ports identifier="P241" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P242" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.66">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N109" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L109" height="15.0" width="36.0" text="b_1_0"/>
+          <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P244" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.67">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N110" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L110" height="15.0" width="36.0" text="b_2_0"/>
+          <ports identifier="P245" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P246" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.68">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N111" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L111" height="15.0" width="36.0" text="b_3_0"/>
+          <ports identifier="P247" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P248" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.69">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N112" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L112" height="15.0" width="36.0" text="b_0_1"/>
+          <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P250" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.70">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N113" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L113" height="15.0" width="36.0" text="b_1_1"/>
+          <ports identifier="P251" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.7">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P252" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.71">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N114" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L114" height="15.0" width="36.0" text="b_2_1"/>
+          <ports identifier="P253" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.8">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P254" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.72">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N115" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L115" height="15.0" width="36.0" text="b_3_1"/>
+          <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.9">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P256" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.73">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N116" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L116" height="15.0" width="36.0" text="b_0_2"/>
+          <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.12">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P258" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.74">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N117" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L117" height="15.0" width="36.0" text="b_1_2"/>
+          <ports identifier="P259" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.13">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P260" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.75">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N118" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L118" height="15.0" width="36.0" text="b_2_2"/>
+          <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.14">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P262" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.76">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N119" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L119" height="15.0" width="36.0" text="b_3_2"/>
+          <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.15">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P264" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.77">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N120" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L120" height="15.0" width="78.0" text="outputAdder0"/>
+          <ports identifier="P265" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.79 //@children.4/@children.0/@children.3/@containedEdges.80 //@children.4/@children.0/@children.3/@containedEdges.81 //@children.4/@children.0/@children.3/@containedEdges.82 //@children.4/@children.0/@children.3/@containedEdges.88 //@children.4/@children.0/@children.3/@containedEdges.89 //@children.4/@children.0/@children.3/@containedEdges.90">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P267" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.78">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N121" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L121" height="15.0" width="98.0" text="outputScale_0_0"/>
+          <ports identifier="P268" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.23">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P269" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.79">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N122" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L122" height="15.0" width="98.0" text="outputScale_0_1"/>
+          <ports identifier="P270" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.31">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P271" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.80">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N123" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L123" height="15.0" width="98.0" text="outputScale_0_2"/>
+          <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.39">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P273" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.81">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N124" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L124" height="15.0" width="98.0" text="outputScale_0_3"/>
+          <ports identifier="P274" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.47">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P275" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.82">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N125" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L125" height="15.0" width="78.0" text="outputAdder1"/>
+          <ports identifier="P276" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.84 //@children.4/@children.0/@children.3/@containedEdges.85 //@children.4/@children.0/@children.3/@containedEdges.86 //@children.4/@children.0/@children.3/@containedEdges.87 //@children.4/@children.0/@children.3/@containedEdges.91 //@children.4/@children.0/@children.3/@containedEdges.92 //@children.4/@children.0/@children.3/@containedEdges.93">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P277" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P278" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.83">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N126" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L126" height="15.0" width="98.0" text="outputScale_1_0"/>
+          <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.24">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P280" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.84">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N127" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L127" height="15.0" width="98.0" text="outputScale_1_1"/>
+          <ports identifier="P281" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.32">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P282" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.85">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N128" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L128" height="15.0" width="98.0" text="outputScale_1_2"/>
+          <ports identifier="P283" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.40">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P284" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.86">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N129" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L129" height="15.0" width="98.0" text="outputScale_1_3"/>
+          <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.48">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P286" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.87">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N130" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L130" height="15.0" width="99.0" text="feedThrough_0_0"/>
+          <ports identifier="P287" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P288" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.88">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N131" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L131" height="15.0" width="99.0" text="feedThrough_0_1"/>
+          <ports identifier="P289" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.10">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P290" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.89">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N132" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L132" height="15.0" width="99.0" text="feedThrough_0_2"/>
+          <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.16">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P292" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.90">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N133" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L133" height="15.0" width="99.0" text="feedThrough_1_0"/>
+          <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P294" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.91">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N134" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L134" height="15.0" width="99.0" text="feedThrough_1_1"/>
+          <ports identifier="P295" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.11">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P296" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.92">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N135" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L135" height="15.0" width="99.0" text="feedThrough_1_2"/>
+          <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@children.3/@containedEdges.17">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P298" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@children.3/@containedEdges.93">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E123" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.24/@ports.0"/>
+        <containedEdges identifier="E124" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.25/@ports.0"/>
+        <containedEdges identifier="E125" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.26/@ports.0"/>
+        <containedEdges identifier="E126" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.27/@ports.0"/>
+        <containedEdges identifier="E127" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.46/@ports.0"/>
+        <containedEdges identifier="E128" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.49/@ports.0"/>
+        <containedEdges identifier="E129" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.28/@ports.0"/>
+        <containedEdges identifier="E130" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.29/@ports.0"/>
+        <containedEdges identifier="E131" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.30/@ports.0"/>
+        <containedEdges identifier="E132" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.31/@ports.0"/>
+        <containedEdges identifier="E133" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.47/@ports.0"/>
+        <containedEdges identifier="E134" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.50/@ports.0"/>
+        <containedEdges identifier="E135" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.32/@ports.0"/>
+        <containedEdges identifier="E136" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.33/@ports.0"/>
+        <containedEdges identifier="E137" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.34/@ports.0"/>
+        <containedEdges identifier="E138" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.35/@ports.0"/>
+        <containedEdges identifier="E139" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.48/@ports.0"/>
+        <containedEdges identifier="E140" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.3/@children.51/@ports.0"/>
+        <containedEdges identifier="E141" sources="//@children.4/@children.0/@children.3/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.2"/>
+        <containedEdges identifier="E142" sources="//@children.4/@children.0/@children.3/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@children.8/@ports.0"/>
+        <containedEdges identifier="E143" sources="//@children.4/@children.0/@children.3/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@children.12/@ports.0"/>
+        <containedEdges identifier="E144" sources="//@children.4/@children.0/@children.3/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@children.16/@ports.0"/>
+        <containedEdges identifier="E145" sources="//@children.4/@children.0/@children.3/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@children.20/@ports.0"/>
+        <containedEdges identifier="E146" sources="//@children.4/@children.0/@children.3/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@children.37/@ports.0"/>
+        <containedEdges identifier="E147" sources="//@children.4/@children.0/@children.3/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@children.42/@ports.0"/>
+        <containedEdges identifier="E148" sources="//@children.4/@children.0/@children.3/@children.1/@ports.2" targets="//@children.4/@children.0/@children.3/@children.0/@ports.0"/>
+        <containedEdges identifier="E149" sources="//@children.4/@children.0/@children.3/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.2"/>
+        <containedEdges identifier="E150" sources="//@children.4/@children.0/@children.3/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@children.9/@ports.0"/>
+        <containedEdges identifier="E151" sources="//@children.4/@children.0/@children.3/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@children.13/@ports.0"/>
+        <containedEdges identifier="E152" sources="//@children.4/@children.0/@children.3/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@children.17/@ports.0"/>
+        <containedEdges identifier="E153" sources="//@children.4/@children.0/@children.3/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@children.21/@ports.0"/>
+        <containedEdges identifier="E154" sources="//@children.4/@children.0/@children.3/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@children.38/@ports.0"/>
+        <containedEdges identifier="E155" sources="//@children.4/@children.0/@children.3/@children.2/@ports.1" targets="//@children.4/@children.0/@children.3/@children.43/@ports.0"/>
+        <containedEdges identifier="E156" sources="//@children.4/@children.0/@children.3/@children.3/@ports.2" targets="//@children.4/@children.0/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E157" sources="//@children.4/@children.0/@children.3/@children.4/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.2"/>
+        <containedEdges identifier="E158" sources="//@children.4/@children.0/@children.3/@children.4/@ports.1" targets="//@children.4/@children.0/@children.3/@children.10/@ports.0"/>
+        <containedEdges identifier="E159" sources="//@children.4/@children.0/@children.3/@children.4/@ports.1" targets="//@children.4/@children.0/@children.3/@children.14/@ports.0"/>
+        <containedEdges identifier="E160" sources="//@children.4/@children.0/@children.3/@children.4/@ports.1" targets="//@children.4/@children.0/@children.3/@children.18/@ports.0"/>
+        <containedEdges identifier="E161" sources="//@children.4/@children.0/@children.3/@children.4/@ports.1" targets="//@children.4/@children.0/@children.3/@children.22/@ports.0"/>
+        <containedEdges identifier="E162" sources="//@children.4/@children.0/@children.3/@children.4/@ports.1" targets="//@children.4/@children.0/@children.3/@children.39/@ports.0"/>
+        <containedEdges identifier="E163" sources="//@children.4/@children.0/@children.3/@children.4/@ports.1" targets="//@children.4/@children.0/@children.3/@children.44/@ports.0"/>
+        <containedEdges identifier="E164" sources="//@children.4/@children.0/@children.3/@children.5/@ports.2" targets="//@children.4/@children.0/@children.3/@children.4/@ports.0"/>
+        <containedEdges identifier="E165" sources="//@children.4/@children.0/@children.3/@children.6/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.2"/>
+        <containedEdges identifier="E166" sources="//@children.4/@children.0/@children.3/@children.6/@ports.1" targets="//@children.4/@children.0/@children.3/@children.11/@ports.0"/>
+        <containedEdges identifier="E167" sources="//@children.4/@children.0/@children.3/@children.6/@ports.1" targets="//@children.4/@children.0/@children.3/@children.15/@ports.0"/>
+        <containedEdges identifier="E168" sources="//@children.4/@children.0/@children.3/@children.6/@ports.1" targets="//@children.4/@children.0/@children.3/@children.19/@ports.0"/>
+        <containedEdges identifier="E169" sources="//@children.4/@children.0/@children.3/@children.6/@ports.1" targets="//@children.4/@children.0/@children.3/@children.23/@ports.0"/>
+        <containedEdges identifier="E170" sources="//@children.4/@children.0/@children.3/@children.6/@ports.1" targets="//@children.4/@children.0/@children.3/@children.40/@ports.0"/>
+        <containedEdges identifier="E171" sources="//@children.4/@children.0/@children.3/@children.6/@ports.1" targets="//@children.4/@children.0/@children.3/@children.45/@ports.0"/>
+        <containedEdges identifier="E172" sources="//@children.4/@children.0/@children.3/@children.7/@ports.2" targets="//@children.4/@children.0/@children.3/@children.6/@ports.0"/>
+        <containedEdges identifier="E173" sources="//@children.4/@children.0/@children.3/@children.8/@ports.1" targets="//@children.4/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E174" sources="//@children.4/@children.0/@children.3/@children.9/@ports.1" targets="//@children.4/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E175" sources="//@children.4/@children.0/@children.3/@children.10/@ports.1" targets="//@children.4/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E176" sources="//@children.4/@children.0/@children.3/@children.11/@ports.1" targets="//@children.4/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E177" sources="//@children.4/@children.0/@children.3/@children.12/@ports.1" targets="//@children.4/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E178" sources="//@children.4/@children.0/@children.3/@children.13/@ports.1" targets="//@children.4/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E179" sources="//@children.4/@children.0/@children.3/@children.14/@ports.1" targets="//@children.4/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E180" sources="//@children.4/@children.0/@children.3/@children.15/@ports.1" targets="//@children.4/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E181" sources="//@children.4/@children.0/@children.3/@children.16/@ports.1" targets="//@children.4/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E182" sources="//@children.4/@children.0/@children.3/@children.17/@ports.1" targets="//@children.4/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E183" sources="//@children.4/@children.0/@children.3/@children.18/@ports.1" targets="//@children.4/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E184" sources="//@children.4/@children.0/@children.3/@children.19/@ports.1" targets="//@children.4/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E185" sources="//@children.4/@children.0/@children.3/@children.20/@ports.1" targets="//@children.4/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E186" sources="//@children.4/@children.0/@children.3/@children.21/@ports.1" targets="//@children.4/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E187" sources="//@children.4/@children.0/@children.3/@children.22/@ports.1" targets="//@children.4/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E188" sources="//@children.4/@children.0/@children.3/@children.23/@ports.1" targets="//@children.4/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E189" sources="//@children.4/@children.0/@children.3/@children.24/@ports.1" targets="//@children.4/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E190" sources="//@children.4/@children.0/@children.3/@children.25/@ports.1" targets="//@children.4/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E191" sources="//@children.4/@children.0/@children.3/@children.26/@ports.1" targets="//@children.4/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E192" sources="//@children.4/@children.0/@children.3/@children.27/@ports.1" targets="//@children.4/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E193" sources="//@children.4/@children.0/@children.3/@children.28/@ports.1" targets="//@children.4/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E194" sources="//@children.4/@children.0/@children.3/@children.29/@ports.1" targets="//@children.4/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E195" sources="//@children.4/@children.0/@children.3/@children.30/@ports.1" targets="//@children.4/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E196" sources="//@children.4/@children.0/@children.3/@children.31/@ports.1" targets="//@children.4/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E197" sources="//@children.4/@children.0/@children.3/@children.32/@ports.1" targets="//@children.4/@children.0/@children.3/@children.1/@ports.0"/>
+        <containedEdges identifier="E198" sources="//@children.4/@children.0/@children.3/@children.33/@ports.1" targets="//@children.4/@children.0/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E199" sources="//@children.4/@children.0/@children.3/@children.34/@ports.1" targets="//@children.4/@children.0/@children.3/@children.5/@ports.0"/>
+        <containedEdges identifier="E200" sources="//@children.4/@children.0/@children.3/@children.35/@ports.1" targets="//@children.4/@children.0/@children.3/@children.7/@ports.0"/>
+        <containedEdges identifier="E201" sources="//@children.4/@children.0/@children.3/@children.36/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E202" sources="//@children.4/@children.0/@children.3/@children.37/@ports.1" targets="//@children.4/@children.0/@children.3/@children.36/@ports.0"/>
+        <containedEdges identifier="E203" sources="//@children.4/@children.0/@children.3/@children.38/@ports.1" targets="//@children.4/@children.0/@children.3/@children.36/@ports.0"/>
+        <containedEdges identifier="E204" sources="//@children.4/@children.0/@children.3/@children.39/@ports.1" targets="//@children.4/@children.0/@children.3/@children.36/@ports.0"/>
+        <containedEdges identifier="E205" sources="//@children.4/@children.0/@children.3/@children.40/@ports.1" targets="//@children.4/@children.0/@children.3/@children.36/@ports.0"/>
+        <containedEdges identifier="E206" sources="//@children.4/@children.0/@children.3/@children.41/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.1"/>
+        <containedEdges identifier="E207" sources="//@children.4/@children.0/@children.3/@children.42/@ports.1" targets="//@children.4/@children.0/@children.3/@children.41/@ports.0"/>
+        <containedEdges identifier="E208" sources="//@children.4/@children.0/@children.3/@children.43/@ports.1" targets="//@children.4/@children.0/@children.3/@children.41/@ports.0"/>
+        <containedEdges identifier="E209" sources="//@children.4/@children.0/@children.3/@children.44/@ports.1" targets="//@children.4/@children.0/@children.3/@children.41/@ports.0"/>
+        <containedEdges identifier="E210" sources="//@children.4/@children.0/@children.3/@children.45/@ports.1" targets="//@children.4/@children.0/@children.3/@children.41/@ports.0"/>
+        <containedEdges identifier="E211" sources="//@children.4/@children.0/@children.3/@children.46/@ports.1" targets="//@children.4/@children.0/@children.3/@children.36/@ports.0"/>
+        <containedEdges identifier="E212" sources="//@children.4/@children.0/@children.3/@children.47/@ports.1" targets="//@children.4/@children.0/@children.3/@children.36/@ports.0"/>
+        <containedEdges identifier="E213" sources="//@children.4/@children.0/@children.3/@children.48/@ports.1" targets="//@children.4/@children.0/@children.3/@children.36/@ports.0"/>
+        <containedEdges identifier="E214" sources="//@children.4/@children.0/@children.3/@children.49/@ports.1" targets="//@children.4/@children.0/@children.3/@children.41/@ports.0"/>
+        <containedEdges identifier="E215" sources="//@children.4/@children.0/@children.3/@children.50/@ports.1" targets="//@children.4/@children.0/@children.3/@children.41/@ports.0"/>
+        <containedEdges identifier="E216" sources="//@children.4/@children.0/@children.3/@children.51/@ports.1" targets="//@children.4/@children.0/@children.3/@children.41/@ports.0"/>
+      </children>
+      <containedEdges identifier="E115" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E116" sources="//@children.4/@children.0/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E118" sources="//@children.4/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E119" sources="//@children.4/@children.0/@children.1/@ports.1" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.4/@children.0/@children.2/@ports.1" targets="//@children.4/@children.0/@ports.4"/>
+      <containedEdges identifier="E121" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@ports.3"/>
+      <containedEdges identifier="E122" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N136" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L136" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P299" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P300" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N137">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L137" height="15.0" width="110.0" text="CTCompositeActor"/>
+      <ports identifier="P301" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P302" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.4 //@children.4/@containedEdges.5" incomingEdges="//@children.4/@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P303" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.7" incomingEdges="//@children.4/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P304" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.6" incomingEdges="//@children.4/@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N138">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L138" height="15.0" width="97.0" text="voltage converter"/>
+        <ports identifier="P305" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@children.0/@containedEdges.0" incomingEdges="//@children.4/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P306" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.1" incomingEdges="//@children.4/@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N139" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L139" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P307" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.0/@containedEdges.0 //@children.4/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P309" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N140" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L140" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P310" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P311" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P312" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.0/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N141" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L141" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P313" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.0/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P314" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.0/@containedEdges.3 //@children.4/@children.2/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N142" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L142" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.0/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P316" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.0/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N143" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L143" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P317" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.0/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P318" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.0/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E226" sources="//@children.4/@children.2/@children.0/@ports.0" targets="//@children.4/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E227" sources="//@children.4/@children.2/@children.0/@children.0/@ports.2" targets="//@children.4/@children.2/@children.0/@children.2/@ports.0"/>
+        <containedEdges identifier="E228" sources="//@children.4/@children.2/@children.0/@children.1/@ports.2" targets="//@children.4/@children.2/@children.0/@ports.1"/>
+        <containedEdges identifier="E229" sources="//@children.4/@children.2/@children.0/@children.2/@ports.1" targets="//@children.4/@children.2/@children.0/@children.3/@ports.0"/>
+        <containedEdges identifier="E230" sources="//@children.4/@children.2/@children.0/@children.2/@ports.1" targets="//@children.4/@children.2/@children.0/@children.4/@ports.0"/>
+        <containedEdges identifier="E231" sources="//@children.4/@children.2/@children.0/@children.3/@ports.1" targets="//@children.4/@children.2/@children.0/@children.0/@ports.0"/>
+        <containedEdges identifier="E232" sources="//@children.4/@children.2/@children.0/@children.4/@ports.1" targets="//@children.4/@children.2/@children.0/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N144">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L144" height="15.0" width="89.0" text="motor electrical"/>
+        <ports identifier="P319" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@children.1/@containedEdges.0" incomingEdges="//@children.4/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P320" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.2 //@children.4/@children.2/@containedEdges.3" incomingEdges="//@children.4/@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N145" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L145" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.1/@containedEdges.0 //@children.4/@children.2/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P322" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P323" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N146" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L146" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P324" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P325" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P326" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.1/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N147" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L147" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.1/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P328" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.1/@containedEdges.3 //@children.4/@children.2/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N148" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L148" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.1/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P330" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.1/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N149" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L149" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P331" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.1/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P332" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.1/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E233" sources="//@children.4/@children.2/@children.1/@ports.0" targets="//@children.4/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E234" sources="//@children.4/@children.2/@children.1/@children.0/@ports.2" targets="//@children.4/@children.2/@children.1/@children.2/@ports.0"/>
+        <containedEdges identifier="E235" sources="//@children.4/@children.2/@children.1/@children.1/@ports.2" targets="//@children.4/@children.2/@children.1/@ports.1"/>
+        <containedEdges identifier="E236" sources="//@children.4/@children.2/@children.1/@children.2/@ports.1" targets="//@children.4/@children.2/@children.1/@children.3/@ports.0"/>
+        <containedEdges identifier="E237" sources="//@children.4/@children.2/@children.1/@children.2/@ports.1" targets="//@children.4/@children.2/@children.1/@children.4/@ports.0"/>
+        <containedEdges identifier="E238" sources="//@children.4/@children.2/@children.1/@children.3/@ports.1" targets="//@children.4/@children.2/@children.1/@children.0/@ports.0"/>
+        <containedEdges identifier="E239" sources="//@children.4/@children.2/@children.1/@children.4/@ports.1" targets="//@children.4/@children.2/@children.1/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N150">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L150" height="15.0" width="103.0" text="motor mechanical"/>
+        <ports identifier="P333" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@children.2/@containedEdges.0" incomingEdges="//@children.4/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P334" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.4 //@children.4/@children.2/@containedEdges.5" incomingEdges="//@children.4/@children.2/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N151" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L151" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.2/@containedEdges.0 //@children.4/@children.2/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P336" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P337" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N152" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L152" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P340" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.2/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N153" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L153" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P341" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.2/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P342" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.2/@containedEdges.3 //@children.4/@children.2/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N154" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L154" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P343" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.2/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P344" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.2/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N155" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L155" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.2/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P346" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.2/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E240" sources="//@children.4/@children.2/@children.2/@ports.0" targets="//@children.4/@children.2/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E241" sources="//@children.4/@children.2/@children.2/@children.0/@ports.2" targets="//@children.4/@children.2/@children.2/@children.2/@ports.0"/>
+        <containedEdges identifier="E242" sources="//@children.4/@children.2/@children.2/@children.1/@ports.2" targets="//@children.4/@children.2/@children.2/@ports.1"/>
+        <containedEdges identifier="E243" sources="//@children.4/@children.2/@children.2/@children.2/@ports.1" targets="//@children.4/@children.2/@children.2/@children.3/@ports.0"/>
+        <containedEdges identifier="E244" sources="//@children.4/@children.2/@children.2/@children.2/@ports.1" targets="//@children.4/@children.2/@children.2/@children.4/@ports.0"/>
+        <containedEdges identifier="E245" sources="//@children.4/@children.2/@children.2/@children.3/@ports.1" targets="//@children.4/@children.2/@children.2/@children.0/@ports.0"/>
+        <containedEdges identifier="E246" sources="//@children.4/@children.2/@children.2/@children.4/@ports.1" targets="//@children.4/@children.2/@children.2/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N156">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L156" height="15.0" width="17.0" text="phi"/>
+        <ports identifier="P347" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@children.3/@containedEdges.0" incomingEdges="//@children.4/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P348" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.6" incomingEdges="//@children.4/@children.2/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N157" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L157" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P349" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.3/@containedEdges.0 //@children.4/@children.2/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P351" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N158" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L158" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P352" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P353" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P354" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.3/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N159" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L159" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P355" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P356" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.3/@containedEdges.3 //@children.4/@children.2/@children.3/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N160" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L160" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.3/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P358" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.3/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N161" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L161" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P359" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.3/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P360" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.3/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E247" sources="//@children.4/@children.2/@children.3/@ports.0" targets="//@children.4/@children.2/@children.3/@children.0/@ports.0"/>
+        <containedEdges identifier="E248" sources="//@children.4/@children.2/@children.3/@children.0/@ports.2" targets="//@children.4/@children.2/@children.3/@children.2/@ports.0"/>
+        <containedEdges identifier="E249" sources="//@children.4/@children.2/@children.3/@children.1/@ports.2" targets="//@children.4/@children.2/@children.3/@ports.1"/>
+        <containedEdges identifier="E250" sources="//@children.4/@children.2/@children.3/@children.2/@ports.1" targets="//@children.4/@children.2/@children.3/@children.3/@ports.0"/>
+        <containedEdges identifier="E251" sources="//@children.4/@children.2/@children.3/@children.2/@ports.1" targets="//@children.4/@children.2/@children.3/@children.4/@ports.0"/>
+        <containedEdges identifier="E252" sources="//@children.4/@children.2/@children.3/@children.3/@ports.1" targets="//@children.4/@children.2/@children.3/@children.0/@ports.0"/>
+        <containedEdges identifier="E253" sources="//@children.4/@children.2/@children.3/@children.4/@ports.1" targets="//@children.4/@children.2/@children.3/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N162">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L162" height="15.0" width="162.0" text="ContinuousTransferFunction"/>
+        <ports identifier="P361" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@children.4/@containedEdges.0" incomingEdges="//@children.4/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P362" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.7" incomingEdges="//@children.4/@children.2/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N163" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L163" height="15.0" width="63.0" text="InputAdder"/>
+          <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.4/@containedEdges.0 //@children.4/@children.2/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P365" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N164" height="41.0" width="41.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L164" height="15.0" width="74.0" text="OutputAdder"/>
+          <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P367" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+            <properties key="org.eclipse.elk.port.index" value="-1"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P368" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@children.4/@containedEdges.2">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N165" height="46.0" width="44.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L165" height="15.0" width="62.0" text="Integrator0"/>
+          <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.4/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P370" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.4/@containedEdges.3 //@children.4/@children.2/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N166" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L166" height="15.0" width="65.0" text="Feedback0"/>
+          <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.4/@containedEdges.3">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P372" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.4/@containedEdges.5">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <children identifier="N167" height="46.0" width="66.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L167" height="15.0" width="78.0" text="Feedforward0"/>
+          <ports identifier="P373" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@children.4/@containedEdges.4">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P374" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.2/@children.4/@containedEdges.6">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E254" sources="//@children.4/@children.2/@children.4/@ports.0" targets="//@children.4/@children.2/@children.4/@children.0/@ports.0"/>
+        <containedEdges identifier="E255" sources="//@children.4/@children.2/@children.4/@children.0/@ports.2" targets="//@children.4/@children.2/@children.4/@children.2/@ports.0"/>
+        <containedEdges identifier="E256" sources="//@children.4/@children.2/@children.4/@children.1/@ports.2" targets="//@children.4/@children.2/@children.4/@ports.1"/>
+        <containedEdges identifier="E257" sources="//@children.4/@children.2/@children.4/@children.2/@ports.1" targets="//@children.4/@children.2/@children.4/@children.3/@ports.0"/>
+        <containedEdges identifier="E258" sources="//@children.4/@children.2/@children.4/@children.2/@ports.1" targets="//@children.4/@children.2/@children.4/@children.4/@ports.0"/>
+        <containedEdges identifier="E259" sources="//@children.4/@children.2/@children.4/@children.3/@ports.1" targets="//@children.4/@children.2/@children.4/@children.0/@ports.0"/>
+        <containedEdges identifier="E260" sources="//@children.4/@children.2/@children.4/@children.4/@ports.1" targets="//@children.4/@children.2/@children.4/@children.1/@ports.0"/>
+      </children>
+      <children identifier="N168" height="46.0" width="44.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L168" height="15.0" width="55.0" text="Integrator"/>
+        <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P376" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.4/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E217" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E218" sources="//@children.4/@children.2/@children.0/@ports.1" targets="//@children.4/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E219" sources="//@children.4/@children.2/@children.1/@ports.1" targets="//@children.4/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E220" sources="//@children.4/@children.2/@children.1/@ports.1" targets="//@children.4/@children.2/@children.3/@ports.0"/>
+      <containedEdges identifier="E221" sources="//@children.4/@children.2/@children.2/@ports.1" targets="//@children.4/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E222" sources="//@children.4/@children.2/@children.2/@ports.1" targets="//@children.4/@children.2/@children.5/@ports.0"/>
+      <containedEdges identifier="E223" sources="//@children.4/@children.2/@children.3/@ports.1" targets="//@children.4/@children.2/@ports.3"/>
+      <containedEdges identifier="E224" sources="//@children.4/@children.2/@children.4/@ports.1" targets="//@children.4/@children.2/@ports.2"/>
+      <containedEdges identifier="E225" sources="//@children.4/@children.2/@children.5/@ports.1" targets="//@children.4/@children.2/@ports.1"/>
+    </children>
+    <containedEdges identifier="E107" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E108" sources="//@children.4/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E109" sources="//@children.4/@children.0/@ports.4" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E110" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.0/@ports.2"/>
+    <containedEdges identifier="E111" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@ports.3"/>
+    <containedEdges identifier="E112" sources="//@children.4/@children.2/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E113" sources="//@children.4/@children.2/@ports.3" targets="//@children.4/@ports.5"/>
+    <containedEdges identifier="E114" sources="//@children.4/@children.2/@ports.2" targets="//@children.4/@ports.4"/>
+  </children>
+  <children identifier="N169">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L169" height="15.0" width="100.0" text="VehicleDynamics"/>
+    <ports identifier="P377" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0 //@children.5/@containedEdges.1 //@children.5/@containedEdges.2 //@children.5/@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P378" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.4 //@children.5/@containedEdges.5 //@children.5/@containedEdges.6 //@children.5/@containedEdges.7" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P379" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.8 //@children.5/@containedEdges.9 //@children.5/@containedEdges.10 //@children.5/@containedEdges.11" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P380" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11 //@containedEdges.12" incomingEdges="//@children.5/@containedEdges.16 //@children.5/@containedEdges.18 //@children.5/@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P381" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.12 //@children.5/@containedEdges.13 //@children.5/@containedEdges.14 //@children.5/@containedEdges.15" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N170" height="10.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L170" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P382" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P383" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P384" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P385" incomingEdges="//@children.5/@containedEdges.17 //@children.5/@containedEdges.19 //@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P386" incomingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N171" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L171" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P387" y="8.199999809265137" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P388" y="16.399999618530273" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P389" y="24.600000381469727" incomingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P390" x="61.0" y="20.5" outgoingEdges="//@children.5/@containedEdges.16 //@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P391" y="32.79999923706055" incomingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N172" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L172" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P392" y="8.199999809265137" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P393" y="16.399999618530273" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P394" y="24.600000381469727" incomingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P395" x="61.0" y="20.5" outgoingEdges="//@children.5/@containedEdges.18 //@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P396" y="32.79999923706055" incomingEdges="//@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N173" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L173" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P397" y="8.199999809265137" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P398" y="16.399999618530273" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P399" y="24.600000381469727" incomingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P400" x="61.0" y="20.5" outgoingEdges="//@children.5/@containedEdges.20 //@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P401" y="32.79999923706055" incomingEdges="//@children.5/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E261" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E262" sources="//@children.5/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E263" sources="//@children.5/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E264" sources="//@children.5/@ports.0" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E265" sources="//@children.5/@ports.1" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E266" sources="//@children.5/@ports.1" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E267" sources="//@children.5/@ports.1" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E268" sources="//@children.5/@ports.1" targets="//@children.5/@children.3/@ports.1"/>
+    <containedEdges identifier="E269" sources="//@children.5/@ports.2" targets="//@children.5/@children.0/@ports.2"/>
+    <containedEdges identifier="E270" sources="//@children.5/@ports.2" targets="//@children.5/@children.1/@ports.2"/>
+    <containedEdges identifier="E271" sources="//@children.5/@ports.2" targets="//@children.5/@children.2/@ports.2"/>
+    <containedEdges identifier="E272" sources="//@children.5/@ports.2" targets="//@children.5/@children.3/@ports.2"/>
+    <containedEdges identifier="E273" sources="//@children.5/@ports.4" targets="//@children.5/@children.0/@ports.4"/>
+    <containedEdges identifier="E274" sources="//@children.5/@ports.4" targets="//@children.5/@children.1/@ports.4"/>
+    <containedEdges identifier="E275" sources="//@children.5/@ports.4" targets="//@children.5/@children.2/@ports.4"/>
+    <containedEdges identifier="E276" sources="//@children.5/@ports.4" targets="//@children.5/@children.3/@ports.4"/>
+    <containedEdges identifier="E277" sources="//@children.5/@children.1/@ports.3" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E278" sources="//@children.5/@children.1/@ports.3" targets="//@children.5/@children.0/@ports.3"/>
+    <containedEdges identifier="E279" sources="//@children.5/@children.2/@ports.3" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E280" sources="//@children.5/@children.2/@ports.3" targets="//@children.5/@children.0/@ports.3"/>
+    <containedEdges identifier="E281" sources="//@children.5/@children.3/@ports.3" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E282" sources="//@children.5/@children.3/@ports.3" targets="//@children.5/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N174">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L174" height="15.0" width="132.0" text="RearActuatorController"/>
+    <ports identifier="P402" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P403" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P404" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.4 //@children.6/@containedEdges.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P405" height="8.0" width="8.0" outgoingEdges="//@containedEdges.13 //@containedEdges.14" incomingEdges="//@children.6/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P406" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.6 //@children.6/@containedEdges.7" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N175" height="10.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L175" height="15.0" width="61.0" text="delta_r_sp"/>
+      <ports identifier="P407" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P408" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P409" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P410" incomingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P411" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N176" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L176" height="15.0" width="61.0" text="delta_r_sp"/>
+      <ports identifier="P412" y="8.199999809265137" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P413" y="16.399999618530273" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P414" y="24.600000381469727" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P415" x="61.0" y="20.5" outgoingEdges="//@children.6/@containedEdges.8 //@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P416" y="32.79999923706055" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E283" sources="//@children.6/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E284" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E285" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E286" sources="//@children.6/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E287" sources="//@children.6/@ports.2" targets="//@children.6/@children.0/@ports.2"/>
+    <containedEdges identifier="E288" sources="//@children.6/@ports.2" targets="//@children.6/@children.1/@ports.2"/>
+    <containedEdges identifier="E289" sources="//@children.6/@ports.4" targets="//@children.6/@children.0/@ports.4"/>
+    <containedEdges identifier="E290" sources="//@children.6/@ports.4" targets="//@children.6/@children.1/@ports.4"/>
+    <containedEdges identifier="E291" sources="//@children.6/@children.1/@ports.3" targets="//@children.6/@ports.3"/>
+    <containedEdges identifier="E292" sources="//@children.6/@children.1/@ports.3" targets="//@children.6/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N177" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L177" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N178" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L178" height="15.0" width="52.0" text="Rad2deg"/>
+    <ports identifier="P418" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P419" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N179" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L179" height="15.0" width="8.0" text="u"/>
+    <ports identifier="P420" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N180" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L180" height="15.0" width="15.0" text="u2"/>
+    <ports identifier="P421" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.3" targets="//@children.5/@ports.4"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.4" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.5" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.3" targets="//@children.6/@ports.4"/>
+  <containedEdges identifier="E13" sources="//@children.5/@ports.3" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E15" sources="//@children.6/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E16" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/tdl_activerearsteeringde_ActiveRearSteeringDE.elkg
+++ b/realworld/ptolemy/hierarchical/tdl_activerearsteeringde_ActiveRearSteeringDE.elkg
@@ -1,0 +1,1808 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="164.0" text="signalGenerator_frontgAngle"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.0/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="75.0" text="smoothJump"/>
+      <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P5" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P10" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P17" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E22" sources="//@children.0/@children.0/@children.0/@ports.2" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.0/@children.6/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.0/@children.7/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="82.0" text="smoothJump2"/>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.1" incomingEdges="//@children.0/@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N12" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P29" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.2 //@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E30" sources="//@children.0/@children.1/@children.0/@ports.2" targets="//@children.0/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.0/@children.1/@children.1/@ports.1" targets="//@children.0/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.1/@children.2/@ports.1" targets="//@children.0/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.1/@children.3/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.1/@children.4/@ports.2" targets="//@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.1/@children.5/@ports.0" targets="//@children.0/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.1/@children.6/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.0/@children.1/@children.7/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N20" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L21" height="15.0" width="82.0" text="smoothJump3"/>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3" incomingEdges="//@children.0/@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N22" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.2 //@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N27" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E38" sources="//@children.0/@children.3/@children.0/@ports.2" targets="//@children.0/@children.3/@children.1/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.3/@children.1/@ports.1" targets="//@children.0/@children.3/@children.6/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.3/@children.2/@ports.1" targets="//@children.0/@children.3/@children.4/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.3/@children.3/@ports.0" targets="//@children.0/@children.3/@children.0/@ports.1"/>
+      <containedEdges identifier="E42" sources="//@children.0/@children.3/@children.4/@ports.2" targets="//@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.0/@children.3/@children.5/@ports.0" targets="//@children.0/@children.3/@children.4/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.3/@children.6/@ports.0" targets="//@children.0/@children.3/@children.2/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.3/@children.7/@ports.0" targets="//@children.0/@children.3/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N30">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L30" height="15.0" width="82.0" text="smoothJump4"/>
+      <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@children.0/@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N31" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.4/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P67" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.4/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P70" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="80.0" text="AddSubtract2"/>
+        <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.4/@containedEdges.2 //@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P74" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="216.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P75" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="25.0" width="72.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="72.0" y="8.5" outgoingEdges="//@children.0/@children.4/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.4/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="71.0" text="CurrentTime"/>
+        <ports identifier="P79" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.4/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E46" sources="//@children.0/@children.4/@children.0/@ports.2" targets="//@children.0/@children.4/@children.1/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.0/@children.4/@children.1/@ports.1" targets="//@children.0/@children.4/@children.6/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.4/@children.2/@ports.1" targets="//@children.0/@children.4/@children.4/@ports.0"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.4/@children.3/@ports.0" targets="//@children.0/@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.4/@children.4/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.4/@children.5/@ports.0" targets="//@children.0/@children.4/@children.4/@ports.0"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.4/@children.6/@ports.0" targets="//@children.0/@children.4/@children.2/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.4/@children.7/@ports.0" targets="//@children.0/@children.4/@children.0/@ports.0"/>
+    </children>
+    <children identifier="N39" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="96.0" text="PeriodicSampler"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.2/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N40">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L40" height="15.0" width="153.0" text="signalBuilder_speedProfile"/>
+    <ports identifier="P83" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3 //@containedEdges.4" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N41" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.10 //@children.1/@containedEdges.33 //@children.1/@containedEdges.43 //@children.1/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5 //@children.1/@containedEdges.6 //@children.1/@containedEdges.7 //@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="71.0" text="CurrentTime"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12 //@children.1/@containedEdges.13 //@children.1/@containedEdges.14 //@children.1/@containedEdges.15 //@children.1/@containedEdges.16 //@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.19 //@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.20 //@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="62.0" text="EventFilter"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="61.0" text="LogicalNot"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="69.0" text="EventFilter2"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P115" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="75.0" text="Comparator3"/>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.28 //@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.29 //@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N57" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L57" height="15.0" width="75.0" text="Comparator4"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N58" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L58" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N59" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L59" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P127" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N60" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L60" height="15.0" width="69.0" text="EventFilter3"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N61" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L61" height="15.0" width="69.0" text="LogicalNot2"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N62" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L62" height="15.0" width="89.0" text="LogicFunction3"/>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.25 //@children.1/@containedEdges.35 //@children.1/@containedEdges.45 //@children.1/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N63" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L63" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P136" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P137" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N64" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L64" height="15.0" width="75.0" text="Comparator5"/>
+      <ports identifier="P138" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P139" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N65" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L65" height="15.0" width="89.0" text="LogicFunction4"/>
+      <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.38 //@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P142" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.39 //@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N66" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L66" height="15.0" width="75.0" text="Comparator6"/>
+      <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P145" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N67" height="25.0" width="24.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L67" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P146" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N68" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L68" height="15.0" width="42.0" text="Ramp3"/>
+      <ports identifier="P148" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.43">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N69" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L69" height="15.0" width="69.0" text="EventFilter4"/>
+      <ports identifier="P151" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.44">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N70" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L70" height="15.0" width="69.0" text="LogicalNot3"/>
+      <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P154" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.45">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N71" height="25.0" width="24.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L71" height="15.0" width="42.0" text="Const8"/>
+      <ports identifier="P155" height="8.0" width="8.0" x="24.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P156" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N72" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L72" height="15.0" width="42.0" text="Const9"/>
+      <ports identifier="P157" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.47">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N73" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L73" height="15.0" width="75.0" text="Comparator7"/>
+      <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P160" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.46">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P161" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.48 //@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N74" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L74" height="15.0" width="69.0" text="LogicalNot4"/>
+      <ports identifier="P162" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.48">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P163" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.50">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N75" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L75" height="15.0" width="69.0" text="EventFilter5"/>
+      <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.49">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P165" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.51">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E54" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E57" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E59" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.13/@ports.1"/>
+    <containedEdges identifier="E60" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.17/@ports.1"/>
+    <containedEdges identifier="E61" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.22/@ports.1"/>
+    <containedEdges identifier="E62" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.26/@ports.1"/>
+    <containedEdges identifier="E63" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.30/@ports.1"/>
+    <containedEdges identifier="E64" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E65" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E66" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.8/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.16/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.23/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.25/@ports.0"/>
+    <containedEdges identifier="E71" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.32/@ports.0"/>
+    <containedEdges identifier="E72" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E73" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E74" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E75" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E76" sources="//@children.1/@children.8/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E77" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E78" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E79" sources="//@children.1/@children.11/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E80" sources="//@children.1/@children.12/@ports.1" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E81" sources="//@children.1/@children.13/@ports.0" targets="//@children.1/@children.14/@ports.1"/>
+    <containedEdges identifier="E82" sources="//@children.1/@children.14/@ports.2" targets="//@children.1/@children.15/@ports.0"/>
+    <containedEdges identifier="E83" sources="//@children.1/@children.15/@ports.1" targets="//@children.1/@children.19/@ports.0"/>
+    <containedEdges identifier="E84" sources="//@children.1/@children.15/@ports.1" targets="//@children.1/@children.20/@ports.0"/>
+    <containedEdges identifier="E85" sources="//@children.1/@children.16/@ports.2" targets="//@children.1/@children.15/@ports.0"/>
+    <containedEdges identifier="E86" sources="//@children.1/@children.17/@ports.0" targets="//@children.1/@children.16/@ports.1"/>
+    <containedEdges identifier="E87" sources="//@children.1/@children.18/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E88" sources="//@children.1/@children.19/@ports.1" targets="//@children.1/@children.18/@ports.1"/>
+    <containedEdges identifier="E89" sources="//@children.1/@children.20/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E90" sources="//@children.1/@children.21/@ports.1" targets="//@children.1/@children.12/@ports.0"/>
+    <containedEdges identifier="E91" sources="//@children.1/@children.22/@ports.0" targets="//@children.1/@children.23/@ports.1"/>
+    <containedEdges identifier="E92" sources="//@children.1/@children.23/@ports.2" targets="//@children.1/@children.24/@ports.0"/>
+    <containedEdges identifier="E93" sources="//@children.1/@children.24/@ports.1" targets="//@children.1/@children.28/@ports.0"/>
+    <containedEdges identifier="E94" sources="//@children.1/@children.24/@ports.1" targets="//@children.1/@children.29/@ports.0"/>
+    <containedEdges identifier="E95" sources="//@children.1/@children.25/@ports.2" targets="//@children.1/@children.24/@ports.0"/>
+    <containedEdges identifier="E96" sources="//@children.1/@children.26/@ports.0" targets="//@children.1/@children.25/@ports.1"/>
+    <containedEdges identifier="E97" sources="//@children.1/@children.27/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E98" sources="//@children.1/@children.28/@ports.1" targets="//@children.1/@children.27/@ports.1"/>
+    <containedEdges identifier="E99" sources="//@children.1/@children.29/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E100" sources="//@children.1/@children.30/@ports.0" targets="//@children.1/@children.32/@ports.1"/>
+    <containedEdges identifier="E101" sources="//@children.1/@children.31/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E102" sources="//@children.1/@children.32/@ports.2" targets="//@children.1/@children.33/@ports.0"/>
+    <containedEdges identifier="E103" sources="//@children.1/@children.32/@ports.2" targets="//@children.1/@children.34/@ports.0"/>
+    <containedEdges identifier="E104" sources="//@children.1/@children.33/@ports.1" targets="//@children.1/@children.21/@ports.0"/>
+    <containedEdges identifier="E105" sources="//@children.1/@children.34/@ports.1" targets="//@children.1/@children.31/@ports.1"/>
+  </children>
+  <children identifier="N76" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L76" height="15.0" width="42.0" text="sigGen"/>
+    <ports identifier="P166" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N77" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L77" height="15.0" width="59.0" text="speedProf"/>
+    <ports identifier="P167" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N78">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L78" height="15.0" width="43.0" text="Vehicle"/>
+    <ports identifier="P168" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P169" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.1" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P170" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.4/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P171" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6 //@containedEdges.7 //@containedEdges.8" incomingEdges="//@children.4/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P172" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.4/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P173" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.4/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N79">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L79" height="15.0" width="51.0" text="DCServo"/>
+      <ports identifier="P174" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P175" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.2 //@children.4/@containedEdges.3" incomingEdges="//@children.4/@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P176" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.5" incomingEdges="//@children.4/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P177" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.4" incomingEdges="//@children.4/@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N80" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="97.0" text="voltage converter"/>
+        <ports identifier="P178" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P179" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="89.0" text="motor electrical"/>
+        <ports identifier="P180" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P181" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.2 //@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="72.0" text="AddSubtract"/>
+        <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P184" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="103.0" text="motor mechanical"/>
+        <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P186" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.5 //@children.4/@children.0/@containedEdges.6 //@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="17.0" text="phi"/>
+        <ports identifier="P187" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P188" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N85" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L85" height="15.0" width="79.0" text="speed sensor"/>
+        <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P190" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N86" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L86" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P192" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N87" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L87" height="15.0" width="25.0" text="phi1"/>
+        <ports identifier="P193" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P194" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N88" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L88" height="15.0" width="68.0" text="TimedDelay"/>
+        <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P196" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E115" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E116" sources="//@children.4/@children.0/@children.0/@ports.1" targets="//@children.4/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.4/@children.0/@children.1/@ports.1" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E118" sources="//@children.4/@children.0/@children.1/@ports.1" targets="//@children.4/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E119" sources="//@children.4/@children.0/@children.2/@ports.2" targets="//@children.4/@children.0/@children.3/@ports.0"/>
+      <containedEdges identifier="E120" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E121" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E122" sources="//@children.4/@children.0/@children.3/@ports.1" targets="//@children.4/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E123" sources="//@children.4/@children.0/@children.4/@ports.1" targets="//@children.4/@children.0/@ports.1"/>
+      <containedEdges identifier="E124" sources="//@children.4/@children.0/@children.5/@ports.1" targets="//@children.4/@children.0/@ports.2"/>
+      <containedEdges identifier="E125" sources="//@children.4/@children.0/@children.6/@ports.1" targets="//@children.4/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E126" sources="//@children.4/@children.0/@children.7/@ports.1" targets="//@children.4/@children.0/@ports.3"/>
+      <containedEdges identifier="E127" sources="//@children.4/@children.0/@children.8/@ports.1" targets="//@children.4/@children.0/@children.6/@ports.0"/>
+    </children>
+    <children identifier="N89">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L89" height="15.0" width="103.0" text="Lin Einspurmodell"/>
+      <ports identifier="P197" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.2" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P198" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.0" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P199" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.1" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P200" height="8.0" width="8.0" incomingEdges="//@children.4/@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P201" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.6" incomingEdges="//@children.4/@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P202" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N90" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L90" height="15.0" width="34.0" text="Scale"/>
+        <ports identifier="P203" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P204" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N91" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L91" height="15.0" width="41.0" text="Scale2"/>
+        <ports identifier="P205" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P206" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N92" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L92" height="15.0" width="41.0" text="Scale3"/>
+        <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P208" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N93">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+        <labels identifier="L93" height="15.0" width="35.0" text="carLTI"/>
+        <ports identifier="P209" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@children.3/@containedEdges.0" incomingEdges="//@children.4/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.6" incomingEdges="//@children.4/@children.1/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <children identifier="N94" height="61.0" width="151.0">
+          <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+          <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+          <labels identifier="L94" height="15.0" width="188.0" text="LinearDifferenceEquationSystem"/>
+          <ports identifier="P211" height="8.0" width="8.0" x="-8.0" y="26.5" incomingEdges="//@children.4/@children.1/@children.3/@containedEdges.0">
+            <properties key="org.eclipse.elk.port.index" value="0"/>
+            <properties key="org.eclipse.elk.port.side" value="WEST"/>
+          </ports>
+          <ports identifier="P212" height="8.0" width="8.0" x="151.0" y="15.0" outgoingEdges="//@children.4/@children.1/@children.3/@containedEdges.1">
+            <properties key="org.eclipse.elk.port.index" value="1"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+          <ports identifier="P213" height="8.0" width="8.0" x="151.0" y="38.0">
+            <properties key="org.eclipse.elk.port.index" value="2"/>
+            <properties key="org.eclipse.elk.port.side" value="EAST"/>
+          </ports>
+        </children>
+        <containedEdges identifier="E138" sources="//@children.4/@children.1/@children.3/@ports.0" targets="//@children.4/@children.1/@children.3/@children.0/@ports.0"/>
+        <containedEdges identifier="E139" sources="//@children.4/@children.1/@children.3/@children.0/@ports.1" targets="//@children.4/@children.1/@children.3/@ports.1"/>
+      </children>
+      <children identifier="N95" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L95" height="15.0" width="100.0" text="VectorAssembler"/>
+        <ports identifier="P214" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.0 //@children.4/@children.1/@containedEdges.1 //@children.4/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N96" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L96" height="15.0" width="117.0" text="VectorDisassembler"/>
+        <ports identifier="P216" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P217" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.8 //@children.4/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E128" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E129" sources="//@children.4/@children.1/@ports.2" targets="//@children.4/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E130" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E131" sources="//@children.4/@children.1/@children.0/@ports.1" targets="//@children.4/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E132" sources="//@children.4/@children.1/@children.1/@ports.1" targets="//@children.4/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E133" sources="//@children.4/@children.1/@children.2/@ports.1" targets="//@children.4/@children.1/@ports.4"/>
+      <containedEdges identifier="E134" sources="//@children.4/@children.1/@children.3/@ports.1" targets="//@children.4/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E135" sources="//@children.4/@children.1/@children.4/@ports.1" targets="//@children.4/@children.1/@children.3/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.4/@children.1/@children.5/@ports.1" targets="//@children.4/@children.1/@ports.3"/>
+      <containedEdges identifier="E137" sources="//@children.4/@children.1/@children.5/@ports.1" targets="//@children.4/@children.1/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N97" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L97" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P218" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N98" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L98" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P220" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E106" sources="//@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E107" sources="//@children.4/@ports.1" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E108" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@ports.3"/>
+    <containedEdges identifier="E109" sources="//@children.4/@children.0/@ports.1" targets="//@children.4/@children.1/@ports.1"/>
+    <containedEdges identifier="E110" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@ports.5"/>
+    <containedEdges identifier="E111" sources="//@children.4/@children.0/@ports.2" targets="//@children.4/@ports.4"/>
+    <containedEdges identifier="E112" sources="//@children.4/@children.1/@ports.4" targets="//@children.4/@ports.2"/>
+    <containedEdges identifier="E113" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.1/@ports.2"/>
+    <containedEdges identifier="E114" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N99">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L99" height="15.0" width="100.0" text="VehicleDynamics"/>
+    <ports identifier="P223" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0 //@children.5/@containedEdges.1 //@children.5/@containedEdges.2 //@children.5/@containedEdges.3" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P224" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.4 //@children.5/@containedEdges.5 //@children.5/@containedEdges.6 //@children.5/@containedEdges.7" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P225" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.8 //@children.5/@containedEdges.9 //@children.5/@containedEdges.10 //@children.5/@containedEdges.11" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P226" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.5/@containedEdges.16 //@children.5/@containedEdges.18 //@children.5/@containedEdges.20">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P227" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.12 //@children.5/@containedEdges.13 //@children.5/@containedEdges.14 //@children.5/@containedEdges.15" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N100" height="10.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L100" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P228" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P229" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P230" incomingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P231" incomingEdges="//@children.5/@containedEdges.17 //@children.5/@containedEdges.19 //@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P232" incomingEdges="//@children.5/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N101" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L101" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P233" y="8.199999809265137" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P234" y="16.399999618530273" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P235" y="24.600000381469727" incomingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P236" x="61.0" y="20.5" outgoingEdges="//@children.5/@containedEdges.16 //@children.5/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P237" y="32.79999923706055" incomingEdges="//@children.5/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N102" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L102" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P238" y="8.199999809265137" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P239" y="16.399999618530273" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P240" y="24.600000381469727" incomingEdges="//@children.5/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P241" x="61.0" y="20.5" outgoingEdges="//@children.5/@containedEdges.18 //@children.5/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P242" y="32.79999923706055" incomingEdges="//@children.5/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N103" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L103" height="15.0" width="64.0" text="delta_r_act"/>
+      <ports identifier="P243" y="8.199999809265137" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P244" y="16.399999618530273" incomingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P245" y="24.600000381469727" incomingEdges="//@children.5/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P246" x="61.0" y="20.5" outgoingEdges="//@children.5/@containedEdges.20 //@children.5/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P247" y="32.79999923706055" incomingEdges="//@children.5/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E140" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E141" sources="//@children.5/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E142" sources="//@children.5/@ports.0" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E143" sources="//@children.5/@ports.0" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E144" sources="//@children.5/@ports.1" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E145" sources="//@children.5/@ports.1" targets="//@children.5/@children.1/@ports.1"/>
+    <containedEdges identifier="E146" sources="//@children.5/@ports.1" targets="//@children.5/@children.2/@ports.1"/>
+    <containedEdges identifier="E147" sources="//@children.5/@ports.1" targets="//@children.5/@children.3/@ports.1"/>
+    <containedEdges identifier="E148" sources="//@children.5/@ports.2" targets="//@children.5/@children.0/@ports.2"/>
+    <containedEdges identifier="E149" sources="//@children.5/@ports.2" targets="//@children.5/@children.1/@ports.2"/>
+    <containedEdges identifier="E150" sources="//@children.5/@ports.2" targets="//@children.5/@children.2/@ports.2"/>
+    <containedEdges identifier="E151" sources="//@children.5/@ports.2" targets="//@children.5/@children.3/@ports.2"/>
+    <containedEdges identifier="E152" sources="//@children.5/@ports.4" targets="//@children.5/@children.0/@ports.4"/>
+    <containedEdges identifier="E153" sources="//@children.5/@ports.4" targets="//@children.5/@children.1/@ports.4"/>
+    <containedEdges identifier="E154" sources="//@children.5/@ports.4" targets="//@children.5/@children.2/@ports.4"/>
+    <containedEdges identifier="E155" sources="//@children.5/@ports.4" targets="//@children.5/@children.3/@ports.4"/>
+    <containedEdges identifier="E156" sources="//@children.5/@children.1/@ports.3" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E157" sources="//@children.5/@children.1/@ports.3" targets="//@children.5/@children.0/@ports.3"/>
+    <containedEdges identifier="E158" sources="//@children.5/@children.2/@ports.3" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E159" sources="//@children.5/@children.2/@ports.3" targets="//@children.5/@children.0/@ports.3"/>
+    <containedEdges identifier="E160" sources="//@children.5/@children.3/@ports.3" targets="//@children.5/@ports.3"/>
+    <containedEdges identifier="E161" sources="//@children.5/@children.3/@ports.3" targets="//@children.5/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N104">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L104" height="15.0" width="132.0" text="RearActuatorController"/>
+    <ports identifier="P248" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P249" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P250" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.4 //@children.6/@containedEdges.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P251" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12 //@containedEdges.13" incomingEdges="//@children.6/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P252" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.6 //@children.6/@containedEdges.7" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N105" height="10.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L105" height="15.0" width="61.0" text="delta_r_sp"/>
+      <ports identifier="P253" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P254" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P255" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P256" incomingEdges="//@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P257" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N106" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L106" height="15.0" width="61.0" text="delta_r_sp"/>
+      <ports identifier="P258" y="8.199999809265137" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P259" y="16.399999618530273" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P260" y="24.600000381469727" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P261" x="61.0" y="20.5" outgoingEdges="//@children.6/@containedEdges.8 //@children.6/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P262" y="32.79999923706055" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E162" sources="//@children.6/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E163" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E164" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E165" sources="//@children.6/@ports.1" targets="//@children.6/@children.1/@ports.1"/>
+    <containedEdges identifier="E166" sources="//@children.6/@ports.2" targets="//@children.6/@children.0/@ports.2"/>
+    <containedEdges identifier="E167" sources="//@children.6/@ports.2" targets="//@children.6/@children.1/@ports.2"/>
+    <containedEdges identifier="E168" sources="//@children.6/@ports.4" targets="//@children.6/@children.0/@ports.4"/>
+    <containedEdges identifier="E169" sources="//@children.6/@ports.4" targets="//@children.6/@children.1/@ports.4"/>
+    <containedEdges identifier="E170" sources="//@children.6/@children.1/@ports.3" targets="//@children.6/@ports.3"/>
+    <containedEdges identifier="E171" sources="//@children.6/@children.1/@ports.3" targets="//@children.6/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N107" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L107" height="15.0" width="18.0" text="out"/>
+    <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N108" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L108" height="15.0" width="52.0" text="Rad2deg"/>
+    <ports identifier="P264" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P265" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N109" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L109" height="15.0" width="8.0" text="u"/>
+    <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.2" targets="//@children.5/@ports.2"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.3" targets="//@children.5/@ports.4"/>
+  <containedEdges identifier="E8" sources="//@children.4/@ports.3" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E9" sources="//@children.4/@ports.3" targets="//@children.8/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.4/@ports.4" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.5" targets="//@children.6/@ports.2"/>
+  <containedEdges identifier="E12" sources="//@children.5/@ports.3" targets="//@children.6/@ports.4"/>
+  <containedEdges identifier="E13" sources="//@children.6/@ports.3" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E14" sources="//@children.6/@ports.3" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E15" sources="//@children.8/@ports.1" targets="//@children.7/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/tm_controllers_Controllers.elkg
+++ b/realworld/ptolemy/hierarchical/tm_controllers_Controllers.elkg
@@ -1,0 +1,554 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="56.0" text="Sampler1"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="38.0" text="Plant1"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2" incomingEdges="//@children.1/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="63.0" text="InputAdder"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.6 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="74.0" text="OutputAdder"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="62.0" text="Integrator0"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="65.0" text="Feedback0"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="78.0" text="Feedforward0"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.8 //@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="65.0" text="Feedback1"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="78.0" text="Feedforward1"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E15" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="81.0" text="TimedPlotter1"/>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="84.0" text="ZeroOrderHold"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="80.0" text="AddSubtract2"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="91.0" text="ZeroOrderHold2"/>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N18">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L18" height="15.0" width="38.0" text="Plant2"/>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9 //@containedEdges.10" incomingEdges="//@children.9/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N19" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="63.0" text="InputAdder"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.6 //@children.9/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="74.0" text="OutputAdder"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.9/@containedEdges.7 //@children.9/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.9/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="62.0" text="Integrator0"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.3 //@children.9/@containedEdges.4 //@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="65.0" text="Feedback0"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="78.0" text="Feedforward0"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="62.0" text="Integrator1"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.8 //@children.9/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="65.0" text="Feedback1"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="78.0" text="Feedforward1"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.9/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.9/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E27" sources="//@children.9/@ports.0" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@children.2/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.9/@children.1/@ports.2" targets="//@children.9/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.4/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.9/@children.2/@ports.2" targets="//@children.9/@children.5/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.9/@children.3/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.9/@children.4/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.9/@children.5/@ports.2" targets="//@children.9/@children.6/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.9/@children.5/@ports.2" targets="//@children.9/@children.7/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.9/@children.6/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.9/@children.7/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+  </children>
+  <children identifier="N27">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L27" height="15.0" width="82.0" text="TM controllers"/>
+    <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.1" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0" incomingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" outgoingEdges="//@containedEdges.12" incomingEdges="//@children.10/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" outgoingEdges="//@containedEdges.11" incomingEdges="//@children.10/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N28">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L28" height="15.0" width="94.0" text="CompositeActor"/>
+      <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.1" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.2" incomingEdges="//@children.10/@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@children.10/@children.0/@containedEdges.0" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.3" incomingEdges="//@children.10/@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N29" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="63.0" text="Controller1"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="63.0" text="Controller2"/>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.10/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.10/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E43" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E44" sources="//@children.10/@children.0/@ports.0" targets="//@children.10/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.10/@children.0/@children.0/@ports.1" targets="//@children.10/@children.0/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.10/@children.0/@children.1/@ports.1" targets="//@children.10/@children.0/@ports.3"/>
+    </children>
+    <containedEdges identifier="E39" sources="//@children.10/@ports.1" targets="//@children.10/@children.0/@ports.2"/>
+    <containedEdges identifier="E40" sources="//@children.10/@ports.0" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@ports.2"/>
+    <containedEdges identifier="E42" sources="//@children.10/@children.0/@ports.3" targets="//@children.10/@ports.3"/>
+  </children>
+  <children identifier="N31" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L31" height="15.0" width="81.0" text="TimedPlotter2"/>
+    <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N32" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L32" height="15.0" width="56.0" text="Sampler2"/>
+    <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.10/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.2" targets="//@children.9/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.7/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.8/@ports.0" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E10" sources="//@children.9/@ports.1" targets="//@children.11/@ports.0"/>
+  <containedEdges identifier="E11" sources="//@children.9/@ports.1" targets="//@children.12/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.10/@ports.3" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E13" sources="//@children.10/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E14" sources="//@children.12/@ports.1" targets="//@children.10/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/tm_fft_FFT.elkg
+++ b/realworld/ptolemy/hierarchical/tm_fft_FFT.elkg
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="159.0" text="TMCompositeFacade (FFT)"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="24.0" text="FFT"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="84.0" text="AbsoluteValue"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="96.0" text="SequenceScope"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Pulse"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N7" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="217.0" text="Atomic Composite Actor (Noisy Sine)"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1 //@containedEdges.2 //@containedEdges.3" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="28.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="72.0" text="TrigFunction"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="28.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.2 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="56.0" text="Gaussian"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="5.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.3/@children.1/@ports.1" targets="//@children.3/@children.2/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.3/@children.2/@ports.2" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N14" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="93.0" text="RealTimePlotter"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/tm_mergedevents_MergedEvents.elkg
+++ b/realworld/ptolemy/hierarchical/tm_mergedevents_MergedEvents.elkg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="33.0" text="Clock"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="80.0" text="PoissonClock"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="21.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="37.0" text="Merge"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="49.0" text="Sampler"/>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="34.0" text="Pulse"/>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="130.0" text="typed composite actor"/>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="53.0" text="TimeGap"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L10" height="15.0" width="130.0" text="typed composite actor"/>
+      <ports identifier="P18" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.3" incomingEdges="//@children.6/@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.2/@containedEdges.1" incomingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N11" height="25.0" width="37.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="77.0" text="SampleDelay"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.6/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="83.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P23" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@children.6/@children.2/@containedEdges.3 //@children.6/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.6/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.6/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.6/@children.2/@ports.1" targets="//@children.6/@children.2/@children.1/@ports.2"/>
+      <containedEdges identifier="E13" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.2/@children.1/@ports.3"/>
+      <containedEdges identifier="E14" sources="//@children.6/@children.2/@children.0/@ports.1" targets="//@children.6/@children.2/@children.1/@ports.1"/>
+      <containedEdges identifier="E15" sources="//@children.6/@children.2/@children.1/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.6/@children.2/@children.1/@ports.0" targets="//@children.6/@children.2/@children.0/@ports.0"/>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.6/@children.1/@ports.1" targets="//@children.6/@children.2/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.6/@children.2/@ports.0" targets="//@children.6/@children.0/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.4/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.4/@ports.0" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/unit_staticunits_StaticUnits.elkg
+++ b/realworld/ptolemy/hierarchical/unit_staticunits_StaticUnits.elkg
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="60.0" text="population"/>
+    <ports identifier="P2" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="110.0" text="growthAddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="238.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="28.0" text="Limit"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="328.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="39.0" text="growth"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="90.0" text="HeatProduction"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="25.0" width="243.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="181.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="90.0" text="HeatExchanger"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E19" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.3/@ports.3" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="23.0" text="flow"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.3/@ports.3"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/unit_staticunits_StaticUnits2.elkg
+++ b/realworld/ptolemy/hierarchical/unit_staticunits_StaticUnits2.elkg
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="74.0" text="TimedPlotter"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="60.0" text="population"/>
+    <ports identifier="P2" outgoingEdges="//@containedEdges.0 //@containedEdges.1" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="110.0" text="growthAddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="238.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="28.0" text="Limit"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="238.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="55.0" text="Integrator"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="328.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="39.0" text="growth"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="328.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@ports.1" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="90.0" text="HeatProduction"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" outgoingEdges="//@containedEdges.2" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="25.0" width="243.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="243.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E18" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="90.0" text="HeatExchanger"/>
+    <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@containedEdges.3" incomingEdges="//@children.3/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="25.0" width="181.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="90.0" text="HeatExchanger"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="181.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="0.25" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.75" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E20" sources="//@children.3/@ports.1" targets="//@children.3/@children.0/@ports.3"/>
+    <containedEdges identifier="E21" sources="//@children.3/@ports.0" targets="//@children.3/@children.0/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.3/@ports.3" targets="//@children.3/@children.0/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@ports.2"/>
+  </children>
+  <children identifier="N11" height="41.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="72.0" text="AddSubtract"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="46.0" width="44.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="55.0" text="Integrator"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="9.333333015441895" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" x="44.0" y="19.0" outgoingEdges="//@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="26.66666603088379" y="46.0">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="25.0" width="29.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="53.0" text="TempCW"/>
+    <ports identifier="P35" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="25.0" width="32.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="49.0" text="flow rate"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="25.0" width="14.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="158.0" text="Convert Population to Joule"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="14.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.8/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.2" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.2" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E7" sources="//@children.5/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E8" sources="//@children.6/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E9" sources="//@children.7/@ports.0" targets="//@children.3/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.8/@ports.0" targets="//@children.2/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/verification_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
+++ b/realworld/ptolemy/hierarchical/verification_irobothillclimbing_iRobotCreateCodeGenExperimental.elkg
@@ -1,0 +1,650 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="180.0" text="iRobotSensorSignalProcessing"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0" incomingEdges="//@children.0/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.1" incomingEdges="//@children.0/@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="48.0" text="Sensors"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="76.0" y="-5.5625">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="76.0" y="-3.125">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="76.0" y="-0.6875">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="76.0" y="1.75">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="76.0" y="4.1875">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="76.0" y="6.625">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="76.0" y="9.0625" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="76.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="76.0" y="13.9375" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="8"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="76.0" y="16.375" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="9"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="76.0" y="18.8125">
+        <properties key="org.eclipse.elk.port.index" value="10"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="76.0" y="21.25">
+        <properties key="org.eclipse.elk.port.index" value="11"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="76.0" y="23.6875">
+        <properties key="org.eclipse.elk.port.index" value="12"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="76.0" y="26.125">
+        <properties key="org.eclipse.elk.port.index" value="13"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="76.0" y="28.5625">
+        <properties key="org.eclipse.elk.port.index" value="14"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-15"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="25.0" width="33.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="33.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.8" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.9" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.7" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.6" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.15"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@ports.1"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="87.0" text="iRobotActuator"/>
+    <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N9" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="38.0" text="Speed"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.3 //@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="36.0" text="Drive2"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="76.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="36.0" text="Drive3"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="76.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="36.0" text="Drive4"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="76.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="36.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="72.0" text="RotateAngle"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="36.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="75.0" text="UnitDistance"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E21" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.3"/>
+    <containedEdges identifier="E22" sources="//@children.1/@ports.1" targets="//@children.1/@children.5/@ports.3"/>
+    <containedEdges identifier="E23" sources="//@children.1/@ports.2" targets="//@children.1/@children.6/@ports.3"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.5/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.3/@ports.4"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.5/@ports.4"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.6/@ports.4"/>
+  </children>
+  <children identifier="N18" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L18" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P59" height="8.0" width="8.0" x="1.8571428060531616" y="41.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P60" height="8.0" width="8.0" x="11.714285850524902" y="41.0" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" x="21.571428298950195" y="41.0" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P62" height="8.0" width="8.0" x="31.428571701049805" y="41.0" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P63" height="8.0" width="8.0" x="41.28571319580078" y="41.0" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P64" height="8.0" width="8.0" x="51.14285659790039" y="41.0" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-5"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P65" height="8.0" width="8.0" x="61.0" y="1.7999999523162842" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="11.600000381469727" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P67" height="8.0" width="8.0" x="61.0" y="21.399999618530273" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" x="61.0" y="31.200000762939453">
+      <properties key="org.eclipse.elk.port.index" value="11"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N19">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L19" height="15.0" width="186.0" text="AccelerometerSignalProcessing"/>
+    <ports identifier="P71" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.3/@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P72" height="8.0" width="8.0" outgoingEdges="//@containedEdges.8" incomingEdges="//@children.3/@containedEdges.15">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@containedEdges.9" incomingEdges="//@children.3/@containedEdges.16">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P74" height="8.0" width="8.0" outgoingEdges="//@containedEdges.10" incomingEdges="//@children.3/@containedEdges.17">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P75" height="8.0" width="8.0" outgoingEdges="//@containedEdges.6" incomingEdges="//@children.3/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P76" height="8.0" width="8.0" outgoingEdges="//@containedEdges.7" incomingEdges="//@children.3/@containedEdges.14">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N20" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="28.0" text="ADC"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="76.0" y="5.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1 //@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="76.0" y="18.0" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="224.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="212.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="457.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="73.0" text="Expression5"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="473.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="73.0" text="Expression6"/>
+      <ports identifier="P90" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="119.0" text="BooleanToAnything5"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="119.0" text="BooleanToAnything6"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E33" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.1/@ports.1"/>
+    <containedEdges identifier="E34" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.3/@ports.1"/>
+    <containedEdges identifier="E35" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.5/@ports.1"/>
+    <containedEdges identifier="E36" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.2/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.3/@children.0/@ports.1" targets="//@children.3/@children.6/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.10/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.3/@children.3/@ports.0" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.12/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.3/@children.5/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.11/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@ports.4"/>
+    <containedEdges identifier="E47" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@ports.5"/>
+    <containedEdges identifier="E48" sources="//@children.3/@children.10/@ports.1" targets="//@children.3/@ports.1"/>
+    <containedEdges identifier="E49" sources="//@children.3/@children.11/@ports.1" targets="//@children.3/@ports.2"/>
+    <containedEdges identifier="E50" sources="//@children.3/@children.12/@ports.1" targets="//@children.3/@ports.3"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.2/@ports.9"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.2/@ports.10"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.6" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.7" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.2/@ports.8" targets="//@children.1/@ports.2"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.3/@ports.4" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E8" sources="//@children.3/@ports.5" targets="//@children.2/@ports.2"/>
+  <containedEdges identifier="E9" sources="//@children.3/@ports.1" targets="//@children.2/@ports.3"/>
+  <containedEdges identifier="E10" sources="//@children.3/@ports.2" targets="//@children.2/@ports.4"/>
+  <containedEdges identifier="E11" sources="//@children.3/@ports.3" targets="//@children.2/@ports.5"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/verification_irobothillclimbing_iRobotCreateVerification.elkg
+++ b/realworld/ptolemy/hierarchical/verification_irobothillclimbing_iRobotCreateVerification.elkg
@@ -1,0 +1,916 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="Slope"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="-1.875" incomingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="10.375" incomingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="22.625" outgoingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="-1.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="6.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="6"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="13.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="7"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="20.0" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="8"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="27.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="9"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="34.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="10"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="28.75" outgoingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="34.875" outgoingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L2" height="15.0" width="180.0" text="iRobotSensorSignalProcessing"/>
+    <ports identifier="P14" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P15" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <children identifier="N3" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="48.0" text="Sensors"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="76.0" y="-5.5625">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="76.0" y="-3.125">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="76.0" y="-0.6875">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="76.0" y="1.75">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="76.0" y="4.1875">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="76.0" y="6.625">
+        <properties key="org.eclipse.elk.port.index" value="5"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="76.0" y="9.0625" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="6"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="76.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="7"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="76.0" y="13.9375" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="8"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="76.0" y="16.375" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="9"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="76.0" y="18.8125">
+        <properties key="org.eclipse.elk.port.index" value="10"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="76.0" y="21.25">
+        <properties key="org.eclipse.elk.port.index" value="11"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="76.0" y="23.6875">
+        <properties key="org.eclipse.elk.port.index" value="12"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="76.0" y="26.125">
+        <properties key="org.eclipse.elk.port.index" value="13"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="76.0" y="28.5625">
+        <properties key="org.eclipse.elk.port.index" value="14"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="-15"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="89.0" text="LogicFunction2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="47.0" text="Switch2"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.8" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.0/@ports.9" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.0/@ports.7" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.0/@ports.6" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@ports.3"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@ports.2"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.2/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.4/@ports.2"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="186.0" text="AccelerometerSignalProcessing"/>
+    <ports identifier="P50" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.13">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.29">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.25">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.27">
+      <properties key="org.eclipse.elk.port.index" value="-4"/>
+      <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+    </ports>
+    <ports identifier="P55" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.21">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="28.0" text="ADC"/>
+      <ports identifier="P56" height="8.0" width="8.0" x="76.0" y="5.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="76.0" y="18.0" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="224.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="224.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="212.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="212.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="40.0" text="Switch"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.10 //@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="47.0" text="Switch2"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.12 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.14 //@children.2/@containedEdges.15 //@children.2/@containedEdges.16 //@children.2/@containedEdges.17 //@children.2/@containedEdges.18 //@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@children.2/@containedEdges.10 //@children.2/@containedEdges.12 //@children.2/@containedEdges.20 //@children.2/@containedEdges.24 //@children.2/@containedEdges.26 //@children.2/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="47.0" text="Switch3"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.20 //@children.2/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="457.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="73.0" text="Expression5"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="457.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="473.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="73.0" text="Expression6"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="473.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="47.0" text="Switch5"/>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.24 //@children.2/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="47.0" text="Switch6"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.26 //@children.2/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="47.0" text="Switch4"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.28 //@children.2/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="112.0" text="BooleanToAnything"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="119.0" text="BooleanToAnything2"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="119.0" text="BooleanToAnything3"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="119.0" text="BooleanToAnything4"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="119.0" text="BooleanToAnything5"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="119.0" text="BooleanToAnything6"/>
+      <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E28" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.10/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.2/@children.0/@ports.1" targets="//@children.2/@children.11/@ports.1"/>
+    <containedEdges identifier="E34" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.15/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.18/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.17/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.20/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.12/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.13/@ports.0"/>
+    <containedEdges identifier="E47" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.14/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@ports.5"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.16/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.19/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.12/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.2/@children.12/@ports.1" targets="//@children.2/@ports.3"/>
+    <containedEdges identifier="E54" sources="//@children.2/@children.13/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E55" sources="//@children.2/@children.13/@ports.1" targets="//@children.2/@ports.4"/>
+    <containedEdges identifier="E56" sources="//@children.2/@children.14/@ports.1" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.2/@children.14/@ports.1" targets="//@children.2/@ports.2"/>
+    <containedEdges identifier="E58" sources="//@children.2/@children.15/@ports.1" targets="//@children.2/@children.5/@ports.2"/>
+    <containedEdges identifier="E59" sources="//@children.2/@children.16/@ports.1" targets="//@children.2/@children.9/@ports.2"/>
+    <containedEdges identifier="E60" sources="//@children.2/@children.17/@ports.1" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E61" sources="//@children.2/@children.18/@ports.1" targets="//@children.2/@children.14/@ports.2"/>
+    <containedEdges identifier="E62" sources="//@children.2/@children.19/@ports.1" targets="//@children.2/@children.12/@ports.2"/>
+    <containedEdges identifier="E63" sources="//@children.2/@children.20/@ports.1" targets="//@children.2/@children.13/@ports.2"/>
+  </children>
+  <children identifier="N33">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L33" height="15.0" width="87.0" text="iRobotActuator"/>
+    <ports identifier="P104" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P105" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P106" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N34" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="38.0" text="Speed"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4 //@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="46.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P111" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="36.0" text="Drive2"/>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.3/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="76.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P118" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="36.0" text="Drive3"/>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="76.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P124" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="31.0" width="76.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="36.0" text="Drive4"/>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="-0.20000000298023224" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="76.0" y="11.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="7.599999904632568" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="15.399999618530273" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="23.200000762939453" incomingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="72.0" text="RotateAngle"/>
+      <ports identifier="P130" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.9 //@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P131" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="25.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="75.0" text="UnitDistance"/>
+      <ports identifier="P132" height="8.0" width="8.0" x="39.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P133" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="105.0" text="AnythingToDouble"/>
+      <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P135" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E64" sources="//@children.3/@ports.0" targets="//@children.3/@children.3/@ports.3"/>
+    <containedEdges identifier="E65" sources="//@children.3/@ports.1" targets="//@children.3/@children.5/@ports.3"/>
+    <containedEdges identifier="E66" sources="//@children.3/@ports.2" targets="//@children.3/@children.9/@ports.0"/>
+    <containedEdges identifier="E67" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E68" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E69" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.6/@ports.0"/>
+    <containedEdges identifier="E70" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.6/@ports.2"/>
+    <containedEdges identifier="E71" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.5/@ports.2"/>
+    <containedEdges identifier="E72" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.3/@ports.2"/>
+    <containedEdges identifier="E73" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.3/@ports.4"/>
+    <containedEdges identifier="E74" sources="//@children.3/@children.7/@ports.0" targets="//@children.3/@children.5/@ports.4"/>
+    <containedEdges identifier="E75" sources="//@children.3/@children.8/@ports.0" targets="//@children.3/@children.6/@ports.4"/>
+    <containedEdges identifier="E76" sources="//@children.3/@children.9/@ports.1" targets="//@children.3/@children.6/@ports.3"/>
+  </children>
+  <children identifier="N44" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L44" height="15.0" width="57.0" text="iRobotCtrl"/>
+    <ports identifier="P136" height="8.0" width="8.0" x="61.0" y="-1.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P137" height="8.0" width="8.0" x="61.0" y="6.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P138" height="8.0" width="8.0" x="61.0" y="13.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P139" height="8.0" width="8.0" x="61.0" y="20.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P140" height="8.0" width="8.0" x="61.0" y="27.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="4"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P141" height="8.0" width="8.0" x="61.0" y="34.0" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="5"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P142" height="8.0" width="8.0" x="-8.0" y="-1.875" outgoingEdges="//@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="-6"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P143" height="8.0" width="8.0" x="-8.0" y="4.25" outgoingEdges="//@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="-7"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P144" height="8.0" width="8.0" x="-8.0" y="10.375" outgoingEdges="//@containedEdges.12">
+      <properties key="org.eclipse.elk.port.index" value="-8"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P145" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-9"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="22.625" incomingEdges="//@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="-10"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.8">
+      <properties key="org.eclipse.elk.port.index" value="-11"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="34.875" incomingEdges="//@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="-12"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.5" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.6" targets="//@children.4/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.0/@ports.7" targets="//@children.4/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.0/@ports.8" targets="//@children.4/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.0/@ports.9" targets="//@children.4/@ports.4"/>
+  <containedEdges identifier="E6" sources="//@children.0/@ports.10" targets="//@children.4/@ports.5"/>
+  <containedEdges identifier="E7" sources="//@children.0/@ports.3" targets="//@children.4/@ports.9"/>
+  <containedEdges identifier="E8" sources="//@children.0/@ports.4" targets="//@children.4/@ports.10"/>
+  <containedEdges identifier="E9" sources="//@children.0/@ports.11" targets="//@children.4/@ports.11"/>
+  <containedEdges identifier="E10" sources="//@children.0/@ports.12" targets="//@children.4/@ports.12"/>
+  <containedEdges identifier="E11" sources="//@children.4/@ports.6" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E12" sources="//@children.4/@ports.7" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E13" sources="//@children.4/@ports.8" targets="//@children.0/@ports.2"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_antennapattern_AntennaModel.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_antennapattern_AntennaModel.elkg
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="25.0" width="281.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="102.0" text="HammingWindow"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="281.0" y="8.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="59.0" text="Normalize"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="25.0" width="111.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="107.0" text="PlaneWavePhasor"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="111.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="113.0" text="SumArrayElements"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="101.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="103.0" text="AntennaElements"/>
+    <ports identifier="P11" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P12" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.1" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@containedEdges.4" incomingEdges="//@children.5/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N7" height="25.0" width="352.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="352.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="41.0" text="Repeat"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="254.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="254.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.3 //@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="49.0" text="Repeat2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="87.0" text="MultiplyDivide2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.6 //@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="68.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.5/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.5/@ports.1" targets="//@children.5/@children.4/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.1/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.5/@children.1/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.5/@children.3/@ports.2" targets="//@children.5/@children.6/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.5/@children.4/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.5/@children.5/@ports.2" targets="//@children.5/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.5/@children.6/@ports.0" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.5/@children.7/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="49.0" text="Steering"/>
+    <ports identifier="P32" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.1" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" outgoingEdges="//@containedEdges.5" incomingEdges="//@children.6/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="25.0" width="411.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="411.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="254.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="254.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="80.0" text="MultiplyDivide"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.2 //@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="110.0" text="ArrayToSequence2"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="110.0" text="SequenceToArray2"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.6/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.6/@ports.1" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.4/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.6/@children.2/@ports.2" targets="//@children.6/@children.5/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.6/@children.3/@ports.1" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.6/@children.4/@ports.1" targets="//@children.6/@children.0/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.6/@children.5/@ports.1" targets="//@children.6/@ports.2"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.1" targets="//@children.6/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.0" targets="//@children.5/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.5/@ports.2" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.2" targets="//@children.4/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_antennapattern_ReceiveAntennaPattern.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_antennapattern_ReceiveAntennaPattern.elkg
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="42.0" width="46.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="45.0" text="Discard"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L13" height="15.0" width="168.0" text="TransmitPropertyTransformer"/>
+      <ports identifier="P29" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N14" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="99.0" text="CartesianToPolar"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@children.11/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@children.11/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="31.0" y="5.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@children.11/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="25.0" width="81.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P37" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@children.0/@children.11/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@children.11/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.11/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="104.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@children.0/@children.11/@containedEdges.2 //@children.0/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="99.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@children.0/@children.11/@containedEdges.4 //@children.0/@children.11/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="81.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@children.0/@children.11/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@children.11/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@children.11/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.11/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.11/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.11/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.11/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.11/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.11/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.0/@children.11/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.11/@containedEdges.9 //@children.0/@children.11/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.11/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="83.0" text="AntennaModel"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.11/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.11/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.0/@children.11/@children.1/@ports.3" targets="//@children.0/@children.11/@children.10/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.11/@children.2/@ports.0" targets="//@children.0/@children.11/@children.1/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.11/@children.3/@ports.0" targets="//@children.0/@children.11/@children.2/@ports.2"/>
+      <containedEdges identifier="E18" sources="//@children.0/@children.11/@children.3/@ports.0" targets="//@children.0/@children.11/@children.5/@ports.2"/>
+      <containedEdges identifier="E19" sources="//@children.0/@children.11/@children.4/@ports.0" targets="//@children.0/@children.11/@children.2/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.0/@children.11/@children.4/@ports.0" targets="//@children.0/@children.11/@children.5/@ports.1"/>
+      <containedEdges identifier="E21" sources="//@children.0/@children.11/@children.5/@ports.0" targets="//@children.0/@children.11/@children.1/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.0/@children.11/@children.6/@ports.0" targets="//@children.0/@children.11/@children.0/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.11/@children.7/@ports.2" targets="//@children.0/@children.11/@children.6/@ports.2"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.11/@children.7/@ports.1" targets="//@children.0/@children.11/@children.9/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.11/@children.8/@ports.0" targets="//@children.0/@children.11/@children.7/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.11/@children.9/@ports.2" targets="//@children.0/@children.11/@children.6/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.11/@children.10/@ports.1" targets="//@children.0/@children.11/@children.9/@ports.0"/>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.6/@ports.2"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.8/@ports.3" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.11/@ports.1" targets="//@children.0/@children.10/@ports.0"/>
+  </children>
+  <children identifier="N25">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L25" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P60" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N26" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E28" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_antennapattern_TransmitAntennaPattern.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_antennapattern_TransmitAntennaPattern.elkg
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.6/@ports.2"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.8/@ports.3" targets="//@children.0/@children.9/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.9/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N12">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L12" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P28" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L14" height="15.0" width="168.0" text="TransmitPropertyTransformer"/>
+      <ports identifier="P32" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N15" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="31.0" width="31.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="99.0" text="CartesianToPolar"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P38" height="8.0" width="8.0" x="31.0" y="5.0">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="81.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="104.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="104.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.2 //@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="99.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P45" height="8.0" width="8.0" x="99.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.4 //@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="81.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="81.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P55" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="25.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="42.0" text="Const3"/>
+        <ports identifier="P56" height="8.0" width="8.0" x="67.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="8.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="80.0" text="MultiplyDivide"/>
+        <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.9 //@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="83.0" text="AntennaModel"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E15" sources="//@children.1/@children.1/@children.1/@ports.3" targets="//@children.1/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.1/@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E17" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.2"/>
+      <containedEdges identifier="E18" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.5/@ports.2"/>
+      <containedEdges identifier="E19" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E21" sources="//@children.1/@children.1/@children.5/@ports.0" targets="//@children.1/@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E22" sources="//@children.1/@children.1/@children.6/@ports.0" targets="//@children.1/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.1/@children.1/@children.7/@ports.2" targets="//@children.1/@children.1/@children.6/@ports.2"/>
+      <containedEdges identifier="E24" sources="//@children.1/@children.1/@children.7/@ports.1" targets="//@children.1/@children.1/@children.9/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.1/@children.1/@children.8/@ports.0" targets="//@children.1/@children.1/@children.7/@ports.0"/>
+      <containedEdges identifier="E26" sources="//@children.1/@children.1/@children.9/@ports.2" targets="//@children.1/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E27" sources="//@children.1/@children.1/@children.10/@ports.1" targets="//@children.1/@children.1/@children.9/@ports.0"/>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_circularrange_CircularRange.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_circularrange_CircularRange.elkg
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="116.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="116.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="55.0" text="Sinewave"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="66.0" text="Transmitter"/>
+    <ports identifier="P13" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E5" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_collisions_Collisions.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_collisions_Collisions.elkg
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="73.0" text="Transmitter0"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="17.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N5">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L5" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P10" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1 //@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="99.0" text="CollisionDetector"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.13 //@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.9 //@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="81.0" text="TimedPlotter2"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.23 //@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L11" height="15.0" width="75.0" text="SquarePulse"/>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@containedEdges.0 //@children.1/@children.5/@containedEdges.1 //@children.1/@children.5/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.13" incomingEdges="//@children.1/@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.5/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N12" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P26" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.5/@containedEdges.1 //@children.1/@children.5/@containedEdges.4 //@children.1/@children.5/@containedEdges.6 //@children.1/@children.5/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P30" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.5/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.5/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.5/@containedEdges.7 //@children.1/@children.5/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E29" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.5/@children.3/@ports.0"/>
+      <containedEdges identifier="E32" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.5/@children.3/@ports.2"/>
+      <containedEdges identifier="E33" sources="//@children.1/@children.5/@children.0/@ports.0" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.1/@children.5/@children.1/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E35" sources="//@children.1/@children.5/@children.2/@ports.0" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.1/@children.5/@children.3/@ports.1" targets="//@children.1/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E37" sources="//@children.1/@children.5/@children.3/@ports.1" targets="//@children.1/@children.5/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="82.0" text="SquarePulse2"/>
+      <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.0 //@children.1/@children.6/@containedEdges.1 //@children.1/@children.6/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.14" incomingEdges="//@children.1/@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.6/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N17" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.6/@containedEdges.1 //@children.1/@children.6/@containedEdges.4 //@children.1/@children.6/@containedEdges.6 //@children.1/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P42" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.6/@containedEdges.7 //@children.1/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.1/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E38" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E39" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E40" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.1/@children.6/@ports.2" targets="//@children.1/@children.6/@children.3/@ports.2"/>
+      <containedEdges identifier="E42" sources="//@children.1/@children.6/@children.0/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.1/@children.6/@children.1/@ports.1" targets="//@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.1/@children.6/@children.2/@ports.0" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.1/@children.6/@children.3/@ports.1" targets="//@children.1/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.1/@children.6/@children.3/@ports.1" targets="//@children.1/@children.6/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N21" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.16 //@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="94.0" text="BooleanSwitch4"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.1/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.1/@ports.0" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.1/@children.12/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.1/@ports.4" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.1/@ports.4" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.11/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.12/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.6/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.13/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.10/@ports.1" targets="//@children.1/@children.13/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.11/@ports.2" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.11/@ports.3" targets="//@children.1/@children.6/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.12/@ports.2" targets="//@children.1/@children.5/@ports.2"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.12/@ports.3" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.13/@ports.2" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.13/@ports.3" targets="//@children.1/@children.4/@ports.0"/>
+  </children>
+  <children identifier="N28">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L28" height="15.0" width="73.0" text="Transmitter1"/>
+    <ports identifier="P67" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N29" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P68" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="36.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="37.0" text="Server"/>
+      <ports identifier="P72" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="67.0" y="14.0" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="17.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="42.0" y="36.0">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P85" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P89" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E47" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E52" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E53" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E54" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.7/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_collisions_CollisionsDeterministic.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_collisions_CollisionsDeterministic.elkg
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="73.0" text="Transmitter0"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  </children>
+  <children identifier="N4">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L4" height="15.0" width="73.0" text="Transmitter1"/>
+    <ports identifier="P7" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="96.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="96.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="61.0" text="TimeDelay"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="29.0" y="46.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E3" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@ports.0"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P16" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2 //@children.2/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N9" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="99.0" text="CollisionDetector"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.13 //@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.9 //@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="81.0" text="TimedPlotter2"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.23 //@children.2/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L14" height="15.0" width="75.0" text="SquarePulse"/>
+      <ports identifier="P29" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.5/@containedEdges.0 //@children.2/@children.5/@containedEdges.1 //@children.2/@children.5/@containedEdges.2" incomingEdges="//@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.13" incomingEdges="//@children.2/@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.5/@containedEdges.3" incomingEdges="//@children.2/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N15" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P32" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.5/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.5/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.5/@containedEdges.1 //@children.2/@children.5/@containedEdges.4 //@children.2/@children.5/@containedEdges.6 //@children.2/@children.5/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@children.5/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P36" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.5/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.5/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.5/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.5/@containedEdges.7 //@children.2/@children.5/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.2/@children.5/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E31" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.5/@children.0/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E33" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.5/@children.3/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.2/@children.5/@ports.2" targets="//@children.2/@children.5/@children.3/@ports.2"/>
+      <containedEdges identifier="E35" sources="//@children.2/@children.5/@children.0/@ports.0" targets="//@children.2/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E36" sources="//@children.2/@children.5/@children.1/@ports.1" targets="//@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E37" sources="//@children.2/@children.5/@children.2/@ports.0" targets="//@children.2/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E38" sources="//@children.2/@children.5/@children.3/@ports.1" targets="//@children.2/@children.5/@children.1/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.2/@children.5/@children.3/@ports.1" targets="//@children.2/@children.5/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N19">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L19" height="15.0" width="82.0" text="SquarePulse2"/>
+      <ports identifier="P41" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.6/@containedEdges.0 //@children.2/@children.6/@containedEdges.1 //@children.2/@children.6/@containedEdges.2" incomingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.14" incomingEdges="//@children.2/@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.6/@containedEdges.3" incomingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N20" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.6/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.6/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="41.0" width="21.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="37.0" text="Merge"/>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.6/@containedEdges.1 //@children.2/@children.6/@containedEdges.4 //@children.2/@children.6/@containedEdges.6 //@children.2/@children.6/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P47" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@children.6/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="42.0" text="Const2"/>
+        <ports identifier="P48" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.2/@children.6/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="61.0" text="TimeDelay"/>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.6/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P51" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@children.6/@containedEdges.7 //@children.2/@children.6/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="29.0" y="46.0" incomingEdges="//@children.2/@children.6/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E40" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.6/@children.0/@ports.1"/>
+      <containedEdges identifier="E41" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E42" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.6/@children.3/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.2/@children.6/@ports.2" targets="//@children.2/@children.6/@children.3/@ports.2"/>
+      <containedEdges identifier="E44" sources="//@children.2/@children.6/@children.0/@ports.0" targets="//@children.2/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.2/@children.6/@children.1/@ports.1" targets="//@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E46" sources="//@children.2/@children.6/@children.2/@ports.0" targets="//@children.2/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.2/@children.6/@children.3/@ports.1" targets="//@children.2/@children.6/@children.1/@ports.0"/>
+      <containedEdges identifier="E48" sources="//@children.2/@children.6/@children.3/@ports.1" targets="//@children.2/@children.6/@children.2/@ports.1"/>
+    </children>
+    <children identifier="N24" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="44.0" text="Merge2"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.16 //@children.2/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="94.0" text="BooleanSwitch4"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.2/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.2/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.2/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E6" sources="//@children.2/@ports.0" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.2/@ports.0" targets="//@children.2/@children.11/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.2/@ports.0" targets="//@children.2/@children.12/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.2/@children.1/@ports.3" targets="//@children.2/@children.8/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.2/@children.1/@ports.4" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.1/@ports.4" targets="//@children.2/@children.9/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.3/@ports.1" targets="//@children.2/@children.11/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.3/@ports.2" targets="//@children.2/@children.1/@ports.2"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.3/@ports.2" targets="//@children.2/@children.12/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.5/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.6/@ports.1" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.13/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.2/@children.9/@ports.0" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.13/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.11/@ports.2" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.11/@ports.3" targets="//@children.2/@children.6/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.2/@children.12/@ports.2" targets="//@children.2/@children.5/@ports.2"/>
+    <containedEdges identifier="E28" sources="//@children.2/@children.12/@ports.3" targets="//@children.2/@children.6/@ports.2"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.13/@ports.2" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.13/@ports.3" targets="//@children.2/@children.4/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_evaderandpursuer_EvaderAndPursuer.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_evaderandpursuer_EvaderAndPursuer.elkg
@@ -1,0 +1,360 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="40.0" text="Evader"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="25.0" width="94.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="94.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="48.0" text="Random"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="74.0" text="modal model"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="81.0" text="Accumulator2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="70.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="70.0" width="73.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="73.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="31.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.10 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="48.0" text="Poisson"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="70.0" text="MostRecent"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="78.0" text="MostRecent2"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="26.5" y="41.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.11/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.12/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.11/@ports.1" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="46.0" text="Pursuer"/>
+    <ports identifier="P35" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="68.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="46.0" text="Pursuer"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.2/@ports.2" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.2/@ports.3" targets="//@children.1/@children.3/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_intersections_Intersections.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_intersections_Intersections.elkg
@@ -1,0 +1,4503 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="34.0" text="4Way"/>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="83.0" text="PedLightNorth"/>
+      <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1 //@children.0/@children.0/@containedEdges.2 //@children.0/@children.0/@containedEdges.3 //@children.0/@children.0/@containedEdges.4 //@children.0/@children.0/@containedEdges.5 //@children.0/@children.0/@containedEdges.6 //@children.0/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P13" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P18" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P19" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P34" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E6" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E7" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E9" sources="//@children.0/@children.0/@children.0/@ports.5" targets="//@children.0/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E10" sources="//@children.0/@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@children.6/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@children.7/@ports.0" targets="//@children.0/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.8/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.9/@ports.0" targets="//@children.0/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E18" sources="//@children.0/@children.0/@children.10/@ports.2" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N14">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L14" height="15.0" width="82.0" text="PedLightWest"/>
+      <ports identifier="P37" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.0 //@children.0/@children.1/@containedEdges.1 //@children.0/@children.1/@containedEdges.2 //@children.0/@children.1/@containedEdges.3 //@children.0/@children.1/@containedEdges.4 //@children.0/@children.1/@containedEdges.5 //@children.0/@children.1/@containedEdges.6 //@children.0/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N15" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P43" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N16" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L16" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P44" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N17" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P49" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N19" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L19" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P52" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P54" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N20" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L20" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P55" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N21" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L21" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P58" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P59" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P60" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N22" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L22" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P61" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N23" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P64" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P65" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P66" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P67" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E19" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E20" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E22" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.1/@children.0/@ports.5" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.1/@children.1/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.1/@children.3/@ports.0" targets="//@children.0/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.1/@children.4/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E31" sources="//@children.0/@children.1/@children.5/@ports.0" targets="//@children.0/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.1/@children.6/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E33" sources="//@children.0/@children.1/@children.7/@ports.0" targets="//@children.0/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.1/@children.8/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E35" sources="//@children.0/@children.1/@children.9/@ports.0" targets="//@children.0/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E36" sources="//@children.0/@children.1/@children.10/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N26">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L26" height="15.0" width="86.0" text="PedLightSouth"/>
+      <ports identifier="P73" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.2/@containedEdges.0 //@children.0/@children.2/@containedEdges.1 //@children.0/@children.2/@containedEdges.2 //@children.0/@children.2/@containedEdges.3 //@children.0/@children.2/@containedEdges.4 //@children.0/@children.2/@containedEdges.5 //@children.0/@children.2/@containedEdges.6 //@children.0/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N27" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L27" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P79" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N28" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P80" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P85" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P90" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P91" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P93" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P97" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P101" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P102" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N36" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L36" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P103" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.0/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N37" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P106" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P107" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P108" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E37" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E38" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E39" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E40" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E41" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.7/@ports.1"/>
+      <containedEdges identifier="E42" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E43" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E44" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E45" sources="//@children.0/@children.2/@children.0/@ports.5" targets="//@children.0/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E46" sources="//@children.0/@children.2/@children.1/@ports.0" targets="//@children.0/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.0/@children.2/@children.3/@ports.0" targets="//@children.0/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.0/@children.2/@children.4/@ports.2" targets="//@children.0/@children.2/@children.0/@ports.3"/>
+      <containedEdges identifier="E49" sources="//@children.0/@children.2/@children.5/@ports.0" targets="//@children.0/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E50" sources="//@children.0/@children.2/@children.6/@ports.2" targets="//@children.0/@children.2/@children.0/@ports.4"/>
+      <containedEdges identifier="E51" sources="//@children.0/@children.2/@children.7/@ports.0" targets="//@children.0/@children.2/@children.8/@ports.1"/>
+      <containedEdges identifier="E52" sources="//@children.0/@children.2/@children.8/@ports.2" targets="//@children.0/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E53" sources="//@children.0/@children.2/@children.9/@ports.0" targets="//@children.0/@children.2/@children.10/@ports.1"/>
+      <containedEdges identifier="E54" sources="//@children.0/@children.2/@children.10/@ports.2" targets="//@children.0/@children.2/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N38">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L38" height="15.0" width="78.0" text="PedLightEast"/>
+      <ports identifier="P109" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.3/@containedEdges.0 //@children.0/@children.3/@containedEdges.1 //@children.0/@children.3/@containedEdges.2 //@children.0/@children.3/@containedEdges.3 //@children.0/@children.3/@containedEdges.4 //@children.0/@children.3/@containedEdges.5 //@children.0/@children.3/@containedEdges.6 //@children.0/@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N39" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L39" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.0/@children.3/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.3/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.3/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.3/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.0/@children.3/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P115" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N40" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L40" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P116" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.3/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P117" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N41" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L41" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P119" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.3/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P120" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N42" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L42" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P121" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P122" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N43" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L43" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P124" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.3/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P125" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.3/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P126" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N44" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L44" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P127" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P128" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N45" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L45" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P129" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P130" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.3/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P131" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.3/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P132" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N46" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L46" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P133" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P134" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N47" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L47" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P135" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P136" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.3/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P137" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.3/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P138" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N48" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L48" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P139" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.0/@children.3/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P140" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.3/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N49" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L49" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P141" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.3/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P142" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.3/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P143" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.3/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P144" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E55" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.3/@ports.1"/>
+      <containedEdges identifier="E56" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.4/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.5/@ports.1"/>
+      <containedEdges identifier="E58" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.6/@ports.0"/>
+      <containedEdges identifier="E59" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.7/@ports.1"/>
+      <containedEdges identifier="E60" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.8/@ports.0"/>
+      <containedEdges identifier="E61" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.9/@ports.1"/>
+      <containedEdges identifier="E62" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.3/@children.10/@ports.0"/>
+      <containedEdges identifier="E63" sources="//@children.0/@children.3/@children.0/@ports.5" targets="//@children.0/@children.3/@children.2/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.0/@children.3/@children.1/@ports.0" targets="//@children.0/@children.3/@children.0/@ports.0"/>
+      <containedEdges identifier="E65" sources="//@children.0/@children.3/@children.3/@ports.0" targets="//@children.0/@children.3/@children.4/@ports.1"/>
+      <containedEdges identifier="E66" sources="//@children.0/@children.3/@children.4/@ports.2" targets="//@children.0/@children.3/@children.0/@ports.3"/>
+      <containedEdges identifier="E67" sources="//@children.0/@children.3/@children.5/@ports.0" targets="//@children.0/@children.3/@children.6/@ports.1"/>
+      <containedEdges identifier="E68" sources="//@children.0/@children.3/@children.6/@ports.2" targets="//@children.0/@children.3/@children.0/@ports.4"/>
+      <containedEdges identifier="E69" sources="//@children.0/@children.3/@children.7/@ports.0" targets="//@children.0/@children.3/@children.8/@ports.1"/>
+      <containedEdges identifier="E70" sources="//@children.0/@children.3/@children.8/@ports.2" targets="//@children.0/@children.3/@children.0/@ports.2"/>
+      <containedEdges identifier="E71" sources="//@children.0/@children.3/@children.9/@ports.0" targets="//@children.0/@children.3/@children.10/@ports.1"/>
+      <containedEdges identifier="E72" sources="//@children.0/@children.3/@children.10/@ports.2" targets="//@children.0/@children.3/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N50">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L50" height="15.0" width="43.0" text="3WayS"/>
+    <children identifier="N51">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L51" height="15.0" width="82.0" text="PedLightWest"/>
+      <ports identifier="P145" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0 //@children.1/@children.0/@containedEdges.1 //@children.1/@children.0/@containedEdges.2 //@children.1/@children.0/@containedEdges.3 //@children.1/@children.0/@containedEdges.4 //@children.1/@children.0/@containedEdges.5 //@children.1/@children.0/@containedEdges.6 //@children.1/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N52" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L52" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P146" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.1/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P147" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P148" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P149" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P150" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.1/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P151" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N53" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L53" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P152" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P153" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P154" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N54" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L54" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P155" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P156" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N55" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L55" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P157" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P158" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N56" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L56" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P159" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P160" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P161" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P162" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N57" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L57" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P163" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P164" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N58" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L58" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P165" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P166" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P167" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P168" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N59" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L59" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P169" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P170" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N60" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L60" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P171" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P172" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P173" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P174" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N61" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L61" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P175" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P176" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N62" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L62" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P177" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P178" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P179" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P180" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E73" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E74" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E75" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E76" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E77" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E78" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E79" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E80" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E81" sources="//@children.1/@children.0/@children.0/@ports.5" targets="//@children.1/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E82" sources="//@children.1/@children.0/@children.1/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E83" sources="//@children.1/@children.0/@children.3/@ports.0" targets="//@children.1/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E84" sources="//@children.1/@children.0/@children.4/@ports.2" targets="//@children.1/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E85" sources="//@children.1/@children.0/@children.5/@ports.0" targets="//@children.1/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E86" sources="//@children.1/@children.0/@children.6/@ports.2" targets="//@children.1/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E87" sources="//@children.1/@children.0/@children.7/@ports.0" targets="//@children.1/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E88" sources="//@children.1/@children.0/@children.8/@ports.2" targets="//@children.1/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E89" sources="//@children.1/@children.0/@children.9/@ports.0" targets="//@children.1/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E90" sources="//@children.1/@children.0/@children.10/@ports.2" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N63">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L63" height="15.0" width="86.0" text="PedLightSouth"/>
+      <ports identifier="P181" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0 //@children.1/@children.1/@containedEdges.1 //@children.1/@children.1/@containedEdges.2 //@children.1/@children.1/@containedEdges.3 //@children.1/@children.1/@containedEdges.4 //@children.1/@children.1/@containedEdges.5 //@children.1/@children.1/@containedEdges.6 //@children.1/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N64" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L64" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P182" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P183" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P184" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P185" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P186" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P187" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N65" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L65" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P188" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P189" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P190" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N66" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L66" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P191" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P192" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N67" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L67" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P193" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P194" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N68" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L68" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P195" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P196" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P197" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P198" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N69" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L69" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P199" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P200" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N70" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L70" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P201" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P202" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P203" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P204" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N71" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L71" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P205" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P206" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N72" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L72" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P207" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P208" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P209" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P210" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N73" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L73" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P211" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P212" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N74" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L74" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P213" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P214" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P215" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P216" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E91" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E92" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E93" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E94" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E95" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E96" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E97" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E98" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E99" sources="//@children.1/@children.1/@children.0/@ports.5" targets="//@children.1/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E100" sources="//@children.1/@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E101" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E102" sources="//@children.1/@children.1/@children.4/@ports.2" targets="//@children.1/@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E103" sources="//@children.1/@children.1/@children.5/@ports.0" targets="//@children.1/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E104" sources="//@children.1/@children.1/@children.6/@ports.2" targets="//@children.1/@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E105" sources="//@children.1/@children.1/@children.7/@ports.0" targets="//@children.1/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E106" sources="//@children.1/@children.1/@children.8/@ports.2" targets="//@children.1/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E107" sources="//@children.1/@children.1/@children.9/@ports.0" targets="//@children.1/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E108" sources="//@children.1/@children.1/@children.10/@ports.2" targets="//@children.1/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N75">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L75" height="15.0" width="78.0" text="PedLightEast"/>
+      <ports identifier="P217" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.0 //@children.1/@children.2/@containedEdges.1 //@children.1/@children.2/@containedEdges.2 //@children.1/@children.2/@containedEdges.3 //@children.1/@children.2/@containedEdges.4 //@children.1/@children.2/@containedEdges.5 //@children.1/@children.2/@containedEdges.6 //@children.1/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N76" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L76" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P218" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.1/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P219" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P220" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P221" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P222" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P223" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N77" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L77" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P224" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P225" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P226" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N78" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L78" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P227" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P228" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N79" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L79" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P229" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.1/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P230" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N80" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L80" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P231" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P232" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P233" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P234" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N81" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L81" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P235" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.1/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P236" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N82" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L82" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P237" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P238" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P239" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P240" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N83" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L83" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P241" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.1/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P242" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N84" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L84" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P243" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P244" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P245" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P246" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N85" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L85" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P247" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.1/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P248" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N86" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L86" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P249" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P250" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P251" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P252" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E109" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E110" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E111" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E112" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E113" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.7/@ports.1"/>
+      <containedEdges identifier="E114" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E115" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E116" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E117" sources="//@children.1/@children.2/@children.0/@ports.5" targets="//@children.1/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E118" sources="//@children.1/@children.2/@children.1/@ports.0" targets="//@children.1/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E119" sources="//@children.1/@children.2/@children.3/@ports.0" targets="//@children.1/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E120" sources="//@children.1/@children.2/@children.4/@ports.2" targets="//@children.1/@children.2/@children.0/@ports.3"/>
+      <containedEdges identifier="E121" sources="//@children.1/@children.2/@children.5/@ports.0" targets="//@children.1/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E122" sources="//@children.1/@children.2/@children.6/@ports.2" targets="//@children.1/@children.2/@children.0/@ports.4"/>
+      <containedEdges identifier="E123" sources="//@children.1/@children.2/@children.7/@ports.0" targets="//@children.1/@children.2/@children.8/@ports.1"/>
+      <containedEdges identifier="E124" sources="//@children.1/@children.2/@children.8/@ports.2" targets="//@children.1/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E125" sources="//@children.1/@children.2/@children.9/@ports.0" targets="//@children.1/@children.2/@children.10/@ports.1"/>
+      <containedEdges identifier="E126" sources="//@children.1/@children.2/@children.10/@ports.2" targets="//@children.1/@children.2/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N87">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L87" height="15.0" width="44.0" text="3WayN"/>
+    <children identifier="N88">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L88" height="15.0" width="83.0" text="PedLightNorth"/>
+      <ports identifier="P253" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.0/@containedEdges.0 //@children.2/@children.0/@containedEdges.1 //@children.2/@children.0/@containedEdges.2 //@children.2/@children.0/@containedEdges.3 //@children.2/@children.0/@containedEdges.4 //@children.2/@children.0/@containedEdges.5 //@children.2/@children.0/@containedEdges.6 //@children.2/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N89" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L89" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P254" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.2/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P255" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P256" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P257" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P258" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.2/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P259" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N90" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L90" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P260" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P261" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P262" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N91" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L91" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P263" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P264" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N92" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L92" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P265" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P266" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N93" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L93" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P267" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P268" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P269" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P270" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N94" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L94" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P271" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P272" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N95" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L95" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P273" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P274" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P275" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P276" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N96" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L96" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P277" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P278" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N97" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L97" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P279" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P280" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P281" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P282" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N98" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L98" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P283" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.2/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P284" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N99" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L99" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P285" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P286" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P287" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P288" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E127" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E128" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E129" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E130" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E131" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E132" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E133" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E134" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E135" sources="//@children.2/@children.0/@children.0/@ports.5" targets="//@children.2/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E136" sources="//@children.2/@children.0/@children.1/@ports.0" targets="//@children.2/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E137" sources="//@children.2/@children.0/@children.3/@ports.0" targets="//@children.2/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E138" sources="//@children.2/@children.0/@children.4/@ports.2" targets="//@children.2/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E139" sources="//@children.2/@children.0/@children.5/@ports.0" targets="//@children.2/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E140" sources="//@children.2/@children.0/@children.6/@ports.2" targets="//@children.2/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E141" sources="//@children.2/@children.0/@children.7/@ports.0" targets="//@children.2/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E142" sources="//@children.2/@children.0/@children.8/@ports.2" targets="//@children.2/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E143" sources="//@children.2/@children.0/@children.9/@ports.0" targets="//@children.2/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E144" sources="//@children.2/@children.0/@children.10/@ports.2" targets="//@children.2/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N100">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L100" height="15.0" width="82.0" text="PedLightWest"/>
+      <ports identifier="P289" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.1/@containedEdges.0 //@children.2/@children.1/@containedEdges.1 //@children.2/@children.1/@containedEdges.2 //@children.2/@children.1/@containedEdges.3 //@children.2/@children.1/@containedEdges.4 //@children.2/@children.1/@containedEdges.5 //@children.2/@children.1/@containedEdges.6 //@children.2/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N101" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L101" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P290" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.2/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P291" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P292" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P293" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P294" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.2/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P295" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N102" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L102" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P296" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P297" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P298" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N103" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L103" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P299" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P300" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N104" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L104" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P301" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.2/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P302" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N105" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L105" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P303" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P304" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P305" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P306" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N106" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L106" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P307" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.2/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P308" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N107" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L107" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P309" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P310" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P311" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P312" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N108" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L108" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P313" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.2/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P314" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N109" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L109" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P315" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P316" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P317" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P318" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N110" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L110" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P319" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.2/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P320" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N111" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L111" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P321" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P322" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P323" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P324" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E145" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E146" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E147" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E148" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E149" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E150" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E151" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E152" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E153" sources="//@children.2/@children.1/@children.0/@ports.5" targets="//@children.2/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E154" sources="//@children.2/@children.1/@children.1/@ports.0" targets="//@children.2/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E155" sources="//@children.2/@children.1/@children.3/@ports.0" targets="//@children.2/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E156" sources="//@children.2/@children.1/@children.4/@ports.2" targets="//@children.2/@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E157" sources="//@children.2/@children.1/@children.5/@ports.0" targets="//@children.2/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E158" sources="//@children.2/@children.1/@children.6/@ports.2" targets="//@children.2/@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E159" sources="//@children.2/@children.1/@children.7/@ports.0" targets="//@children.2/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E160" sources="//@children.2/@children.1/@children.8/@ports.2" targets="//@children.2/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E161" sources="//@children.2/@children.1/@children.9/@ports.0" targets="//@children.2/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E162" sources="//@children.2/@children.1/@children.10/@ports.2" targets="//@children.2/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N112">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L112" height="15.0" width="78.0" text="PedLightEast"/>
+      <ports identifier="P325" height="8.0" width="8.0" outgoingEdges="//@children.2/@children.2/@containedEdges.0 //@children.2/@children.2/@containedEdges.1 //@children.2/@children.2/@containedEdges.2 //@children.2/@children.2/@containedEdges.3 //@children.2/@children.2/@containedEdges.4 //@children.2/@children.2/@containedEdges.5 //@children.2/@children.2/@containedEdges.6 //@children.2/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N113" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L113" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P326" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.2/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P327" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P328" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P329" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.2/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P330" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.2/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P331" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N114" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L114" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P332" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P333" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P334" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N115" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L115" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P335" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P336" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N116" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L116" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P337" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.2/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P338" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N117" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L117" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P339" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P340" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P341" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P342" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N118" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L118" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P343" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.2/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P344" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N119" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L119" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P345" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P346" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P347" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P348" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N120" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L120" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P349" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.2/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P350" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N121" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L121" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P351" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P352" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P353" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P354" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N122" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L122" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P355" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.2/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P356" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N123" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L123" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P357" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P358" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P359" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P360" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E163" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E164" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E165" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E166" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E167" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.7/@ports.1"/>
+      <containedEdges identifier="E168" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E169" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E170" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E171" sources="//@children.2/@children.2/@children.0/@ports.5" targets="//@children.2/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E172" sources="//@children.2/@children.2/@children.1/@ports.0" targets="//@children.2/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E173" sources="//@children.2/@children.2/@children.3/@ports.0" targets="//@children.2/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E174" sources="//@children.2/@children.2/@children.4/@ports.2" targets="//@children.2/@children.2/@children.0/@ports.3"/>
+      <containedEdges identifier="E175" sources="//@children.2/@children.2/@children.5/@ports.0" targets="//@children.2/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E176" sources="//@children.2/@children.2/@children.6/@ports.2" targets="//@children.2/@children.2/@children.0/@ports.4"/>
+      <containedEdges identifier="E177" sources="//@children.2/@children.2/@children.7/@ports.0" targets="//@children.2/@children.2/@children.8/@ports.1"/>
+      <containedEdges identifier="E178" sources="//@children.2/@children.2/@children.8/@ports.2" targets="//@children.2/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E179" sources="//@children.2/@children.2/@children.9/@ports.0" targets="//@children.2/@children.2/@children.10/@ports.1"/>
+      <containedEdges identifier="E180" sources="//@children.2/@children.2/@children.10/@ports.2" targets="//@children.2/@children.2/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N124">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L124" height="15.0" width="56.0" text="2WayEW"/>
+    <children identifier="N125">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L125" height="15.0" width="82.0" text="PedLightWest"/>
+      <ports identifier="P361" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.0/@containedEdges.0 //@children.3/@children.0/@containedEdges.1 //@children.3/@children.0/@containedEdges.2 //@children.3/@children.0/@containedEdges.3 //@children.3/@children.0/@containedEdges.4 //@children.3/@children.0/@containedEdges.5 //@children.3/@children.0/@containedEdges.6 //@children.3/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N126" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L126" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P362" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.3/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P363" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P364" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P365" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P366" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P367" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N127" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L127" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P368" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P369" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P370" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N128" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L128" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P371" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P372" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N129" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L129" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P373" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P374" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N130" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L130" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P375" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P376" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P377" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P378" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N131" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L131" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P379" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P380" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N132" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L132" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P381" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P382" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P383" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P384" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N133" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L133" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P385" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P386" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N134" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L134" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P387" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P388" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P389" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P390" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N135" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L135" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P391" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P392" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N136" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L136" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P393" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P394" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P395" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P396" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E181" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E182" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E183" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E184" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E185" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E186" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E187" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E188" sources="//@children.3/@children.0/@ports.0" targets="//@children.3/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E189" sources="//@children.3/@children.0/@children.0/@ports.5" targets="//@children.3/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E190" sources="//@children.3/@children.0/@children.1/@ports.0" targets="//@children.3/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E191" sources="//@children.3/@children.0/@children.3/@ports.0" targets="//@children.3/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E192" sources="//@children.3/@children.0/@children.4/@ports.2" targets="//@children.3/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E193" sources="//@children.3/@children.0/@children.5/@ports.0" targets="//@children.3/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E194" sources="//@children.3/@children.0/@children.6/@ports.2" targets="//@children.3/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E195" sources="//@children.3/@children.0/@children.7/@ports.0" targets="//@children.3/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E196" sources="//@children.3/@children.0/@children.8/@ports.2" targets="//@children.3/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E197" sources="//@children.3/@children.0/@children.9/@ports.0" targets="//@children.3/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E198" sources="//@children.3/@children.0/@children.10/@ports.2" targets="//@children.3/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N137">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L137" height="15.0" width="78.0" text="PedLightEast"/>
+      <ports identifier="P397" height="8.0" width="8.0" outgoingEdges="//@children.3/@children.1/@containedEdges.0 //@children.3/@children.1/@containedEdges.1 //@children.3/@children.1/@containedEdges.2 //@children.3/@children.1/@containedEdges.3 //@children.3/@children.1/@containedEdges.4 //@children.3/@children.1/@containedEdges.5 //@children.3/@children.1/@containedEdges.6 //@children.3/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N138" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L138" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P398" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.3/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P399" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P400" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P401" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.3/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P402" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.3/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P403" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.3/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N139" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L139" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P404" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P405" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P406" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N140" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L140" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P407" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P408" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N141" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L141" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P409" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.3/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P410" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N142" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L142" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P411" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P412" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P413" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P414" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N143" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L143" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P415" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.3/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P416" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N144" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L144" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P417" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P418" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P419" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P420" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N145" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L145" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P421" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.3/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P422" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N146" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L146" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P423" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P424" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P425" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P426" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N147" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L147" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P427" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.3/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P428" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N148" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L148" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P429" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P430" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P431" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P432" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E199" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E200" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E201" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E202" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E203" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E204" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E205" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E206" sources="//@children.3/@children.1/@ports.0" targets="//@children.3/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E207" sources="//@children.3/@children.1/@children.0/@ports.5" targets="//@children.3/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E208" sources="//@children.3/@children.1/@children.1/@ports.0" targets="//@children.3/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E209" sources="//@children.3/@children.1/@children.3/@ports.0" targets="//@children.3/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E210" sources="//@children.3/@children.1/@children.4/@ports.2" targets="//@children.3/@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E211" sources="//@children.3/@children.1/@children.5/@ports.0" targets="//@children.3/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E212" sources="//@children.3/@children.1/@children.6/@ports.2" targets="//@children.3/@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E213" sources="//@children.3/@children.1/@children.7/@ports.0" targets="//@children.3/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E214" sources="//@children.3/@children.1/@children.8/@ports.2" targets="//@children.3/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E215" sources="//@children.3/@children.1/@children.9/@ports.0" targets="//@children.3/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E216" sources="//@children.3/@children.1/@children.10/@ports.2" targets="//@children.3/@children.1/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N149">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L149" height="15.0" width="43.0" text="3WayE"/>
+    <children identifier="N150">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L150" height="15.0" width="83.0" text="PedLightNorth"/>
+      <ports identifier="P433" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.0/@containedEdges.0 //@children.4/@children.0/@containedEdges.1 //@children.4/@children.0/@containedEdges.2 //@children.4/@children.0/@containedEdges.3 //@children.4/@children.0/@containedEdges.4 //@children.4/@children.0/@containedEdges.5 //@children.4/@children.0/@containedEdges.6 //@children.4/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N151" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L151" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P434" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.4/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P435" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P436" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P437" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P438" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P439" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N152" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L152" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P440" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P441" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P442" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N153" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L153" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P443" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P444" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N154" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L154" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P445" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P446" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N155" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L155" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P447" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P448" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P449" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P450" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N156" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L156" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P451" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P452" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N157" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L157" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P453" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P454" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P455" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P456" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N158" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L158" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P457" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P458" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N159" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L159" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P459" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P460" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P461" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P462" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N160" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L160" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P463" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.4/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P464" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N161" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L161" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P465" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P466" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P467" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P468" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E217" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E218" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E219" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E220" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E221" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E222" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E223" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E224" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E225" sources="//@children.4/@children.0/@children.0/@ports.5" targets="//@children.4/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E226" sources="//@children.4/@children.0/@children.1/@ports.0" targets="//@children.4/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E227" sources="//@children.4/@children.0/@children.3/@ports.0" targets="//@children.4/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E228" sources="//@children.4/@children.0/@children.4/@ports.2" targets="//@children.4/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E229" sources="//@children.4/@children.0/@children.5/@ports.0" targets="//@children.4/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E230" sources="//@children.4/@children.0/@children.6/@ports.2" targets="//@children.4/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E231" sources="//@children.4/@children.0/@children.7/@ports.0" targets="//@children.4/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E232" sources="//@children.4/@children.0/@children.8/@ports.2" targets="//@children.4/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E233" sources="//@children.4/@children.0/@children.9/@ports.0" targets="//@children.4/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E234" sources="//@children.4/@children.0/@children.10/@ports.2" targets="//@children.4/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N162">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L162" height="15.0" width="86.0" text="PedLightSouth"/>
+      <ports identifier="P469" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.1/@containedEdges.0 //@children.4/@children.1/@containedEdges.1 //@children.4/@children.1/@containedEdges.2 //@children.4/@children.1/@containedEdges.3 //@children.4/@children.1/@containedEdges.4 //@children.4/@children.1/@containedEdges.5 //@children.4/@children.1/@containedEdges.6 //@children.4/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N163" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L163" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P470" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.4/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P471" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P472" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P473" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P474" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.4/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P475" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N164" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L164" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P476" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P477" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P478" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N165" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L165" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P479" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P480" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N166" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L166" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P481" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.4/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P482" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N167" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L167" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P483" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P484" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P485" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P486" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N168" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L168" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P487" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.4/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P488" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N169" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L169" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P489" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P490" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P491" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P492" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N170" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L170" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P493" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.4/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P494" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N171" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L171" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P495" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P496" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P497" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P498" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N172" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L172" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P499" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.4/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P500" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N173" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L173" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P501" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P502" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P503" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P504" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E235" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E236" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E237" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E238" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E239" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E240" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E241" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E242" sources="//@children.4/@children.1/@ports.0" targets="//@children.4/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E243" sources="//@children.4/@children.1/@children.0/@ports.5" targets="//@children.4/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E244" sources="//@children.4/@children.1/@children.1/@ports.0" targets="//@children.4/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E245" sources="//@children.4/@children.1/@children.3/@ports.0" targets="//@children.4/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E246" sources="//@children.4/@children.1/@children.4/@ports.2" targets="//@children.4/@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E247" sources="//@children.4/@children.1/@children.5/@ports.0" targets="//@children.4/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E248" sources="//@children.4/@children.1/@children.6/@ports.2" targets="//@children.4/@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E249" sources="//@children.4/@children.1/@children.7/@ports.0" targets="//@children.4/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E250" sources="//@children.4/@children.1/@children.8/@ports.2" targets="//@children.4/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E251" sources="//@children.4/@children.1/@children.9/@ports.0" targets="//@children.4/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E252" sources="//@children.4/@children.1/@children.10/@ports.2" targets="//@children.4/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N174">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L174" height="15.0" width="78.0" text="PedLightEast"/>
+      <ports identifier="P505" height="8.0" width="8.0" outgoingEdges="//@children.4/@children.2/@containedEdges.0 //@children.4/@children.2/@containedEdges.1 //@children.4/@children.2/@containedEdges.2 //@children.4/@children.2/@containedEdges.3 //@children.4/@children.2/@containedEdges.4 //@children.4/@children.2/@containedEdges.5 //@children.4/@children.2/@containedEdges.6 //@children.4/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N175" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L175" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P506" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.4/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P507" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P508" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P509" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.4/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P510" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.4/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P511" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N176" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L176" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P512" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P513" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P514" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N177" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L177" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P515" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P516" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N178" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L178" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P517" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.4/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P518" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N179" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L179" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P519" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P520" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P521" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P522" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N180" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L180" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P523" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.4/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P524" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N181" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L181" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P525" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P526" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P527" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P528" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N182" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L182" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P529" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.4/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P530" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N183" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L183" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P531" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P532" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P533" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P534" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N184" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L184" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P535" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.4/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P536" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N185" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L185" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P537" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P538" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P539" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P540" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E253" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E254" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E255" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E256" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E257" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.7/@ports.1"/>
+      <containedEdges identifier="E258" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E259" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E260" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E261" sources="//@children.4/@children.2/@children.0/@ports.5" targets="//@children.4/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E262" sources="//@children.4/@children.2/@children.1/@ports.0" targets="//@children.4/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E263" sources="//@children.4/@children.2/@children.3/@ports.0" targets="//@children.4/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E264" sources="//@children.4/@children.2/@children.4/@ports.2" targets="//@children.4/@children.2/@children.0/@ports.3"/>
+      <containedEdges identifier="E265" sources="//@children.4/@children.2/@children.5/@ports.0" targets="//@children.4/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E266" sources="//@children.4/@children.2/@children.6/@ports.2" targets="//@children.4/@children.2/@children.0/@ports.4"/>
+      <containedEdges identifier="E267" sources="//@children.4/@children.2/@children.7/@ports.0" targets="//@children.4/@children.2/@children.8/@ports.1"/>
+      <containedEdges identifier="E268" sources="//@children.4/@children.2/@children.8/@ports.2" targets="//@children.4/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E269" sources="//@children.4/@children.2/@children.9/@ports.0" targets="//@children.4/@children.2/@children.10/@ports.1"/>
+      <containedEdges identifier="E270" sources="//@children.4/@children.2/@children.10/@ports.2" targets="//@children.4/@children.2/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N186">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L186" height="15.0" width="47.0" text="3WayW"/>
+    <children identifier="N187">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L187" height="15.0" width="83.0" text="PedLightNorth"/>
+      <ports identifier="P541" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.0/@containedEdges.0 //@children.5/@children.0/@containedEdges.1 //@children.5/@children.0/@containedEdges.2 //@children.5/@children.0/@containedEdges.3 //@children.5/@children.0/@containedEdges.4 //@children.5/@children.0/@containedEdges.5 //@children.5/@children.0/@containedEdges.6 //@children.5/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N188" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L188" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P542" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.5/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P543" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P544" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P545" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P546" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.5/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P547" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N189" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L189" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P548" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P549" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P550" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N190" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L190" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P551" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P552" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N191" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L191" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P553" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P554" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N192" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L192" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P555" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P556" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P557" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P558" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N193" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L193" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P559" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P560" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N194" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L194" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P561" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P562" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P563" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P564" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N195" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L195" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P565" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P566" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N196" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L196" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P567" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P568" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P569" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P570" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N197" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L197" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P571" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.5/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P572" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N198" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L198" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P573" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P574" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P575" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P576" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E271" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E272" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E273" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E274" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E275" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E276" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E277" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E278" sources="//@children.5/@children.0/@ports.0" targets="//@children.5/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E279" sources="//@children.5/@children.0/@children.0/@ports.5" targets="//@children.5/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E280" sources="//@children.5/@children.0/@children.1/@ports.0" targets="//@children.5/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E281" sources="//@children.5/@children.0/@children.3/@ports.0" targets="//@children.5/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E282" sources="//@children.5/@children.0/@children.4/@ports.2" targets="//@children.5/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E283" sources="//@children.5/@children.0/@children.5/@ports.0" targets="//@children.5/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E284" sources="//@children.5/@children.0/@children.6/@ports.2" targets="//@children.5/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E285" sources="//@children.5/@children.0/@children.7/@ports.0" targets="//@children.5/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E286" sources="//@children.5/@children.0/@children.8/@ports.2" targets="//@children.5/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E287" sources="//@children.5/@children.0/@children.9/@ports.0" targets="//@children.5/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E288" sources="//@children.5/@children.0/@children.10/@ports.2" targets="//@children.5/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N199">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L199" height="15.0" width="82.0" text="PedLightWest"/>
+      <ports identifier="P577" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.1/@containedEdges.0 //@children.5/@children.1/@containedEdges.1 //@children.5/@children.1/@containedEdges.2 //@children.5/@children.1/@containedEdges.3 //@children.5/@children.1/@containedEdges.4 //@children.5/@children.1/@containedEdges.5 //@children.5/@children.1/@containedEdges.6 //@children.5/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N200" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L200" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P578" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.5/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P579" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P580" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P581" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P582" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.5/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P583" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N201" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L201" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P584" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P585" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P586" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N202" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L202" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P587" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P588" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N203" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L203" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P589" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P590" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N204" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L204" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P591" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P592" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P593" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P594" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N205" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L205" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P595" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P596" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N206" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L206" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P597" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P598" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P599" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P600" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N207" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L207" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P601" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P602" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N208" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L208" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P603" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P604" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P605" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P606" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N209" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L209" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P607" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.5/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P608" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N210" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L210" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P609" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P610" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P611" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P612" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E289" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E290" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E291" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E292" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E293" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E294" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E295" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E296" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E297" sources="//@children.5/@children.1/@children.0/@ports.5" targets="//@children.5/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E298" sources="//@children.5/@children.1/@children.1/@ports.0" targets="//@children.5/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E299" sources="//@children.5/@children.1/@children.3/@ports.0" targets="//@children.5/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E300" sources="//@children.5/@children.1/@children.4/@ports.2" targets="//@children.5/@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E301" sources="//@children.5/@children.1/@children.5/@ports.0" targets="//@children.5/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E302" sources="//@children.5/@children.1/@children.6/@ports.2" targets="//@children.5/@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E303" sources="//@children.5/@children.1/@children.7/@ports.0" targets="//@children.5/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E304" sources="//@children.5/@children.1/@children.8/@ports.2" targets="//@children.5/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E305" sources="//@children.5/@children.1/@children.9/@ports.0" targets="//@children.5/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E306" sources="//@children.5/@children.1/@children.10/@ports.2" targets="//@children.5/@children.1/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N211">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L211" height="15.0" width="86.0" text="PedLightSouth"/>
+      <ports identifier="P613" height="8.0" width="8.0" outgoingEdges="//@children.5/@children.2/@containedEdges.0 //@children.5/@children.2/@containedEdges.1 //@children.5/@children.2/@containedEdges.2 //@children.5/@children.2/@containedEdges.3 //@children.5/@children.2/@containedEdges.4 //@children.5/@children.2/@containedEdges.5 //@children.5/@children.2/@containedEdges.6 //@children.5/@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N212" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L212" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P614" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.5/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P615" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P616" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P617" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.5/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P618" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.5/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P619" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N213" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L213" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P620" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.5/@children.2/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P621" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P622" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N214" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L214" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P623" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@children.2/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P624" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N215" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L215" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P625" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.5/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P626" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N216" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L216" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P627" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P628" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.2/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P629" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.2/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P630" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N217" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L217" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P631" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.5/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P632" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N218" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L218" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P633" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P634" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.2/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P635" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.2/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P636" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N219" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L219" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P637" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.5/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P638" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N220" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L220" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P639" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P640" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.2/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P641" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.2/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P642" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N221" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L221" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P643" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.5/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P644" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.5/@children.2/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N222" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L222" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P645" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.5/@children.2/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P646" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.5/@children.2/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P647" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.5/@children.2/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P648" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E307" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.3/@ports.1"/>
+      <containedEdges identifier="E308" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.4/@ports.0"/>
+      <containedEdges identifier="E309" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.5/@ports.1"/>
+      <containedEdges identifier="E310" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.6/@ports.0"/>
+      <containedEdges identifier="E311" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.7/@ports.1"/>
+      <containedEdges identifier="E312" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.8/@ports.0"/>
+      <containedEdges identifier="E313" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.9/@ports.1"/>
+      <containedEdges identifier="E314" sources="//@children.5/@children.2/@ports.0" targets="//@children.5/@children.2/@children.10/@ports.0"/>
+      <containedEdges identifier="E315" sources="//@children.5/@children.2/@children.0/@ports.5" targets="//@children.5/@children.2/@children.2/@ports.0"/>
+      <containedEdges identifier="E316" sources="//@children.5/@children.2/@children.1/@ports.0" targets="//@children.5/@children.2/@children.0/@ports.0"/>
+      <containedEdges identifier="E317" sources="//@children.5/@children.2/@children.3/@ports.0" targets="//@children.5/@children.2/@children.4/@ports.1"/>
+      <containedEdges identifier="E318" sources="//@children.5/@children.2/@children.4/@ports.2" targets="//@children.5/@children.2/@children.0/@ports.3"/>
+      <containedEdges identifier="E319" sources="//@children.5/@children.2/@children.5/@ports.0" targets="//@children.5/@children.2/@children.6/@ports.1"/>
+      <containedEdges identifier="E320" sources="//@children.5/@children.2/@children.6/@ports.2" targets="//@children.5/@children.2/@children.0/@ports.4"/>
+      <containedEdges identifier="E321" sources="//@children.5/@children.2/@children.7/@ports.0" targets="//@children.5/@children.2/@children.8/@ports.1"/>
+      <containedEdges identifier="E322" sources="//@children.5/@children.2/@children.8/@ports.2" targets="//@children.5/@children.2/@children.0/@ports.2"/>
+      <containedEdges identifier="E323" sources="//@children.5/@children.2/@children.9/@ports.0" targets="//@children.5/@children.2/@children.10/@ports.1"/>
+      <containedEdges identifier="E324" sources="//@children.5/@children.2/@children.10/@ports.2" targets="//@children.5/@children.2/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N223">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L223" height="15.0" width="52.0" text="2WayNS"/>
+    <children identifier="N224">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L224" height="15.0" width="83.0" text="PedLightNorth"/>
+      <ports identifier="P649" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.0/@containedEdges.0 //@children.6/@children.0/@containedEdges.1 //@children.6/@children.0/@containedEdges.2 //@children.6/@children.0/@containedEdges.3 //@children.6/@children.0/@containedEdges.4 //@children.6/@children.0/@containedEdges.5 //@children.6/@children.0/@containedEdges.6 //@children.6/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N225" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L225" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P650" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.6/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P651" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P652" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P653" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P654" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.6/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P655" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N226" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L226" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P656" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P657" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P658" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N227" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L227" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P659" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P660" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N228" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L228" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P661" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P662" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N229" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L229" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P663" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P664" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.0/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P665" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.0/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P666" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N230" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L230" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P667" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P668" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N231" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L231" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P669" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P670" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.0/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P671" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.0/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P672" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N232" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L232" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P673" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P674" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N233" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L233" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P675" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P676" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.0/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P677" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.0/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P678" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N234" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L234" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P679" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.6/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P680" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N235" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L235" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P681" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P682" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.0/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P683" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.0/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P684" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E325" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E326" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.4/@ports.0"/>
+      <containedEdges identifier="E327" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.5/@ports.1"/>
+      <containedEdges identifier="E328" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E329" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.7/@ports.1"/>
+      <containedEdges identifier="E330" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.8/@ports.0"/>
+      <containedEdges identifier="E331" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.9/@ports.1"/>
+      <containedEdges identifier="E332" sources="//@children.6/@children.0/@ports.0" targets="//@children.6/@children.0/@children.10/@ports.0"/>
+      <containedEdges identifier="E333" sources="//@children.6/@children.0/@children.0/@ports.5" targets="//@children.6/@children.0/@children.2/@ports.0"/>
+      <containedEdges identifier="E334" sources="//@children.6/@children.0/@children.1/@ports.0" targets="//@children.6/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E335" sources="//@children.6/@children.0/@children.3/@ports.0" targets="//@children.6/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E336" sources="//@children.6/@children.0/@children.4/@ports.2" targets="//@children.6/@children.0/@children.0/@ports.3"/>
+      <containedEdges identifier="E337" sources="//@children.6/@children.0/@children.5/@ports.0" targets="//@children.6/@children.0/@children.6/@ports.1"/>
+      <containedEdges identifier="E338" sources="//@children.6/@children.0/@children.6/@ports.2" targets="//@children.6/@children.0/@children.0/@ports.4"/>
+      <containedEdges identifier="E339" sources="//@children.6/@children.0/@children.7/@ports.0" targets="//@children.6/@children.0/@children.8/@ports.1"/>
+      <containedEdges identifier="E340" sources="//@children.6/@children.0/@children.8/@ports.2" targets="//@children.6/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E341" sources="//@children.6/@children.0/@children.9/@ports.0" targets="//@children.6/@children.0/@children.10/@ports.1"/>
+      <containedEdges identifier="E342" sources="//@children.6/@children.0/@children.10/@ports.2" targets="//@children.6/@children.0/@children.0/@ports.1"/>
+    </children>
+    <children identifier="N236">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L236" height="15.0" width="86.0" text="PedLightSouth"/>
+      <ports identifier="P685" height="8.0" width="8.0" outgoingEdges="//@children.6/@children.1/@containedEdges.0 //@children.6/@children.1/@containedEdges.1 //@children.6/@children.1/@containedEdges.2 //@children.6/@children.1/@containedEdges.3 //@children.6/@children.1/@containedEdges.4 //@children.6/@children.1/@containedEdges.5 //@children.6/@children.1/@containedEdges.6 //@children.6/@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <children identifier="N237" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L237" height="15.0" width="90.0" text="PedestrianLight"/>
+        <ports identifier="P686" height="8.0" width="8.0" x="-8.0" y="0.1666666716337204" incomingEdges="//@children.6/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P687" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.6/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P688" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P689" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.6/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P690" height="8.0" width="8.0" x="-8.0" y="32.83333206176758" incomingEdges="//@children.6/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="-4"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P691" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="5"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N238" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L238" height="15.0" width="33.0" text="Clock"/>
+        <ports identifier="P692" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.6/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P693" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P694" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N239" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L239" height="15.0" width="67.0" text="SetVariable"/>
+        <ports identifier="P695" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P696" height="8.0" width="8.0" x="61.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N240" height="25.0" width="139.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L240" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P697" height="8.0" width="8.0" x="139.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P698" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N241" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L241" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P699" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P700" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P701" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P702" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N242" height="25.0" width="150.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L242" height="15.0" width="73.0" text="Expression2"/>
+        <ports identifier="P703" height="8.0" width="8.0" x="150.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P704" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N243" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L243" height="15.0" width="94.0" text="BooleanSwitch2"/>
+        <ports identifier="P705" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P706" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P707" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.1/@containedEdges.13">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P708" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N244" height="25.0" width="144.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L244" height="15.0" width="73.0" text="Expression3"/>
+        <ports identifier="P709" height="8.0" width="8.0" x="144.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P710" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N245" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L245" height="15.0" width="94.0" text="BooleanSwitch3"/>
+        <ports identifier="P711" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P712" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.1/@containedEdges.14">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P713" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.1/@containedEdges.15">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P714" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N246" height="25.0" width="135.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L246" height="15.0" width="73.0" text="Expression4"/>
+        <ports identifier="P715" height="8.0" width="8.0" x="135.0" y="8.5" outgoingEdges="//@children.6/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P716" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N247" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L247" height="15.0" width="94.0" text="BooleanSwitch4"/>
+        <ports identifier="P717" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.6/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P718" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.6/@children.1/@containedEdges.16">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P719" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.6/@children.1/@containedEdges.17">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P720" height="8.0" width="8.0" x="39.0" y="28.0">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E343" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E344" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.4/@ports.0"/>
+      <containedEdges identifier="E345" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.5/@ports.1"/>
+      <containedEdges identifier="E346" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E347" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.7/@ports.1"/>
+      <containedEdges identifier="E348" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.8/@ports.0"/>
+      <containedEdges identifier="E349" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.9/@ports.1"/>
+      <containedEdges identifier="E350" sources="//@children.6/@children.1/@ports.0" targets="//@children.6/@children.1/@children.10/@ports.0"/>
+      <containedEdges identifier="E351" sources="//@children.6/@children.1/@children.0/@ports.5" targets="//@children.6/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E352" sources="//@children.6/@children.1/@children.1/@ports.0" targets="//@children.6/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E353" sources="//@children.6/@children.1/@children.3/@ports.0" targets="//@children.6/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E354" sources="//@children.6/@children.1/@children.4/@ports.2" targets="//@children.6/@children.1/@children.0/@ports.3"/>
+      <containedEdges identifier="E355" sources="//@children.6/@children.1/@children.5/@ports.0" targets="//@children.6/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E356" sources="//@children.6/@children.1/@children.6/@ports.2" targets="//@children.6/@children.1/@children.0/@ports.4"/>
+      <containedEdges identifier="E357" sources="//@children.6/@children.1/@children.7/@ports.0" targets="//@children.6/@children.1/@children.8/@ports.1"/>
+      <containedEdges identifier="E358" sources="//@children.6/@children.1/@children.8/@ports.2" targets="//@children.6/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E359" sources="//@children.6/@children.1/@children.9/@ports.0" targets="//@children.6/@children.1/@children.10/@ports.1"/>
+      <containedEdges identifier="E360" sources="//@children.6/@children.1/@children.10/@ports.2" targets="//@children.6/@children.1/@children.0/@ports.1"/>
+    </children>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_linkvisualizer_LinkVisualizer.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_linkvisualizer_LinkVisualizer.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="264.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="264.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P24" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_matlabwirelesssounddetection_MatlabWirelessSoundDetection.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_matlabwirelesssounddetection_MatlabWirelessSoundDetection.elkg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="79.0" text="SoundSource"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="41.0" text="Clock2"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.2/@ports.2"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="119.0" text="WirelessTriangulator"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="68.0" text="Triangulator"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="79.0" text="ArrayElement"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="87.0" text="ArrayElement2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="105.0" text="MatlabExpression"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="60.0" y="16.0" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_network_SimpleModel.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_network_SimpleModel.elkg
@@ -1,0 +1,768 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="114.0" text="WirelessComposite"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="27.0" text="PHY"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.4" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.2" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.3" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.3" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="99.0" text="CollisionDetector"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="67.0" text="TimePlotter"/>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.6 //@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+        <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@ports.3" targets="//@children.0/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@ports.4" targets="//@children.0/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.0/@ports.3" targets="//@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.0/@ports.4" targets="//@children.0/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E18" sources="//@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E19" sources="//@children.0/@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N7">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L7" height="15.0" width="30.0" text="MAC"/>
+      <ports identifier="P20" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.5" incomingEdges="//@children.0/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.2" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.1/@containedEdges.0 //@children.0/@children.1/@containedEdges.1" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.6" incomingEdges="//@children.0/@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <children identifier="N8" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="79.0" text="VariableDelay"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="46.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="44.0" text="Uniform"/>
+        <ports identifier="P27" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.0/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="19.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="32.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="87.0" text="VariableDelay2"/>
+        <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N11" height="46.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L11" height="15.0" width="52.0" text="Uniform2"/>
+        <ports identifier="P34" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.0/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="32.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N12" height="25.0" width="112.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L12" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P38" height="8.0" width="8.0" x="112.0" y="8.5" outgoingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N13" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L13" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P41" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.0/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P42" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.0/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N14" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L14" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P44" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P45" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@children.1/@containedEdges.10 //@children.0/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P46" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.0/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N15" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L15" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@children.0/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E20" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E21" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E22" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E23" sources="//@children.0/@children.1/@children.0/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E24" sources="//@children.0/@children.1/@children.1/@ports.0" targets="//@children.0/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E25" sources="//@children.0/@children.1/@children.2/@ports.1" targets="//@children.0/@children.1/@ports.3"/>
+      <containedEdges identifier="E26" sources="//@children.0/@children.1/@children.3/@ports.0" targets="//@children.0/@children.1/@children.2/@ports.2"/>
+      <containedEdges identifier="E27" sources="//@children.0/@children.1/@children.4/@ports.0" targets="//@children.0/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E28" sources="//@children.0/@children.1/@children.5/@ports.2" targets="//@children.0/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E29" sources="//@children.0/@children.1/@children.5/@ports.1" targets="//@children.0/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E30" sources="//@children.0/@children.1/@children.6/@ports.2" targets="//@children.0/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E31" sources="//@children.0/@children.1/@children.6/@ports.2" targets="//@children.0/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E32" sources="//@children.0/@children.1/@children.6/@ports.3" targets="//@children.0/@children.1/@children.7/@ports.0"/>
+    </children>
+    <children identifier="N16">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L16" height="15.0" width="26.0" text="NET"/>
+      <ports identifier="P48" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.7" incomingEdges="//@children.0/@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.2/@containedEdges.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <children identifier="N17" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L17" height="15.0" width="80.0" text="PoissonClock"/>
+        <ports identifier="P52" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N18" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L18" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E33" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E34" sources="//@children.0/@children.2/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N19" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P55" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.2" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.5" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@ports.5"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.1/@ports.3" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.0/@ports.4"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.0/@ports.3"/>
+  </children>
+  <children identifier="N21">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L21" height="15.0" width="121.0" text="WirelessComposite4"/>
+    <ports identifier="P60" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P61" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N22">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L22" height="15.0" width="27.0" text="PHY"/>
+      <ports identifier="P62" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.0 //@children.1/@children.0/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.4" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.2" incomingEdges="//@children.1/@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.0/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.3" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <children identifier="N23" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L23" height="15.0" width="99.0" text="CollisionDetector"/>
+        <ports identifier="P68" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P71" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.1/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="4"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N24" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L24" height="15.0" width="74.0" text="TimedPlotter"/>
+        <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.0/@containedEdges.6 //@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N25" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L25" height="15.0" width="35.0" text="Ramp"/>
+        <ports identifier="P74" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N26" height="25.0" width="29.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L26" height="15.0" width="34.0" text="Const"/>
+        <ports identifier="P77" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.1/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E46" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E47" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.0/@children.3/@ports.1"/>
+      <containedEdges identifier="E48" sources="//@children.1/@children.0/@ports.3" targets="//@children.1/@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E49" sources="//@children.1/@children.0/@ports.4" targets="//@children.1/@children.0/@children.0/@ports.2"/>
+      <containedEdges identifier="E50" sources="//@children.1/@children.0/@children.0/@ports.3" targets="//@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E51" sources="//@children.1/@children.0/@children.0/@ports.4" targets="//@children.1/@children.0/@children.2/@ports.1"/>
+      <containedEdges identifier="E52" sources="//@children.1/@children.0/@children.2/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E53" sources="//@children.1/@children.0/@children.3/@ports.0" targets="//@children.1/@children.0/@children.1/@ports.0"/>
+    </children>
+    <children identifier="N27">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L27" height="15.0" width="30.0" text="MAC"/>
+      <ports identifier="P79" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.5" incomingEdges="//@children.1/@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.2" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.1/@containedEdges.0 //@children.1/@children.1/@containedEdges.1" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.6" incomingEdges="//@children.1/@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <children identifier="N28" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L28" height="15.0" width="79.0" text="VariableDelay"/>
+        <ports identifier="P83" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.1/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P84" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N29" height="46.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L29" height="15.0" width="44.0" text="Uniform"/>
+        <ports identifier="P86" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.1/@children.1/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="19.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="32.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N30" height="46.0" width="66.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L30" height="15.0" width="87.0" text="VariableDelay2"/>
+        <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.1/@children.1/@containedEdges.10">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P91" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N31" height="46.0" width="67.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L31" height="15.0" width="52.0" text="Uniform2"/>
+        <ports identifier="P93" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.1/@children.1/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="19.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="32.5">
+          <properties key="org.eclipse.elk.port.index" value="-3"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N32" height="25.0" width="112.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L32" height="15.0" width="66.0" text="Expression"/>
+        <ports identifier="P97" height="8.0" width="8.0" x="112.0" y="8.5" outgoingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N33" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L33" height="15.0" width="121.0" text="RecordDisassembler"/>
+        <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@children.1/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P100" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P101" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@children.1/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N34" height="46.0" width="39.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L34" height="15.0" width="87.0" text="BooleanSwitch"/>
+        <ports identifier="P102" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@children.1/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P103" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@children.1/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+        </ports>
+        <ports identifier="P104" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@children.1/@containedEdges.10 //@children.1/@children.1/@containedEdges.11">
+          <properties key="org.eclipse.elk.port.index" value="2"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P105" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N35" height="42.0" width="46.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L35" height="15.0" width="45.0" text="Discard"/>
+        <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="17.0" incomingEdges="//@children.1/@children.1/@containedEdges.12">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E54" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.1/@children.0/@ports.0"/>
+      <containedEdges identifier="E55" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.1/@children.1/@ports.1"/>
+      <containedEdges identifier="E56" sources="//@children.1/@children.1/@ports.1" targets="//@children.1/@children.1/@children.5/@ports.0"/>
+      <containedEdges identifier="E57" sources="//@children.1/@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+      <containedEdges identifier="E58" sources="//@children.1/@children.1/@children.1/@ports.0" targets="//@children.1/@children.1/@children.0/@ports.2"/>
+      <containedEdges identifier="E59" sources="//@children.1/@children.1/@children.2/@ports.1" targets="//@children.1/@children.1/@ports.3"/>
+      <containedEdges identifier="E60" sources="//@children.1/@children.1/@children.3/@ports.0" targets="//@children.1/@children.1/@children.2/@ports.2"/>
+      <containedEdges identifier="E61" sources="//@children.1/@children.1/@children.4/@ports.0" targets="//@children.1/@children.1/@children.6/@ports.1"/>
+      <containedEdges identifier="E62" sources="//@children.1/@children.1/@children.5/@ports.2" targets="//@children.1/@children.1/@children.4/@ports.1"/>
+      <containedEdges identifier="E63" sources="//@children.1/@children.1/@children.5/@ports.1" targets="//@children.1/@children.1/@children.6/@ports.0"/>
+      <containedEdges identifier="E64" sources="//@children.1/@children.1/@children.6/@ports.2" targets="//@children.1/@children.1/@children.2/@ports.0"/>
+      <containedEdges identifier="E65" sources="//@children.1/@children.1/@children.6/@ports.2" targets="//@children.1/@children.1/@children.3/@ports.1"/>
+      <containedEdges identifier="E66" sources="//@children.1/@children.1/@children.6/@ports.3" targets="//@children.1/@children.1/@children.7/@ports.0"/>
+    </children>
+    <children identifier="N36">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L36" height="15.0" width="26.0" text="NET"/>
+      <ports identifier="P107" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.7" incomingEdges="//@children.1/@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" outgoingEdges="//@children.1/@children.2/@containedEdges.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P109" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="NORTH"/>
+      </ports>
+      <children identifier="N37" height="41.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L37" height="15.0" width="80.0" text="PoissonClock"/>
+        <ports identifier="P111" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@children.2/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P112" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N38" height="31.0" width="41.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L38" height="15.0" width="43.0" text="Display"/>
+        <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@children.2/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E67" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.2/@children.1/@ports.0"/>
+      <containedEdges identifier="E68" sources="//@children.1/@children.2/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.0"/>
+    </children>
+    <children identifier="N39" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P114" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P115" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P117" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E35" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.1/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.1/@children.0/@ports.5" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.0/@ports.5"/>
+    <containedEdges identifier="E40" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@children.0/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.1/@children.1/@ports.3" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.1/@ports.2"/>
+    <containedEdges identifier="E43" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.1/@children.4/@ports.2" targets="//@children.1/@children.0/@ports.4"/>
+    <containedEdges identifier="E45" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.0/@ports.3"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_personalareanetwork_Bluetooth2devices.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_personalareanetwork_Bluetooth2devices.elkg
@@ -1,0 +1,693 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="174.0" text="BluetoothDevice1_MasterRole"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="80.0" text="PoissonClock"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="25.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="25.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.11 //@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="113.0" text="BluetoothSlaveRole"/>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="19.0" text="RD"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.1/@containedEdges.2 //@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="63.0" text="Hold mode"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="68.0" text="Comparator"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.29">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="75.0" text="Comparator2"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.11 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.30">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="75.0" text="Comparator3"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.14 //@children.1/@containedEdges.15 //@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.31">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="94.0" text="BooleanSwitch2"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="75.0" text="Comparator4"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.32">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="14.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="14.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.20 //@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="42.0" text="Const4"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.33">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="75.0" text="Comparator5"/>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.1/@containedEdges.22">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.1/@containedEdges.21">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="22.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="82.0" text="LogicFunction"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.19 //@children.1/@containedEdges.23">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="22.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.24">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="127.0" text="Output if in sniff mode"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P70" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="131.0" text="Output if in Data mode"/>
+      <ports identifier="P73" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P74" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.26">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P76" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="73.0" text="Expression4"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="41.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.25">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.26 //@children.1/@containedEdges.28 //@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="25.0" width="79.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="42.0" text="Const5"/>
+      <ports identifier="P80" height="8.0" width="8.0" x="79.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.34">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="94.0" text="BooleanSwitch5"/>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.27">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P84" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.28">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.29 //@children.1/@containedEdges.30 //@children.1/@containedEdges.31 //@children.1/@containedEdges.32 //@children.1/@containedEdges.33 //@children.1/@containedEdges.34 //@children.1/@containedEdges.35 //@children.1/@containedEdges.36 //@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="94.0" text="BooleanSwitch6"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="39.0" y="10.0">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.1/@containedEdges.38">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="42.0" text="Const6"/>
+      <ports identifier="P93" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.39">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.35">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="51.0" text="Display2"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="25.0" width="82.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="42.0" text="Const7"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="82.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.36">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="25.0" width="83.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="42.0" text="Const8"/>
+      <ports identifier="P98" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.41">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.37">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.40">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P101" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.42">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P103" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.1/@ports.0" targets="//@children.1/@children.24/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.15/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.9/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.3/@ports.2" targets="//@children.1/@children.16/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.15/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.1/@children.5/@ports.2" targets="//@children.1/@children.20/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.22/@ports.1"/>
+    <containedEdges identifier="E32" sources="//@children.1/@children.7/@ports.2" targets="//@children.1/@children.27/@ports.1"/>
+    <containedEdges identifier="E33" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.1/@children.9/@ports.2" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.1/@children.10/@ports.2" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.1/@children.11/@ports.0" targets="//@children.1/@children.10/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.1/@children.11/@ports.0" targets="//@children.1/@children.13/@ports.1"/>
+    <containedEdges identifier="E38" sources="//@children.1/@children.12/@ports.0" targets="//@children.1/@children.13/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.1/@children.13/@ports.2" targets="//@children.1/@children.14/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.1/@children.14/@ports.1" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E41" sources="//@children.1/@children.15/@ports.2" targets="//@children.1/@children.17/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.1/@children.16/@ports.2" targets="//@children.1/@children.18/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.1/@children.19/@ports.0" targets="//@children.1/@children.20/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.1/@children.20/@ports.2" targets="//@children.1/@children.18/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E46" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E47" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E48" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.10/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.12/@ports.1"/>
+    <containedEdges identifier="E50" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.19/@ports.1"/>
+    <containedEdges identifier="E51" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.23/@ports.1"/>
+    <containedEdges identifier="E52" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.25/@ports.1"/>
+    <containedEdges identifier="E53" sources="//@children.1/@children.21/@ports.0" targets="//@children.1/@children.26/@ports.1"/>
+    <containedEdges identifier="E54" sources="//@children.1/@children.22/@ports.3" targets="//@children.1/@children.11/@ports.1"/>
+    <containedEdges identifier="E55" sources="//@children.1/@children.23/@ports.0" targets="//@children.1/@children.22/@ports.0"/>
+    <containedEdges identifier="E56" sources="//@children.1/@children.25/@ports.0" targets="//@children.1/@children.27/@ports.0"/>
+    <containedEdges identifier="E57" sources="//@children.1/@children.26/@ports.0" targets="//@children.1/@children.16/@ports.0"/>
+    <containedEdges identifier="E58" sources="//@children.1/@children.27/@ports.2" targets="//@children.1/@children.18/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_personalareanetwork_BluetoothNodes.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_personalareanetwork_BluetoothNodes.elkg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="46.0" text="Pursuer"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.10">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="68.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="68.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="40.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="40.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.2/@ports.2"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@ports.1"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_personalareanetwork_PersonalAreaNetwork.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_personalareanetwork_PersonalAreaNetwork.elkg
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="49.0" text="Follower"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="47.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.4/@ports.2" targets="//@children.0/@children.5/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="40.0" text="Leader"/>
+    <ports identifier="P18" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.9">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="98.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="98.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="98.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="98.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.6 //@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.7/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_personalareanetwork_PersonalAreaNetwork2.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_personalareanetwork_PersonalAreaNetwork2.elkg
@@ -1,0 +1,861 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="49.0" text="Follower"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="25.0" width="47.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="85.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.8 //@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.2" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.3/@ports.2" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.5/@ports.2" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.7/@ports.2" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.7/@ports.3" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.5/@ports.1"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="40.0" text="Leader"/>
+    <ports identifier="P26" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0 //@children.1/@containedEdges.1 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.5 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="21.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E14" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.2/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.7/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.1/@children.2/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.5/@ports.1"/>
+    <containedEdges identifier="E19" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.6/@ports.2"/>
+    <containedEdges identifier="E20" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.8/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.6/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.1/@children.5/@ports.0" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.1/@children.7/@ports.0" targets="//@children.1/@children.8/@ports.3"/>
+    <containedEdges identifier="E25" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+  <children identifier="N21">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L21" height="15.0" width="56.0" text="Follower2"/>
+    <ports identifier="P51" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0 //@children.2/@containedEdges.1 //@children.2/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.4 //@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P59" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.5 //@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P67" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="25.0" width="85.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P69" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P70" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P71" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.10 //@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P75" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N31" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L31" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N32" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="51.0" text="Display2"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E26" sources="//@children.2/@ports.0" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.2/@ports.0" targets="//@children.2/@children.7/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.2/@ports.0" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E31" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E32" sources="//@children.2/@children.3/@ports.2" targets="//@children.2/@children.4/@ports.2"/>
+    <containedEdges identifier="E33" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.2/@children.5/@ports.2" targets="//@children.2/@children.0/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E37" sources="//@children.2/@children.7/@ports.1" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.2/@children.7/@ports.2" targets="//@children.2/@children.3/@ports.0"/>
+    <containedEdges identifier="E39" sources="//@children.2/@children.7/@ports.3" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E40" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.5/@ports.1"/>
+  </children>
+  <children identifier="N33">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L33" height="15.0" width="56.0" text="Follower3"/>
+    <ports identifier="P78" height="8.0" width="8.0" outgoingEdges="//@children.3/@containedEdges.0 //@children.3/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N34" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="74.0" text="SetVariable2"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="72.0" text="AddSubtract"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P83" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="47.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P84" height="8.0" width="8.0" x="47.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.3 //@children.3/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P85" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.3/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="80.0" text="AddSubtract2"/>
+      <ports identifier="P86" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.3/@containedEdges.4 //@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P88" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P89" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P90" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.3/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.3/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N39" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L39" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P92" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.3/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P94" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.3/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P95" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N40" height="25.0" width="85.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="85.0" y="8.5" outgoingEdges="//@children.3/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.3/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.3/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P99" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.3/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="31.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="40.0" text="Equals"/>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.3/@containedEdges.8 //@children.3/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="11.5" outgoingEdges="//@children.3/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E41" sources="//@children.3/@ports.0" targets="//@children.3/@children.2/@ports.1"/>
+    <containedEdges identifier="E42" sources="//@children.3/@ports.0" targets="//@children.3/@children.7/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.3/@children.1/@ports.2" targets="//@children.3/@children.4/@ports.1"/>
+    <containedEdges identifier="E44" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E45" sources="//@children.3/@children.2/@ports.0" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.3/@children.3/@ports.2" targets="//@children.3/@children.4/@ports.2"/>
+    <containedEdges identifier="E47" sources="//@children.3/@children.4/@ports.0" targets="//@children.3/@children.5/@ports.0"/>
+    <containedEdges identifier="E48" sources="//@children.3/@children.5/@ports.2" targets="//@children.3/@children.0/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.3/@children.6/@ports.0" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.3/@children.7/@ports.1" targets="//@children.3/@children.1/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.3/@children.7/@ports.2" targets="//@children.3/@children.3/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.3/@children.7/@ports.3" targets="//@children.3/@children.8/@ports.0"/>
+    <containedEdges identifier="E53" sources="//@children.3/@children.8/@ports.1" targets="//@children.3/@children.5/@ports.1"/>
+  </children>
+  <children identifier="N43">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L43" height="15.0" width="47.0" text="Leader3"/>
+    <ports identifier="P103" height="8.0" width="8.0" incomingEdges="//@children.4/@containedEdges.11">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N44" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P104" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1 //@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P105" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P106" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P107" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P108" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P109" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P110" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P111" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N47" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L47" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P112" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P113" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P114" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N48" height="25.0" width="32.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L48" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P115" height="8.0" width="8.0" x="32.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.5 //@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P116" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N49" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L49" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P117" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7 //@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P118" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N50" height="25.0" width="37.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P119" height="8.0" width="8.0" x="37.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P120" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P121" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="25.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P122" height="8.0" width="8.0" x="21.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P123" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P124" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P125" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P126" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P127" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.4/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E54" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.2/@ports.1"/>
+    <containedEdges identifier="E55" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E56" sources="//@children.4/@children.0/@ports.0" targets="//@children.4/@children.7/@ports.1"/>
+    <containedEdges identifier="E57" sources="//@children.4/@children.2/@ports.0" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E58" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.5/@ports.1"/>
+    <containedEdges identifier="E59" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.6/@ports.2"/>
+    <containedEdges identifier="E60" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.8/@ports.2"/>
+    <containedEdges identifier="E61" sources="//@children.4/@children.5/@ports.0" targets="//@children.4/@children.6/@ports.1"/>
+    <containedEdges identifier="E62" sources="//@children.4/@children.5/@ports.0" targets="//@children.4/@children.8/@ports.1"/>
+    <containedEdges identifier="E63" sources="//@children.4/@children.6/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E64" sources="//@children.4/@children.7/@ports.0" targets="//@children.4/@children.8/@ports.3"/>
+    <containedEdges identifier="E65" sources="//@children.4/@children.8/@ports.0" targets="//@children.4/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_powervariability_PowerVariability.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_powervariability_PowerVariability.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0 //@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="109.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="109.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="117.0" text="Times Antenna Area"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="66.0" text="Transmitter"/>
+    <ports identifier="P20" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.1/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_smallworld_SmallWorldRouter.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_smallworld_SmallWorldRouter.elkg
@@ -1,0 +1,445 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="53.0" text="statistics"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="98.0" text="HistogramPlotter"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N3">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L3" height="15.0" width="31.0" text="Base"/>
+    <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N4" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="80.0" text="Disassembler"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="10.0" y="4.25" outgoingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="10.0" y="28.75" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="4"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="94.0" text="BooleanSwitch3"/>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.1/@containedEdges.4 //@children.1/@containedEdges.5 //@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.7 //@children.1/@containedEdges.8 //@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.1/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="166.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="166.0" y="8.5" outgoingEdges="//@children.1/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.1/@children.0/@ports.2" targets="//@children.1/@children.9/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.1/@children.0/@ports.3" targets="//@children.1/@children.9/@ports.2"/>
+    <containedEdges identifier="E6" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.3/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.1/@ports.2" targets="//@children.1/@children.7/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.3/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.4/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.5/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.6/@ports.0" targets="//@children.1/@children.4/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.1/@children.7/@ports.1" targets="//@children.1/@children.8/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.1/@children.8/@ports.0" targets="//@children.1/@children.5/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.1/@children.9/@ports.0" targets="//@children.1/@children.1/@ports.1"/>
+  </children>
+  <children identifier="N14">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L14" height="15.0" width="43.0" text="Initiator"/>
+    <ports identifier="P29" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N15" height="25.0" width="48.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="48.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.3 //@children.2/@containedEdges.4 //@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="55.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="44.0" text="Uniform"/>
+      <ports identifier="P50" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="52.0" text="Uniform2"/>
+      <ports identifier="P54" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P56" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N24" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P58" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.11 //@children.2/@containedEdges.12 //@children.2/@containedEdges.13 //@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="25.0" width="92.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="92.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.2/@ports.3"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.1/@ports.0" targets="//@children.2/@children.2/@ports.4"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.2/@ports.0" targets="//@children.2/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.7/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.8/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.9/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.2/@children.4/@ports.0" targets="//@children.2/@children.2/@ports.2"/>
+    <containedEdges identifier="E23" sources="//@children.2/@children.5/@ports.0" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.2/@ports.1"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.10/@ports.1"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.8/@ports.0" targets="//@children.2/@children.10/@ports.2"/>
+    <containedEdges identifier="E27" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.1/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E30" sources="//@children.2/@children.9/@ports.1" targets="//@children.2/@children.5/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.2/@children.10/@ports.0" targets="//@children.2/@children.11/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_smallworld_SmallWorldRouter_loss.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_smallworld_SmallWorldRouter_loss.elkg
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="43.0" text="Initiator"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="25.0" width="48.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="48.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="18.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="18.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="1.7999999523162842" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="11.600000381469727" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="21.399999618530273" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-4"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="31.200000762939453" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-5"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5 //@children.0/@containedEdges.6 //@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="50.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="50.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="55.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="55.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.2/@ports.3"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.2/@ports.4"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.2/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.6/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="53.0" text="statistics"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="98.0" text="HistogramPlotter"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E12" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="31.0" text="Base"/>
+    <ports identifier="P24" height="8.0" width="8.0" outgoingEdges="//@children.2/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P25" height="8.0" width="8.0" incomingEdges="//@children.2/@containedEdges.7">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="25.0" width="44.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="44.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="80.0" text="Disassembler"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="10.0" y="8.333333015441895" outgoingEdges="//@children.2/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="10.0" y="24.66666603088379" outgoingEdges="//@children.2/@containedEdges.2 //@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="57.0" text="Previous2"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="25.0" width="83.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="73.0" text="Expression3"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="83.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.2/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.2/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="94.0" text="BooleanSwitch3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.2/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.2/@containedEdges.7 //@children.2/@containedEdges.8 //@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P42" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.2/@containedEdges.10 //@children.2/@containedEdges.11 //@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.2/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="68.0" text="TimedDelay"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.2/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N23" height="25.0" width="115.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L23" height="15.0" width="42.0" text="Const3"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="115.0" y="8.5" outgoingEdges="//@children.2/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.2/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E13" sources="//@children.2/@ports.0" targets="//@children.2/@children.1/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.2/@children.0/@ports.0" targets="//@children.2/@children.4/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.2/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.2/@children.1/@ports.2" targets="//@children.2/@children.3/@ports.1"/>
+    <containedEdges identifier="E17" sources="//@children.2/@children.1/@ports.1" targets="//@children.2/@children.0/@ports.1"/>
+    <containedEdges identifier="E18" sources="//@children.2/@children.2/@ports.1" targets="//@children.2/@children.3/@ports.2"/>
+    <containedEdges identifier="E19" sources="//@children.2/@children.3/@ports.0" targets="//@children.2/@children.4/@ports.1"/>
+    <containedEdges identifier="E20" sources="//@children.2/@children.4/@ports.2" targets="//@children.2/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.2/@children.4/@ports.2" targets="//@children.2/@children.6/@ports.1"/>
+    <containedEdges identifier="E22" sources="//@children.2/@children.4/@ports.2" targets="//@children.2/@children.10/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.2/@children.6/@ports.0" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.2/@children.7/@ports.0" targets="//@children.2/@children.8/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.2/@children.8/@ports.1" targets="//@children.2/@children.5/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.2/@children.9/@ports.0" targets="//@children.2/@children.7/@ports.1"/>
+    <containedEdges identifier="E27" sources="//@children.2/@children.10/@ports.1" targets="//@children.2/@children.11/@ports.1"/>
+    <containedEdges identifier="E28" sources="//@children.2/@children.11/@ports.0" targets="//@children.2/@children.8/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_smartparking_SmartParking.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_smartparking_SmartParking.elkg
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="57.0" text="car model"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="46.0" width="67.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="44.0" text="Uniform"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="67.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="5.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="19.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="32.5">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="79.0" text="VariableDelay"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="10.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="28.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="77.0" text="ParkingClient"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3 //@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="61.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="55.0" text="car arrival"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.2/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.0"/>
+  </children>
+  <children identifier="N6" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="99.0" text="WirelessToWired"/>
+    <ports identifier="P15" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P17" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N7" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L7" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N8" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L8" height="15.0" width="77.0" text="dataCollector"/>
+    <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P20" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N9">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L9" height="15.0" width="62.0" text="signal light"/>
+    <ports identifier="P22" height="8.0" width="8.0" outgoingEdges="//@children.4/@containedEdges.0 //@children.4/@containedEdges.1 //@children.4/@containedEdges.2" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N10" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.4/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.4/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="39.0" y="28.0" outgoingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="21.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="37.0" text="Merge"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.6 //@children.4/@containedEdges.7 //@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="21.0" y="16.5" outgoingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.4/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P31" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.4/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.4/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="68.0" text="SingleEvent"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.4/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.4/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E10" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.4/@ports.0" targets="//@children.4/@children.0/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.4/@ports.0" targets="//@children.4/@children.6/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.4/@children.0/@ports.2" targets="//@children.4/@children.3/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.4/@children.0/@ports.3" targets="//@children.4/@children.4/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.4/@children.1/@ports.1" targets="//@children.4/@children.2/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.4/@children.3/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.4/@children.4/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.4/@children.5/@ports.0" targets="//@children.4/@children.1/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.2" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.2" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_terrainmodel_TerrainModel.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_terrainmodel_TerrainModel.elkg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1 //@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P12" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="25.0" width="264.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="264.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@ports.1"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.6/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.3/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.6/@ports.2" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.3" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.8/@ports.1" targets="//@children.0/@children.7/@ports.1"/>
+  </children>
+  <children identifier="N11">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L11" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P24" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E11" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_terrainmodel_TerrainModel2.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_terrainmodel_TerrainModel2.elkg
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="50.0" text="Receiver"/>
+    <ports identifier="P1" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="25.0" width="220.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="220.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="TimedPlotter"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="121.0" text="RecordDisassembler"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7 //@children.0/@containedEdges.8 //@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="80.0" text="GetProperties"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="31.0" y="11.5" outgoingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="46.0" width="39.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="87.0" text="BooleanSwitch"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="15.5" y="46.0" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="SOUTH"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="39.0" y="10.0" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="39.0" y="28.0">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="79.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="73.0" text="Expression2"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="79.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="31.0" width="31.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="99.0" text="PolarToCartesian"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="31.0" y="5.0" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.0/@children.7/@ports.1"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.4/@ports.2"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.2/@ports.1"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.8/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.11/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.8/@ports.2" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.9/@ports.0" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.11/@ports.2" targets="//@children.0/@children.10/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.11/@ports.3" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.12/@ports.1" targets="//@children.0/@children.10/@ports.1"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="42.0" text="Sender"/>
+    <ports identifier="P35" height="8.0" width="8.0" incomingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N16" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E17" sources="//@children.1/@children.0/@ports.0" targets="//@children.1/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_wirelesssounddetection_WirelessSoundDetection.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_wirelesssounddetection_WirelessSoundDetection.elkg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="79.0" text="SoundSource"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@children.0/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="33.0" text="Clock"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="25.0" width="216.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="216.0" y="8.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="3.0" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="14.0" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="41.0" text="Clock2"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2 //@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="35.0" text="Ramp"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="42.0" text="Ramp2"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P18" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E1" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@ports.0"/>
+    <containedEdges identifier="E2" sources="//@children.0/@children.1/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E3" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.3/@ports.1"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.2/@ports.0" targets="//@children.0/@children.4/@ports.1"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.1/@ports.1"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.1/@ports.2"/>
+  </children>
+  <children identifier="N8">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L8" height="15.0" width="119.0" text="WirelessTriangulator"/>
+    <ports identifier="P19" height="8.0" width="8.0" outgoingEdges="//@children.1/@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="68.0" text="Triangulator"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.1/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.1 //@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="55.0" text="XYPlotter"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="34.0" text="Scale"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.1/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="79.0" text="ArrayElement"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="87.0" text="ArrayElement2"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.1/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.1/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.1/@ports.0" targets="//@children.1/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.3/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.1/@children.0/@ports.1" targets="//@children.1/@children.4/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.1/@children.2/@ports.1" targets="//@children.1/@children.1/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.1/@children.3/@ports.1" targets="//@children.1/@children.1/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.1/@children.4/@ports.1" targets="//@children.1/@children.2/@ports.0"/>
+  </children>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/wireless_zigbee_Zigbee.elkg
+++ b/realworld/ptolemy/hierarchical/wireless_zigbee_Zigbee.elkg
@@ -1,0 +1,771 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="46.0" width="66.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="68.0" text="SingleEvent"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="25.0" width="611.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P2" height="8.0" width="8.0" x="611.0" y="8.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="101.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="42.0" text="Const2"/>
+    <ports identifier="P4" height="8.0" width="8.0" x="101.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="98.0" text="WiredToWireless"/>
+    <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="5.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="18.0" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="31.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="99.0" text="WirelessToWired"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N6" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L6" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4 //@containedEdges.5 //@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N7">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L7" height="15.0" width="121.0" text="WirelessComposite2"/>
+    <ports identifier="P13" height="8.0" width="8.0" incomingEdges="//@children.6/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P14" height="8.0" width="8.0" outgoingEdges="//@children.6/@containedEdges.0 //@children.6/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N8" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.6/@containedEdges.2 //@children.6/@containedEdges.3 //@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="76.0" text="MonitorValue"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="83.0" text="MonitorValue2"/>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.6/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.6/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P21" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P23" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.6/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.6/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E8" sources="//@children.6/@ports.1" targets="//@children.6/@children.0/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.6/@ports.1" targets="//@children.6/@children.1/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.2/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.6/@children.0/@ports.2" targets="//@children.6/@children.4/@ports.1"/>
+    <containedEdges identifier="E13" sources="//@children.6/@children.0/@ports.1" targets="//@children.6/@children.3/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.6/@children.4/@ports.0" targets="//@children.6/@children.5/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.6/@children.5/@ports.0" targets="//@children.6/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N15">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L15" height="15.0" width="114.0" text="WirelessComposite"/>
+    <ports identifier="P27" height="8.0" width="8.0" incomingEdges="//@children.7/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" outgoingEdges="//@children.7/@containedEdges.0 //@children.7/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P30" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.7/@containedEdges.2 //@children.7/@containedEdges.3 //@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="76.0" text="MonitorValue"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="83.0" text="MonitorValue2"/>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.7/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.7/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.7/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.7/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E16" sources="//@children.7/@ports.1" targets="//@children.7/@children.0/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.7/@ports.1" targets="//@children.7/@children.1/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.7/@children.0/@ports.2" targets="//@children.7/@children.4/@ports.1"/>
+    <containedEdges identifier="E21" sources="//@children.7/@children.0/@ports.1" targets="//@children.7/@children.3/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.7/@children.4/@ports.0" targets="//@children.7/@children.5/@ports.1"/>
+    <containedEdges identifier="E23" sources="//@children.7/@children.5/@ports.0" targets="//@children.7/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N23">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L23" height="15.0" width="121.0" text="WirelessComposite3"/>
+    <ports identifier="P41" height="8.0" width="8.0" incomingEdges="//@children.8/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" outgoingEdges="//@children.8/@containedEdges.0 //@children.8/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N24" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L24" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.8/@containedEdges.2 //@children.8/@containedEdges.3 //@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N25" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L25" height="15.0" width="76.0" text="MonitorValue"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N26" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L26" height="15.0" width="83.0" text="MonitorValue2"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.8/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N27" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L27" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.8/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N28" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L28" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N29" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L29" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P51" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.8/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N30" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L30" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.8/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E24" sources="//@children.8/@ports.1" targets="//@children.8/@children.0/@ports.0"/>
+    <containedEdges identifier="E25" sources="//@children.8/@ports.1" targets="//@children.8/@children.1/@ports.0"/>
+    <containedEdges identifier="E26" sources="//@children.8/@children.0/@ports.2" targets="//@children.8/@ports.0"/>
+    <containedEdges identifier="E27" sources="//@children.8/@children.0/@ports.2" targets="//@children.8/@children.2/@ports.0"/>
+    <containedEdges identifier="E28" sources="//@children.8/@children.0/@ports.2" targets="//@children.8/@children.4/@ports.1"/>
+    <containedEdges identifier="E29" sources="//@children.8/@children.0/@ports.1" targets="//@children.8/@children.3/@ports.0"/>
+    <containedEdges identifier="E30" sources="//@children.8/@children.4/@ports.0" targets="//@children.8/@children.5/@ports.1"/>
+    <containedEdges identifier="E31" sources="//@children.8/@children.5/@ports.0" targets="//@children.8/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N31">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L31" height="15.0" width="121.0" text="WirelessComposite4"/>
+    <ports identifier="P55" height="8.0" width="8.0" incomingEdges="//@children.9/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" outgoingEdges="//@children.9/@containedEdges.0 //@children.9/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N32" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L32" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P57" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P58" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P59" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.9/@containedEdges.2 //@children.9/@containedEdges.3 //@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N33" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L33" height="15.0" width="76.0" text="MonitorValue"/>
+      <ports identifier="P60" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N34" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L34" height="15.0" width="83.0" text="MonitorValue2"/>
+      <ports identifier="P61" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.9/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N35" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L35" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P62" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.9/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N36" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L36" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P63" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P64" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N37" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L37" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P65" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P66" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.9/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N38" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L38" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P67" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.9/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P68" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E32" sources="//@children.9/@ports.1" targets="//@children.9/@children.0/@ports.0"/>
+    <containedEdges identifier="E33" sources="//@children.9/@ports.1" targets="//@children.9/@children.1/@ports.0"/>
+    <containedEdges identifier="E34" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@ports.0"/>
+    <containedEdges identifier="E35" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@children.2/@ports.0"/>
+    <containedEdges identifier="E36" sources="//@children.9/@children.0/@ports.2" targets="//@children.9/@children.4/@ports.1"/>
+    <containedEdges identifier="E37" sources="//@children.9/@children.0/@ports.1" targets="//@children.9/@children.3/@ports.0"/>
+    <containedEdges identifier="E38" sources="//@children.9/@children.4/@ports.0" targets="//@children.9/@children.5/@ports.1"/>
+    <containedEdges identifier="E39" sources="//@children.9/@children.5/@ports.0" targets="//@children.9/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N39">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L39" height="15.0" width="121.0" text="WirelessComposite6"/>
+    <ports identifier="P69" height="8.0" width="8.0" incomingEdges="//@children.10/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P70" height="8.0" width="8.0" outgoingEdges="//@children.10/@containedEdges.0 //@children.10/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N40" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L40" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P71" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P72" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P73" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.10/@containedEdges.2 //@children.10/@containedEdges.3 //@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N41" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L41" height="15.0" width="76.0" text="MonitorValue"/>
+      <ports identifier="P74" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N42" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L42" height="15.0" width="83.0" text="MonitorValue2"/>
+      <ports identifier="P75" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.10/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N43" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L43" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P76" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.10/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N44" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L44" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P77" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P78" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N45" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L45" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P79" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P80" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.10/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N46" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L46" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P81" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.10/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P82" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E40" sources="//@children.10/@ports.1" targets="//@children.10/@children.0/@ports.0"/>
+    <containedEdges identifier="E41" sources="//@children.10/@ports.1" targets="//@children.10/@children.1/@ports.0"/>
+    <containedEdges identifier="E42" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@ports.0"/>
+    <containedEdges identifier="E43" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.2/@ports.0"/>
+    <containedEdges identifier="E44" sources="//@children.10/@children.0/@ports.2" targets="//@children.10/@children.4/@ports.1"/>
+    <containedEdges identifier="E45" sources="//@children.10/@children.0/@ports.1" targets="//@children.10/@children.3/@ports.0"/>
+    <containedEdges identifier="E46" sources="//@children.10/@children.4/@ports.0" targets="//@children.10/@children.5/@ports.1"/>
+    <containedEdges identifier="E47" sources="//@children.10/@children.5/@ports.0" targets="//@children.10/@children.6/@ports.0"/>
+  </children>
+  <children identifier="N47" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L47" height="15.0" width="106.0" text="WirelessToWired2"/>
+    <ports identifier="P83" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P84" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P85" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N48" height="31.0" width="31.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L48" height="15.0" width="106.0" text="WirelessToWired3"/>
+    <ports identifier="P86" height="8.0" width="8.0" x="31.0" y="5.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P87" height="8.0" width="8.0" x="-8.0" y="11.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P88" height="8.0" width="8.0" x="31.0" y="18.0" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="2"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N49">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L49" height="15.0" width="121.0" text="WirelessComposite5"/>
+    <ports identifier="P89" height="8.0" width="8.0" incomingEdges="//@children.13/@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P90" height="8.0" width="8.0" outgoingEdges="//@children.13/@containedEdges.0 //@children.13/@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N50" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L50" height="15.0" width="70.0" text="ModalModel"/>
+      <ports identifier="P91" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P92" height="8.0" width="8.0" x="61.0" y="8.333333015441895" outgoingEdges="//@children.13/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P93" height="8.0" width="8.0" x="61.0" y="24.66666603088379" outgoingEdges="//@children.13/@containedEdges.2 //@children.13/@containedEdges.3 //@children.13/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="2"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N51" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L51" height="15.0" width="76.0" text="MonitorValue"/>
+      <ports identifier="P94" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.13/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N52" height="40.0" width="60.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L52" height="15.0" width="83.0" text="MonitorValue2"/>
+      <ports identifier="P95" height="8.0" width="8.0" x="-8.0" y="16.0" incomingEdges="//@children.13/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N53" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L53" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P96" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.13/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N54" height="25.0" width="43.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L54" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P97" height="8.0" width="8.0" x="43.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P98" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N55" height="25.0" width="29.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L55" height="15.0" width="66.0" text="Expression"/>
+      <ports identifier="P99" height="8.0" width="8.0" x="29.0" y="8.5" outgoingEdges="//@children.13/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P100" height="8.0" width="8.0" x="-8.0" y="8.5" incomingEdges="//@children.13/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N56" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L56" height="15.0" width="67.0" text="SetVariable"/>
+      <ports identifier="P101" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.13/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P102" height="8.0" width="8.0" x="61.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E48" sources="//@children.13/@ports.1" targets="//@children.13/@children.0/@ports.0"/>
+    <containedEdges identifier="E49" sources="//@children.13/@ports.1" targets="//@children.13/@children.1/@ports.0"/>
+    <containedEdges identifier="E50" sources="//@children.13/@children.0/@ports.2" targets="//@children.13/@ports.0"/>
+    <containedEdges identifier="E51" sources="//@children.13/@children.0/@ports.2" targets="//@children.13/@children.2/@ports.0"/>
+    <containedEdges identifier="E52" sources="//@children.13/@children.0/@ports.2" targets="//@children.13/@children.4/@ports.1"/>
+    <containedEdges identifier="E53" sources="//@children.13/@children.0/@ports.1" targets="//@children.13/@children.3/@ports.0"/>
+    <containedEdges identifier="E54" sources="//@children.13/@children.4/@ports.0" targets="//@children.13/@children.5/@ports.1"/>
+    <containedEdges identifier="E55" sources="//@children.13/@children.5/@ports.0" targets="//@children.13/@children.6/@ports.0"/>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.0" targets="//@children.1/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.0" targets="//@children.2/@ports.1"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.0" targets="//@children.3/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.3/@ports.1"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.11/@ports.2" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.12/@ports.2" targets="//@children.5/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformer2.elkg
+++ b/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformer2.elkg
@@ -1,0 +1,395 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="73.0" text="StringToXML"/>
+      <ports identifier="P2" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P3" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="80.0" text="StringToXML2"/>
+      <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P5" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="177.0" text="Display - Remove Redundancy"/>
+      <ports identifier="P6" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="63.0" text="FileReader"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="91.0" text="DirectoryListing"/>
+      <ports identifier="P10" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="77.0" text="DownSample"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="70.0" width="261.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="31.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="82.0" text="StringReplace"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="89.0" text="StringReplace2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="89.0" text="StringReplace3"/>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P35" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="171.0" text="Display2 - Remove Repetition"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="160.0" text="Display3 - File Combination"/>
+      <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="80.0" text="StringToXML3"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P39" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="180.0" text="Display4 - Rearrange Hierarchy"/>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="60.0" text="LineWriter"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="91.0" text="XSLTransformer"/>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="98.0" text="XSLTransformer2"/>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P47" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.17 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N22" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L22" height="15.0" width="98.0" text="XSLTransformer3"/>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19 //@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E3" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.18/@ports.0"/>
+    <containedEdges identifier="E4" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.19/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.4/@ports.0" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.10/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.7/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.7/@ports.1" targets="//@children.0/@children.9/@ports.1"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.8/@ports.0" targets="//@children.0/@children.9/@ports.2"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.9/@ports.3" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.9/@ports.3" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.10/@ports.3" targets="//@children.0/@children.11/@ports.1"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.11/@ports.0" targets="//@children.0/@children.18/@ports.2"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.12/@ports.3" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.15/@ports.1" targets="//@children.0/@children.20/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.18/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.18/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.19/@ports.1" targets="//@children.0/@children.12/@ports.2"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.19/@ports.1" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.20/@ports.1" targets="//@children.0/@children.16/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.20/@ports.1" targets="//@children.0/@children.17/@ports.0"/>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P52" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N24" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L24" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P55" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P56" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformer3.elkg
+++ b/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformer3.elkg
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@children.0/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N2" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L2" height="15.0" width="73.0" text="StringToXML"/>
+      <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N3" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L3" height="15.0" width="80.0" text="StringToXML2"/>
+      <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.15">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N4" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L4" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N5" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L5" height="15.0" width="63.0" text="FileReader"/>
+      <ports identifier="P8" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P9" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N6" height="46.0" width="66.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L6" height="15.0" width="103.0" text="ArrayToSequence"/>
+      <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="19.0" incomingEdges="//@children.0/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P12" height="8.0" width="8.0" x="66.0" y="19.0" outgoingEdges="//@children.0/@containedEdges.4 //@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N7" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="74.0" text="Accumulator"/>
+      <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P14" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="41.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="77.0" text="DownSample"/>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="41.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="70.0" width="261.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="31.0">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="82.0" text="StringReplace"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.8">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.9 //@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="89.0" text="StringReplace2"/>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P26" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="10.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="104.0" text="RecordAssembler"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.11">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="89.0" text="StringReplace3"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="4.25">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@containedEdges.17">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P33" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.13">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N14" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L14" height="15.0" width="51.0" text="Display2"/>
+      <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N15" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L15" height="15.0" width="51.0" text="Display3"/>
+      <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N16" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L16" height="15.0" width="80.0" text="StringToXML3"/>
+      <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@containedEdges.10">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N17" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L17" height="15.0" width="51.0" text="Display4"/>
+      <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.0/@containedEdges.19">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N18" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L18" height="15.0" width="60.0" text="LineWriter"/>
+      <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N19" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L19" height="15.0" width="91.0" text="XSLTransformer"/>
+      <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P42" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.15 //@children.0/@containedEdges.16">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@containedEdges.12">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N20" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L20" height="15.0" width="98.0" text="XSLTransformer2"/>
+      <ports identifier="P44" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P45" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.17 //@children.0/@containedEdges.18">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P46" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N21" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L21" height="15.0" width="98.0" text="XSLTransformer3"/>
+      <ports identifier="P47" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@containedEdges.14">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P48" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@containedEdges.19 //@children.0/@containedEdges.20">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P49" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E4" sources="//@children.0/@ports.1" targets="//@children.0/@children.4/@ports.0"/>
+    <containedEdges identifier="E5" sources="//@children.0/@children.0/@ports.1" targets="//@children.0/@children.17/@ports.0"/>
+    <containedEdges identifier="E6" sources="//@children.0/@children.1/@ports.1" targets="//@children.0/@children.18/@ports.0"/>
+    <containedEdges identifier="E7" sources="//@children.0/@children.3/@ports.0" targets="//@children.0/@children.0/@ports.0"/>
+    <containedEdges identifier="E8" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.3/@ports.2"/>
+    <containedEdges identifier="E9" sources="//@children.0/@children.4/@ports.1" targets="//@children.0/@children.9/@ports.2"/>
+    <containedEdges identifier="E10" sources="//@children.0/@children.5/@ports.1" targets="//@children.0/@children.6/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.0/@children.6/@ports.1" targets="//@children.0/@children.8/@ports.1"/>
+    <containedEdges identifier="E12" sources="//@children.0/@children.7/@ports.0" targets="//@children.0/@children.8/@ports.2"/>
+    <containedEdges identifier="E13" sources="//@children.0/@children.8/@ports.3" targets="//@children.0/@children.13/@ports.0"/>
+    <containedEdges identifier="E14" sources="//@children.0/@children.8/@ports.3" targets="//@children.0/@children.14/@ports.0"/>
+    <containedEdges identifier="E15" sources="//@children.0/@children.9/@ports.3" targets="//@children.0/@children.10/@ports.1"/>
+    <containedEdges identifier="E16" sources="//@children.0/@children.10/@ports.0" targets="//@children.0/@children.17/@ports.2"/>
+    <containedEdges identifier="E17" sources="//@children.0/@children.11/@ports.3" targets="//@children.0/@children.5/@ports.0"/>
+    <containedEdges identifier="E18" sources="//@children.0/@children.14/@ports.1" targets="//@children.0/@children.19/@ports.0"/>
+    <containedEdges identifier="E19" sources="//@children.0/@children.17/@ports.1" targets="//@children.0/@children.1/@ports.0"/>
+    <containedEdges identifier="E20" sources="//@children.0/@children.17/@ports.1" targets="//@children.0/@children.2/@ports.0"/>
+    <containedEdges identifier="E21" sources="//@children.0/@children.18/@ports.1" targets="//@children.0/@children.11/@ports.2"/>
+    <containedEdges identifier="E22" sources="//@children.0/@children.18/@ports.1" targets="//@children.0/@children.12/@ports.0"/>
+    <containedEdges identifier="E23" sources="//@children.0/@children.19/@ports.1" targets="//@children.0/@children.15/@ports.0"/>
+    <containedEdges identifier="E24" sources="//@children.0/@children.19/@ports.1" targets="//@children.0/@children.16/@ports.0"/>
+  </children>
+  <children identifier="N22" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L22" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P50" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P51" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P52" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N23" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L23" height="15.0" width="71.0" text="ArrayLength"/>
+    <ports identifier="P53" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P54" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.1/@ports.0" targets="//@children.0/@ports.1"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.1" targets="//@children.0/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformerUsingIterateOverArray.elkg
+++ b/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformerUsingIterateOverArray.elkg
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="93.0" text="IterateOverArray"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="73.0" text="StringToXML"/>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="80.0" text="StringToXML2"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="63.0" text="FileReader"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="82.0" text="StringReplace"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="4.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="89.0" text="StringReplace2"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="4.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="91.0" text="XSLTransformer"/>
+        <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="98.0" text="XSLTransformer2"/>
+        <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E9" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E10" sources="//@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@children.3/@ports.3" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.6/@ports.2"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@children.5/@ports.3" targets="//@children.0/@children.0/@ports.1"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.7/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.2"/>
+    </children>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P28" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="70.0" width="261.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="261.0" y="31.0" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="31.0">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="82.0" text="StringReplace"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="4.25">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P36" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="3"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P37" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P40" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P41" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P42" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="58.0" text="ArraySum"/>
+    <ports identifier="P43" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P44" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.2/@ports.0" targets="//@children.3/@ports.2"/>
+  <containedEdges identifier="E4" sources="//@children.3/@ports.3" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.6/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.7/@ports.1" targets="//@children.3/@ports.1"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformerUsingXMLInclusion.elkg
+++ b/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_XMLFileTransformerUsingXMLInclusion.elkg
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L1" height="15.0" width="93.0" text="IterateOverArray"/>
+    <ports identifier="P1" height="8.0" width="8.0" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" outgoingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <children identifier="N2">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+      <labels identifier="L2" height="15.0" width="99.0" text="IterateComposite"/>
+      <ports identifier="P3" height="8.0" width="8.0" outgoingEdges="//@children.0/@children.0/@containedEdges.0 //@children.0/@children.0/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P4" height="8.0" width="8.0" incomingEdges="//@children.0/@children.0/@containedEdges.9">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <children identifier="N3" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L3" height="15.0" width="73.0" text="StringToXML"/>
+        <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N4" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L4" height="15.0" width="80.0" text="StringToXML2"/>
+        <ports identifier="P7" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P8" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N5" height="41.0" width="51.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L5" height="15.0" width="63.0" text="FileReader"/>
+        <ports identifier="P9" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.4">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.0">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N6" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L6" height="15.0" width="82.0" text="StringReplace"/>
+        <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="4.25">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P13" height="8.0" width="8.0" x="-8.0" y="16.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.0/@children.0/@containedEdges.1">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P15" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="3"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <children identifier="N7" height="41.0" width="10.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L7" height="15.0" width="104.0" text="RecordAssembler"/>
+        <ports identifier="P16" height="8.0" width="8.0" x="10.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P17" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.5">
+          <properties key="org.eclipse.elk.port.index" value="-1"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N8" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L8" height="15.0" width="224.0" text="XSLTransformer - Remove Redundancy"/>
+        <ports identifier="P18" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.2">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P19" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.7">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="24.66666603088379" incomingEdges="//@children.0/@children.0/@containedEdges.6">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N9" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L9" height="15.0" width="211.0" text="XSLTransformer - Remove Repetition"/>
+        <ports identifier="P21" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.0/@children.0/@containedEdges.3">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P22" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+        <ports identifier="P23" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+          <properties key="org.eclipse.elk.port.index" value="-2"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+      </children>
+      <children identifier="N10" height="41.0" width="61.0">
+        <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+        <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+        <labels identifier="L10" height="15.0" width="80.0" text="StringToXML3"/>
+        <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.0/@children.0/@containedEdges.8">
+          <properties key="org.eclipse.elk.port.index" value="0"/>
+          <properties key="org.eclipse.elk.port.side" value="WEST"/>
+        </ports>
+        <ports identifier="P25" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.0/@children.0/@containedEdges.9">
+          <properties key="org.eclipse.elk.port.index" value="1"/>
+          <properties key="org.eclipse.elk.port.side" value="EAST"/>
+        </ports>
+      </children>
+      <containedEdges identifier="E8" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.2/@ports.2"/>
+      <containedEdges identifier="E9" sources="//@children.0/@children.0/@ports.0" targets="//@children.0/@children.0/@children.3/@ports.2"/>
+      <containedEdges identifier="E10" sources="//@children.0/@children.0/@children.0/@ports.1" targets="//@children.0/@children.0/@children.5/@ports.0"/>
+      <containedEdges identifier="E11" sources="//@children.0/@children.0/@children.1/@ports.1" targets="//@children.0/@children.0/@children.6/@ports.0"/>
+      <containedEdges identifier="E12" sources="//@children.0/@children.0/@children.2/@ports.0" targets="//@children.0/@children.0/@children.0/@ports.0"/>
+      <containedEdges identifier="E13" sources="//@children.0/@children.0/@children.3/@ports.3" targets="//@children.0/@children.0/@children.4/@ports.1"/>
+      <containedEdges identifier="E14" sources="//@children.0/@children.0/@children.4/@ports.0" targets="//@children.0/@children.0/@children.5/@ports.2"/>
+      <containedEdges identifier="E15" sources="//@children.0/@children.0/@children.5/@ports.1" targets="//@children.0/@children.0/@children.1/@ports.0"/>
+      <containedEdges identifier="E16" sources="//@children.0/@children.0/@children.6/@ports.1" targets="//@children.0/@children.0/@children.7/@ports.0"/>
+      <containedEdges identifier="E17" sources="//@children.0/@children.0/@children.7/@ports.1" targets="//@children.0/@children.0/@ports.1"/>
+    </children>
+  </children>
+  <children identifier="N11" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L11" height="15.0" width="91.0" text="DirectoryListing"/>
+    <ports identifier="P26" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N12" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L12" height="15.0" width="52.0" text="OUTPUT"/>
+    <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N13" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L13" height="15.0" width="220.0" text="XSLTransformer - Rearrange Hierarchy"/>
+    <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P31" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P32" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N14" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="77.0" text="XMLInclusion"/>
+    <ports identifier="P33" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P34" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.3 //@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P35" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N15" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L15" height="15.0" width="209.0" text="XSLTransformer - Remove One layer"/>
+    <ports identifier="P36" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P37" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P38" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N16" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L16" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P39" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P40" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.6">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N17" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L17" height="15.0" width="73.0" text="Combination"/>
+    <ports identifier="P41" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.4/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.1/@ports.0" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.3/@ports.1" targets="//@children.2/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.4/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E5" sources="//@children.4/@ports.1" targets="//@children.7/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.5/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E7" sources="//@children.6/@ports.1" targets="//@children.3/@ports.0"/>
+</graph:ElkNode>

--- a/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLFile6.elkg
+++ b/realworld/ptolemy/hierarchical/xslt_momlfiletransformation_momlfilesfordemo_SampleMOMLFile6.elkg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  /*******************************************************************************
+   * Copyright (c) 1997-2013 The Regents of the University of California.
+   * All rights reserved.
+   * Permission is hereby granted, without written agreement and without
+   * license or royalty fees, to use, copy, modify, and distribute this
+   * software and its documentation for any purpose, provided that the above
+   * copyright notice and the following two paragraphs appear in all copies
+   * of this software.
+   *
+   * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+   * FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+   * ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+   * THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+   * SUCH DAMAGE.
+   *
+   * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+   * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE
+   * PROVIDED HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF
+   * CALIFORNIA HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+   * ENHANCEMENTS, OR MODIFICATIONS.
+   *******************************************************************************/
+-->
+<graph:ElkNode xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:graph="http://www.eclipse.org/elk/ElkGraph" identifier="G1">
+  <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+  <children identifier="N1" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L1" height="15.0" width="91.0" text="XSLTransformer"/>
+    <ports identifier="P1" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P2" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.0 //@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P3" height="8.0" width="8.0" x="-8.0" y="16.5">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P4" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="-3"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N2" height="41.0" width="61.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L2" height="15.0" width="73.0" text="StringToXML"/>
+    <ports identifier="P5" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@containedEdges.4">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P6" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@containedEdges.2">
+      <properties key="org.eclipse.elk.port.index" value="1"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+  </children>
+  <children identifier="N3" height="25.0" width="127.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L3" height="15.0" width="34.0" text="Const"/>
+    <ports identifier="P7" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@containedEdges.3">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P8" height="8.0" width="8.0" x="-8.0" y="8.5">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N4" height="41.0" width="51.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L4" height="15.0" width="63.0" text="FileReader"/>
+    <ports identifier="P9" height="8.0" width="8.0" x="51.0" y="16.5" outgoingEdges="//@containedEdges.4 //@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="EAST"/>
+    </ports>
+    <ports identifier="P10" height="8.0" width="8.0" x="-8.0" y="8.333333015441895">
+      <properties key="org.eclipse.elk.port.index" value="-1"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <ports identifier="P11" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+      <properties key="org.eclipse.elk.port.index" value="-2"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N5" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L5" height="15.0" width="43.0" text="Display"/>
+    <ports identifier="P12" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.5">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <children identifier="N6">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FREE"/>
+    <labels identifier="L6" height="15.0" width="94.0" text="CompositeActor"/>
+    <ports identifier="P13" height="8.0" width="8.0" outgoingEdges="//@children.5/@containedEdges.0" incomingEdges="//@containedEdges.0">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+    <children identifier="N7" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L7" height="15.0" width="82.0" text="StringReplace"/>
+      <ports identifier="P14" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P15" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P16" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@containedEdges.0">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P17" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.1 //@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="3"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N8" height="25.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L8" height="15.0" width="34.0" text="Const"/>
+      <ports identifier="P18" height="8.0" width="8.0" x="41.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.3">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P19" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N9" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L9" height="15.0" width="73.0" text="StringToXML"/>
+      <ports identifier="P20" height="8.0" width="8.0" x="-8.0" y="16.5" incomingEdges="//@children.5/@containedEdges.1">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P21" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+    </children>
+    <children identifier="N10" height="41.0" width="61.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L10" height="15.0" width="91.0" text="XSLTransformer"/>
+      <ports identifier="P22" height="8.0" width="8.0" x="-8.0" y="4.25" incomingEdges="//@children.5/@containedEdges.4">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P23" height="8.0" width="8.0" x="61.0" y="16.5" outgoingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="1"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P24" height="8.0" width="8.0" x="-8.0" y="16.5">
+        <properties key="org.eclipse.elk.port.index" value="-2"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P25" height="8.0" width="8.0" x="-8.0" y="28.75" incomingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="-3"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N11" height="25.0" width="127.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L11" height="15.0" width="42.0" text="Const2"/>
+      <ports identifier="P26" height="8.0" width="8.0" x="127.0" y="8.5" outgoingEdges="//@children.5/@containedEdges.6">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="EAST"/>
+      </ports>
+      <ports identifier="P27" height="8.0" width="8.0" x="-8.0" y="8.5">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N12" height="41.0" width="51.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L12" height="15.0" width="60.0" text="LineWriter"/>
+      <ports identifier="P28" height="8.0" width="8.0" x="-8.0" y="8.333333015441895" incomingEdges="//@children.5/@containedEdges.5">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+      <ports identifier="P29" height="8.0" width="8.0" x="-8.0" y="24.66666603088379">
+        <properties key="org.eclipse.elk.port.index" value="-1"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <children identifier="N13" height="31.0" width="41.0">
+      <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+      <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+      <labels identifier="L13" height="15.0" width="43.0" text="Display"/>
+      <ports identifier="P30" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@children.5/@containedEdges.2">
+        <properties key="org.eclipse.elk.port.index" value="0"/>
+        <properties key="org.eclipse.elk.port.side" value="WEST"/>
+      </ports>
+    </children>
+    <containedEdges identifier="E7" sources="//@children.5/@ports.0" targets="//@children.5/@children.0/@ports.2"/>
+    <containedEdges identifier="E8" sources="//@children.5/@children.0/@ports.3" targets="//@children.5/@children.2/@ports.0"/>
+    <containedEdges identifier="E9" sources="//@children.5/@children.0/@ports.3" targets="//@children.5/@children.6/@ports.0"/>
+    <containedEdges identifier="E10" sources="//@children.5/@children.1/@ports.0" targets="//@children.5/@children.0/@ports.0"/>
+    <containedEdges identifier="E11" sources="//@children.5/@children.2/@ports.1" targets="//@children.5/@children.3/@ports.0"/>
+    <containedEdges identifier="E12" sources="//@children.5/@children.3/@ports.1" targets="//@children.5/@children.5/@ports.0"/>
+    <containedEdges identifier="E13" sources="//@children.5/@children.4/@ports.0" targets="//@children.5/@children.3/@ports.3"/>
+  </children>
+  <children identifier="N14" height="31.0" width="41.0">
+    <properties key="org.eclipse.elk.nodeLabels.placement" value="[H_LEFT, V_TOP, OUTSIDE]"/>
+    <properties key="org.eclipse.elk.portConstraints" value="FIXED_ORDER"/>
+    <labels identifier="L14" height="15.0" width="51.0" text="Display2"/>
+    <ports identifier="P31" height="8.0" width="8.0" x="-8.0" y="11.5" incomingEdges="//@containedEdges.1">
+      <properties key="org.eclipse.elk.port.index" value="0"/>
+      <properties key="org.eclipse.elk.port.side" value="WEST"/>
+    </ports>
+  </children>
+  <containedEdges identifier="E1" sources="//@children.0/@ports.1" targets="//@children.5/@ports.0"/>
+  <containedEdges identifier="E2" sources="//@children.0/@ports.1" targets="//@children.6/@ports.0"/>
+  <containedEdges identifier="E3" sources="//@children.1/@ports.1" targets="//@children.0/@ports.0"/>
+  <containedEdges identifier="E4" sources="//@children.2/@ports.0" targets="//@children.0/@ports.3"/>
+  <containedEdges identifier="E5" sources="//@children.3/@ports.0" targets="//@children.1/@ports.0"/>
+  <containedEdges identifier="E6" sources="//@children.3/@ports.0" targets="//@children.4/@ports.0"/>
+</graph:ElkNode>


### PR DESCRIPTION
The elkg are identical to the elkt (graph-wise). The idea behind checking in the elkg as well is to significantly reduce the execution time of ELK's unit tests. Parsing the xtext-based elkt files takes very long, especially for larger models. 